### PR TITLE
Releases page statuses

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,9 +2,11 @@
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require bootstrap-editable
+//= require bootstrap/tooltip
 
 $(function() {
   $.fn.editable.defaults.ajaxOptions = {type: "PUT"};
   $.fn.editable.defaults.mode = 'inline';
   $('.js-editable').editable();
+  $('[data-toggle=tooltip]').tooltip();
 });

--- a/app/controllers/feature_reviews_controller.rb
+++ b/app/controllers/feature_reviews_controller.rb
@@ -7,7 +7,7 @@ class FeatureReviewsController < ApplicationController
   def create
     @feature_review_form = feature_review_form
     if @feature_review_form.valid?
-      redirect_to @feature_review_form.url
+      redirect_to @feature_review_form.path
     else
       @app_names = GitRepositoryLocation.app_names
       render :new
@@ -30,7 +30,7 @@ class FeatureReviewsController < ApplicationController
 
     versions = VersionResolver.new(git_repository_for(@application)).related_versions(@version)
     repository = Repositories::FeatureReviewRepository.new
-    @links = repository.feature_reviews_for(versions: versions).map(&:url)
+    @links = repository.feature_reviews_for(versions: versions).map(&:path)
     flash[:error] = 'No Feature Reviews found.' if @links.empty?
   end
 

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -61,6 +61,14 @@ class FeatureReviewWithStatuses < SimpleDelegator
     approved? ? :approved : :unapproved
   end
 
+  def url
+    "#{base_url}?#{query_hash.merge(time: time).to_query}"
+  end
+
+  def path
+    URI(url).request_uri
+  end
+
   private
 
   attr_reader :query

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -3,7 +3,7 @@ require 'queries/feature_review_query'
 class FeatureReviewWithStatuses < SimpleDelegator
   attr_reader :time
 
-  def initialize(feature_review, at: Time.now, query_class: Queries::FeatureReviewQuery)
+  def initialize(feature_review, at: Time.current, query_class: Queries::FeatureReviewQuery)
     super(feature_review)
     @time = at
     @query = query_class.new(feature_review, at: @time)
@@ -63,7 +63,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
 
   def approved_url
     return nil unless approved? && approved_at.present?
-    "#{base_url}?#{query_hash.merge(time: approved_at).to_query}"
+    "#{base_url}?#{query_hash.merge(time: approved_at.utc).to_query}"
   end
 
   def approved_path
@@ -71,7 +71,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def url
-    "#{base_url}?#{query_hash.merge(time: time).to_query}"
+    "#{base_url}?#{query_hash.merge(time: time.utc).to_query}"
   end
 
   def path

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -61,6 +61,15 @@ class FeatureReviewWithStatuses < SimpleDelegator
     approved? ? :approved : :unapproved
   end
 
+  def approved_url
+    return nil unless approved? && approved_at.present?
+    "#{base_url}?#{query_hash.merge(time: approved_at).to_query}"
+  end
+
+  def approved_path
+    URI(approved_url).request_uri if approved_url
+  end
+
   def url
     "#{base_url}?#{query_hash.merge(time: time).to_query}"
   end

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -70,12 +70,12 @@ class FeatureReviewWithStatuses < SimpleDelegator
     URI(approved_url).request_uri if approved_url
   end
 
-  def url
+  def url_with_query_time
     "#{base_url}?#{query_hash.merge(time: time.utc).to_query}"
   end
 
-  def path
-    URI(url).request_uri
+  def path_with_query_time
+    URI(url_with_query_time).request_uri
   end
 
   private

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -61,21 +61,13 @@ class FeatureReviewWithStatuses < SimpleDelegator
     approved? ? :approved : :unapproved
   end
 
-  def approved_url
-    return nil unless approved? && approved_at.present?
-    "#{base_url}?#{query_hash.merge(time: approved_at.utc).to_query}"
-  end
-
   def approved_path
-    URI(approved_url).request_uri if approved_url
-  end
-
-  def url_with_query_time
-    "#{base_url}?#{query_hash.merge(time: time.utc).to_query}"
+    return nil unless approved? && approved_at.present?
+    "#{base_path}?#{query_hash.merge(time: approved_at.utc).to_query}"
   end
 
   def path_with_query_time
-    URI(url_with_query_time).request_uri
+    "#{base_path}?#{query_hash.merge(time: time.utc).to_query}"
   end
 
   private

--- a/app/decorators/release_with_status.rb
+++ b/app/decorators/release_with_status.rb
@@ -20,10 +20,14 @@ class ReleaseWithStatus < SimpleDelegator
   end
 
   def committed_to_master_at
-    @committed_to_master_at ||= git_repository.commit_to_master_for(version).try(:time)
+    @committed_to_master_at ||= commit_to_master.try(:time).try(:utc)
   end
 
   private
 
   attr_reader :git_repository
+
+  def commit_to_master
+    git_repository.commit_to_master_for(version)
+  end
 end

--- a/app/decorators/release_with_status.rb
+++ b/app/decorators/release_with_status.rb
@@ -18,12 +18,4 @@ class ReleaseWithStatus < SimpleDelegator
     return nil if feature_reviews.empty?
     approved? ? :approved : :unapproved
   end
-
-  private
-
-  attr_reader :git_repository
-
-  def commit_to_master
-    git_repository.commit_to_master_for(version)
-  end
 end

--- a/app/decorators/release_with_status.rb
+++ b/app/decorators/release_with_status.rb
@@ -9,7 +9,7 @@ class ReleaseWithStatus < SimpleDelegator
     @query = query_class.new(release: release, git_repository: git_repository, at: time)
   end
 
-  delegate :feature_reviews, to: :query
+  delegate :feature_reviews, to: :@query
 
   def approved?
     feature_reviews.any?(&:approved?)
@@ -19,8 +19,4 @@ class ReleaseWithStatus < SimpleDelegator
     return nil if feature_reviews.empty?
     approved? ? :approved : :unapproved
   end
-
-  private
-
-  attr_reader :query
 end

--- a/app/decorators/release_with_status.rb
+++ b/app/decorators/release_with_status.rb
@@ -5,7 +5,7 @@ class ReleaseWithStatus < SimpleDelegator
     super(release)
     @release = release
     @git_repository = git_repository
-    @query = query_class.new(release: release, git_repository: git_repository, at: committed_to_master_at)
+    @query = query_class.new(release: release, git_repository: git_repository)
   end
 
   delegate :feature_reviews, to: :@query
@@ -17,10 +17,6 @@ class ReleaseWithStatus < SimpleDelegator
   def approval_status
     return nil if feature_reviews.empty?
     approved? ? :approved : :unapproved
-  end
-
-  def committed_to_master_at
-    @committed_to_master_at ||= commit_to_master.try(:time).try(:utc)
   end
 
   private

--- a/app/helpers/feature_reviews_helper.rb
+++ b/app/helpers/feature_reviews_helper.rb
@@ -61,7 +61,7 @@ module FeatureReviewsHelper
     end
   end
 
-  def to_link(url, options = {})
-    link_to url, Addressable::URI.heuristic_parse(url).to_s, options
+  def to_link(path, options = {})
+    link_to path, Addressable::URI.heuristic_parse(path).to_s, options
   end
 end

--- a/app/helpers/feature_reviews_helper.rb
+++ b/app/helpers/feature_reviews_helper.rb
@@ -61,7 +61,7 @@ module FeatureReviewsHelper
     end
   end
 
-  def to_link(path, options = {})
-    link_to path, Addressable::URI.heuristic_parse(path).to_s, options
+  def to_link(url, options = {})
+    link_to url, Addressable::URI.heuristic_parse(url).to_s, options
   end
 end

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -1,12 +1,14 @@
 module ReleasesHelper
   def feature_review_link(feature_review)
     if feature_review.approved_path
-      path = feature_review.approved_path
-      msg = 'View Feature Review at approval time'
+      link_to(
+        feature_review.approval_status,
+        feature_review.approved_path,
+        data: { toggle: 'tooltip' },
+        title: 'View Feature Review at approval time',
+      )
     else
-      path = feature_review.path_with_query_time
-      msg = 'View Feature Review when committed to master'
+      link_to(feature_review.approval_status, feature_review.path)
     end
-    link_to(feature_review.approval_status, path, data: { toggle: 'tooltip' }, title: msg)
   end
 end

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -1,0 +1,6 @@
+module ReleasesHelper
+  def feature_review_link(feature_review)
+    path = feature_review.approved_path || feature_review.path
+    link_to(feature_review.approval_status, path)
+  end
+end

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -1,6 +1,12 @@
 module ReleasesHelper
   def feature_review_link(feature_review)
-    path = feature_review.approved_path || feature_review.path_with_query_time
-    link_to(feature_review.approval_status, path)
+    if feature_review.approved_path
+      path = feature_review.approved_path
+      msg = 'View Feature Review at approval time'
+    else
+      path = feature_review.path_with_query_time
+      msg = 'View Feature Review when committed to master'
+    end
+    link_to(feature_review.approval_status, path, data: { toggle: 'tooltip' }, title: msg)
   end
 end

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -1,6 +1,6 @@
 module ReleasesHelper
   def feature_review_link(feature_review)
-    path = feature_review.approved_path || feature_review.path
+    path = feature_review.approved_path || feature_review.path_with_query_time
     link_to(feature_review.approval_status, path)
   end
 end

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -22,14 +22,6 @@ module Events
       details.fetch('issue').fetch('fields').fetch('status').fetch('name')
     end
 
-    def user_email
-      details.fetch('user').fetch('emailAddress')
-    end
-
-    def updated
-      details.fetch('issue').fetch('fields').fetch('updated')
-    end
-
     def comment
       details.fetch('comment', {}).fetch('body', '')
     end

--- a/app/models/factories/feature_review_factory.rb
+++ b/app/models/factories/feature_review_factory.rb
@@ -13,10 +13,11 @@ module Factories
     end
 
     def create_from_url_string(url)
-      query_hash = Rack::Utils.parse_nested_query(URI(url).query)
+      uri = URI(url)
+      query_hash = Rack::Utils.parse_nested_query(uri.query)
       versions = query_hash.fetch('apps', {}).values.reject(&:blank?)
       create(
-        path: url.to_s,
+        path: uri.request_uri,
         versions: versions,
       )
     end

--- a/app/models/factories/feature_review_factory.rb
+++ b/app/models/factories/feature_review_factory.rb
@@ -16,7 +16,7 @@ module Factories
       query_hash = Rack::Utils.parse_nested_query(URI(url).query)
       versions = query_hash.fetch('apps', {}).values.reject(&:blank?)
       create(
-        url: url.to_s,
+        path: url.to_s,
         versions: versions,
       )
     end

--- a/app/models/feature_review.rb
+++ b/app/models/feature_review.rb
@@ -9,6 +9,7 @@ class FeatureReview
   values do
     attribute :url, String
     attribute :versions, Array
+    attribute :approved_at, DateTime
   end
 
   def app_versions

--- a/app/models/feature_review.rb
+++ b/app/models/feature_review.rb
@@ -7,17 +7,13 @@ class FeatureReview
   include Virtus.value_object
 
   values do
-    attribute :url, String
+    attribute :path, String
     attribute :versions, Array
     attribute :approved_at, DateTime
   end
 
   def app_versions
     query_hash.fetch('apps', {}).select { |_name, version| version.present? }
-  end
-
-  def path
-    URI(url).request_uri
   end
 
   def uat_url
@@ -29,11 +25,11 @@ class FeatureReview
   end
 
   def query_hash
-    Rack::Utils.parse_nested_query(URI(url).query)
+    Rack::Utils.parse_nested_query(URI(path).query)
   end
 
-  def base_url
-    Addressable::URI.parse(url).omit(:query).to_s
+  def base_path
+    Addressable::URI.parse(path).omit(:query).to_s
   end
 
   private

--- a/app/models/feature_review.rb
+++ b/app/models/feature_review.rb
@@ -28,11 +28,15 @@ class FeatureReview
     uat_uri.try(:host)
   end
 
-  private
-
   def query_hash
     Rack::Utils.parse_nested_query(URI(url).query)
   end
+
+  def base_url
+    Addressable::URI.parse(url).omit(:query).to_s
+  end
+
+  private
 
   def uat_uri
     uat_url_param = query_hash.fetch('uat_url', nil)

--- a/app/models/forms/feature_review_form.rb
+++ b/app/models/forms/feature_review_form.rb
@@ -33,7 +33,7 @@ module Forms
       errors.empty?
     end
 
-    def url
+    def path
       hash = {}
       hash[:apps] = apps
       hash[:uat_url] = uat_url if uat_url.present?

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -93,11 +93,6 @@ class GitRepository
     @rugged_repository.path
   end
 
-  def commit_to_master_for(commit_oid)
-    return lookup(commit_oid) if commit_on_master?(commit_oid)
-    merge_to_master_commit(commit_oid)
-  end
-
   private
 
   attr_reader :rugged_repository

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -93,6 +93,11 @@ class GitRepository
     @rugged_repository.path
   end
 
+  def commit_to_master_for(commit_oid)
+    return lookup(commit_oid) if commit_on_master?(commit_oid)
+    merge_to_master_commit(commit_oid)
+  end
+
   private
 
   attr_reader :rugged_repository
@@ -137,14 +142,11 @@ class GitRepository
 
   def validate_commit!(commit_oid)
     fail CommitNotFound, commit_oid unless rugged_repository.exists?(commit_oid)
-  rescue Rugged::InvalidError
-    raise CommitNotValid, commit_oid
+  rescue Rugged::InvalidError; raise CommitNotValid, commit_oid
   end
 
   def instrument(name, &block)
-    ActiveSupport::Notifications.instrument(
-      "#{name}.git_repository",
-      &block)
+    ActiveSupport::Notifications.instrument("#{name}.git_repository", &block)
   end
 
   def main_branch

--- a/app/models/projections/releases_projection.rb
+++ b/app/models/projections/releases_projection.rb
@@ -47,9 +47,7 @@ module Projections
         deploy_for_commit = production_deploy_for_commit(commit)
         deployed = true if deploy_for_commit # A deploy means all subsequent (earlier) commits are deployed.
         if deployed
-          @deployed_releases << create_release_from(
-            commit: commit, deploy: deploy_for_commit
-          )
+          @deployed_releases << create_release_from(commit: commit, deploy: deploy_for_commit)
         else
           @pending_releases << create_release_from(commit: commit)
         end

--- a/app/models/queries/feature_review_query.rb
+++ b/app/models/queries/feature_review_query.rb
@@ -39,7 +39,7 @@ module Queries
 
     def tickets
       ticket_repository.tickets_for(
-        feature_review_url: feature_review.url,
+        feature_review_path: feature_review.path,
         at: time)
     end
 

--- a/app/models/queries/release_query.rb
+++ b/app/models/queries/release_query.rb
@@ -2,7 +2,7 @@ require 'repositories/feature_review_repository'
 
 module Queries
   class ReleaseQuery
-    def initialize(release:, git_repository:, at: Time.now)
+    def initialize(release:, git_repository:, at: Time.current)
       @release = release
       @time = at
 

--- a/app/models/repositories/feature_review_repository.rb
+++ b/app/models/repositories/feature_review_repository.rb
@@ -36,7 +36,7 @@ module Repositories
           url: feature_review.url,
           versions: feature_review.versions,
           event_created_at: event.created_at,
-          approved_at: approved_at_for(feature_review, event.created_at),
+          approved_at: approved_at_for(feature_review, event),
         )
       end
     end
@@ -45,9 +45,10 @@ module Repositories
 
     attr_reader :store
 
-    def approved_at_for(feature_review, event_time)
+    def approved_at_for(feature_review, event)
       new_review = FeatureReviewWithStatuses.new(feature_review)
-      new_review.approved? ? (last_review_approved_at(feature_review.url) || event_time) : nil
+      return unless new_review.approved?
+      last_review_approved_at(feature_review.url) || event.created_at
     end
 
     def last_review_approved_at(url)

--- a/app/models/repositories/feature_review_repository.rb
+++ b/app/models/repositories/feature_review_repository.rb
@@ -21,6 +21,7 @@ module Repositories
           Factories::FeatureReviewFactory.new.create(
             url: most_recent_snapshot.url,
             versions: most_recent_snapshot.versions,
+            approved_at: most_recent_snapshot.approved_at,
           )
         }
     end

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -12,11 +12,11 @@ module Repositories
 
     delegate :table_name, to: :store
 
-    def tickets_for(feature_review_url:, at: nil)
+    def tickets_for(feature_review_path:, at: nil)
       query = at ? store.arel_table['event_created_at'].lteq(at) : nil
       store
         .select('DISTINCT ON (key) *')
-        .where('paths @> ARRAY[?]', prepare_url(feature_review_url))
+        .where('paths @> ARRAY[?]', prepare_path(feature_review_path))
         .where(query)
         .order('key, id DESC')
         .map { |t| Ticket.new(t.attributes) }
@@ -47,8 +47,8 @@ module Repositories
 
     def merge_ticket_paths(ticket, feature_reviews)
       old_paths = ticket.fetch('paths', [])
-      new_paths = feature_review_urls(feature_reviews)
-      old_paths.concat(new_urls).uniq
+      new_paths = feature_review_paths(feature_reviews)
+      old_paths.concat(new_paths).uniq
     end
 
     def merge_ticket_versions(ticket, feature_reviews)
@@ -57,13 +57,13 @@ module Repositories
       old_versions.concat(new_versions).uniq
     end
 
-    def prepare_url(url_string)
-      Addressable::URI.parse(url_string).normalize.to_s
+    def prepare_path(path)
+      Addressable::URI.parse(path).normalize.to_s
     end
 
-    def feature_review_urls(feature_reviews)
+    def feature_review_paths(feature_reviews)
       feature_reviews.map { |feature_review|
-        prepare_url(feature_review.url)
+        prepare_path(feature_review.path)
       }
     end
 

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -16,7 +16,7 @@ module Repositories
       query = at ? store.arel_table['event_created_at'].lteq(at) : nil
       store
         .select('DISTINCT ON (key) *')
-        .where('urls @> ARRAY[?]', prepare_url(feature_review_url))
+        .where('paths @> ARRAY[?]', prepare_url(feature_review_url))
         .where(query)
         .order('key, id DESC')
         .map { |t| Ticket.new(t.attributes) }
@@ -33,7 +33,7 @@ module Repositories
         'key' => event.key,
         'summary' => event.summary,
         'status' => event.status,
-        'urls' => merge_ticket_urls(last_ticket, feature_reviews),
+        'paths' => merge_ticket_paths(last_ticket, feature_reviews),
         'event_created_at' => event.created_at,
         'versions' => merge_ticket_versions(last_ticket, feature_reviews),
       )
@@ -45,10 +45,10 @@ module Repositories
 
     attr_reader :store
 
-    def merge_ticket_urls(ticket, feature_reviews)
-      old_urls = ticket.fetch('urls', [])
-      new_urls = feature_review_urls(feature_reviews)
-      old_urls.concat(new_urls).uniq
+    def merge_ticket_paths(ticket, feature_reviews)
+      old_paths = ticket.fetch('paths', [])
+      new_paths = feature_review_urls(feature_reviews)
+      old_paths.concat(new_urls).uniq
     end
 
     def merge_ticket_versions(ticket, feature_reviews)

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -5,15 +5,9 @@ class Ticket
     attribute :key, String
     attribute :summary, String, default: ''
     attribute :status, String, default: 'To Do'
-    attribute :approver_email, String
-    attribute :approved_at, Time
   end
 
   def approved?
     Rails.application.config.approved_statuses.include?(status)
-  end
-
-  def update_attributes(new_attributes)
-    Ticket.new(attributes.merge(new_attributes))
   end
 end

--- a/app/views/releases/show.html.haml
+++ b/app/views/releases/show.html.haml
@@ -16,7 +16,7 @@
       %td= release.subject
       %td
         - release.feature_reviews.each do |feature_review|
-          %div= link_to(feature_review.approval_status, feature_review.path) if feature_review.path
+          %div= feature_review_link(feature_review)
       %td= release.committed_to_master_at.try(:to_formatted_s, :long_ordinal)
 
 %h2 Deployed
@@ -36,6 +36,6 @@
       %td= release.subject
       %td
         - release.feature_reviews.each do |feature_review|
-          %div= link_to(feature_review.approval_status, feature_review.path) if feature_review.path
+          %div= feature_review_link(feature_review)
       %td= release.committed_to_master_at.try(:to_formatted_s, :long_ordinal)
       %td= release.production_deploy_time.try(:to_formatted_s, :long_ordinal)

--- a/app/views/releases/show.html.haml
+++ b/app/views/releases/show.html.haml
@@ -6,8 +6,9 @@
   %thead
     %tr
       %th{width: '10%'} version
-      %th{width: '40%'} message
-      %th{width: '35%'} feature reviews
+      %th{width: '35%'} message
+      %th{width: '15%'} feature reviews
+      %th{width: '40%'} committed to master
   %tbody
   - @pending_releases.each do |release|
     %tr.pending-release{class: ('danger' unless release.approved?)}
@@ -16,6 +17,7 @@
       %td
         - release.feature_reviews.each do |feature_review|
           %div= link_to(feature_review.approval_status, feature_review.path) if feature_review.path
+      %td= release.committed_to_master_at.try(:to_formatted_s, :long_ordinal)
 
 %h2 Deployed
 
@@ -23,9 +25,10 @@
   %thead
     %tr
       %th{width: '10%'} version
-      %th{width: '40%'} message
-      %th{width: '20%'} feature reviews
-      %th{width: '15%'} last deployed at
+      %th{width: '35%'} message
+      %th{width: '15%'} feature reviews
+      %th{width: '20%'} committed to master
+      %th{width: '20%'} last deployed at
   %tbody
   - @deployed_releases.each do |release|
     %tr.deployed-release{class: ('danger' unless release.approved?)}
@@ -34,4 +37,5 @@
       %td
         - release.feature_reviews.each do |feature_review|
           %div= link_to(feature_review.approval_status, feature_review.path) if feature_review.path
+      %td= release.committed_to_master_at.try(:to_formatted_s, :long_ordinal)
       %td= release.production_deploy_time.try(:to_formatted_s, :long_ordinal)

--- a/app/views/releases/show.html.haml
+++ b/app/views/releases/show.html.haml
@@ -6,9 +6,8 @@
   %thead
     %tr
       %th{width: '10%'} version
-      %th{width: '35%'} message
-      %th{width: '15%'} feature reviews
-      %th{width: '40%'} committed to master
+      %th{width: '55%'} message
+      %th{width: '35%'} feature reviews
   %tbody
   - @pending_releases.each do |release|
     %tr.pending-release{class: ('danger' unless release.approved?)}
@@ -17,7 +16,6 @@
       %td
         - release.feature_reviews.each do |feature_review|
           %div= feature_review_link(feature_review)
-      %td= release.committed_to_master_at.try(:to_formatted_s, :long_ordinal)
 
 %h2 Deployed
 
@@ -25,9 +23,8 @@
   %thead
     %tr
       %th{width: '10%'} version
-      %th{width: '35%'} message
+      %th{width: '55%'} message
       %th{width: '15%'} feature reviews
-      %th{width: '20%'} committed to master
       %th{width: '20%'} last deployed at
   %tbody
   - @deployed_releases.each do |release|
@@ -37,5 +34,4 @@
       %td
         - release.feature_reviews.each do |feature_review|
           %div= feature_review_link(feature_review)
-      %td= release.committed_to_master_at.try(:to_formatted_s, :long_ordinal)
       %td= release.production_deploy_time.try(:to_formatted_s, :long_ordinal)

--- a/config/initializers/respositories.rb
+++ b/config/initializers/respositories.rb
@@ -1,10 +1,15 @@
 Rails.configuration.repositories = [
-  Repositories::FeatureReviewRepository.new,
   Repositories::DeployRepository.new,
   Repositories::BuildRepository.new,
   Repositories::ManualTestRepository.new,
   Repositories::TicketRepository.new,
-  # This must always be last as it depends on DeployRepository.
+
+  # FeatureReviewRepository must always be after TicketRepository
+  # because the feature review must check whether its status changes
+  # which depends on the ticket statuses.
+  Repositories::FeatureReviewRepository.new,
+
+  # UatestRepository must always be last as it depends on DeployRepository.
   # Until we make snapshot updating more robust (e.g. jobs queue or table locking) this will have to remain.
   Repositories::UatestRepository.new,
 ]

--- a/db/migrate/20150910135208_add_approved_at_to_feature_reviews.rb
+++ b/db/migrate/20150910135208_add_approved_at_to_feature_reviews.rb
@@ -1,0 +1,5 @@
+class AddApprovedAtToFeatureReviews < ActiveRecord::Migration
+  def change
+    add_column :feature_reviews, :approved_at, :datetime
+  end
+end

--- a/db/migrate/20150915150206_rename_urls_on_tickets_to_paths.rb
+++ b/db/migrate/20150915150206_rename_urls_on_tickets_to_paths.rb
@@ -1,0 +1,5 @@
+class RenameUrlsOnTicketsToPaths < ActiveRecord::Migration
+  def change
+    rename_column :tickets, :urls, :paths
+  end
+end

--- a/db/migrate/20150915151859_rename_feature_review_url_to_path.rb
+++ b/db/migrate/20150915151859_rename_feature_review_url_to_path.rb
@@ -1,0 +1,5 @@
+class RenameFeatureReviewUrlToPath < ActiveRecord::Migration
+  def change
+    rename_column :feature_reviews, :url, :path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150823124742) do
+ActiveRecord::Schema.define(version: 20150910135208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20150823124742) do
     t.string   "url"
     t.string   "versions",         array: true
     t.datetime "event_created_at"
+    t.datetime "approved_at"
   end
 
   add_index "feature_reviews", ["versions"], name: "index_feature_reviews_on_versions", using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150915150206) do
+ActiveRecord::Schema.define(version: 20150915151859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 20150915150206) do
   end
 
   create_table "feature_reviews", force: :cascade do |t|
-    t.string   "url"
+    t.string   "path"
     t.string   "versions",         array: true
     t.datetime "event_created_at"
     t.datetime "approved_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150910135208) do
+ActiveRecord::Schema.define(version: 20150915150206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,12 +82,12 @@ ActiveRecord::Schema.define(version: 20150910135208) do
     t.string   "key"
     t.string   "summary"
     t.string   "status"
-    t.text     "urls",             array: true
+    t.text     "paths",            array: true
     t.datetime "event_created_at"
     t.string   "versions",         array: true
   end
 
-  add_index "tickets", ["urls"], name: "index_tickets_on_urls", using: :gin
+  add_index "tickets", ["paths"], name: "index_tickets_on_paths", using: :gin
   add_index "tickets", ["versions"], name: "index_tickets_on_versions", using: :gin
 
   create_table "tokens", force: :cascade do |t|

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -9,8 +9,11 @@ Background:
 
 @logged_in
 Scenario: Preparing a Feature Review
-  Given a commit "#abc" by "Alice" is created for app "frontend"
-  And a commit "#def" by "Bob" is created for app "backend"
+  # 2014-10-04
+  Given a commit "#abc" by "Alice" is created at "2014-10-04 11:00:00" for app "frontend"
+  And a commit "#def" by "Bob" is created at "2014-10-04 12:30:00" for app "backend"
+
+  # Today
   When I prepare a feature review for:
     | field name      | content             |
     | frontend        | #abc                |
@@ -24,47 +27,54 @@ Scenario: Preparing a Feature Review
 
 @logged_in
 Scenario: Viewing User Acceptance Tests results on a Feature review
-  Given a commit "#abc" by "Alice" is created for app "frontend"
-  And a commit "#def" by "Bob" is created for app "backend"
-  And commit "#abc" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com"
-  And commit "#def" of "backend" is deployed by "Bob" to server "uat.fundingcircle.com"
+  # 2014-10-04
+  Given a commit "#abc" by "Alice" is created at "2014-10-04 09:00:00" for app "frontend"
+  And commit "#abc" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com" at "2014-10-04 12:00:00"
+
+  # 2014-10-05
+  And a commit "#def" by "Bob" is created at "2014-10-05 10:00:00" for app "backend"
+  And commit "#def" of "backend" is deployed by "Bob" to server "uat.fundingcircle.com" at "2014-10-05 11:00:00"
   And developer prepares review known as "FR_visit" for UAT "uat.fundingcircle.com" with apps
     | app_name | version |
     | frontend | #abc    |
     | backend  | #def    |
-  And User Acceptance Tests at version "abc123" which "passed" on server "uat.fundingcircle.com"
-  And User Acceptance Tests at version "abc123" which "failed" on server "other-uat.fundingcircle.com"
 
+  # 2014-10-06
+  And User Acceptance Tests at version "abc123" which "passed" on server "uat.fundingcircle.com" at "2014-10-06 11:00:00"
+  And User Acceptance Tests at version "abc123" which "failed" on server "other-uat.fundingcircle.com" at "2014-10-06 11:03:25"
+
+  # Today
   When I visit the feature review known as "FR_visit"
-
   Then I should see a summary that includes
     | status  | title                 |
     | success | User Acceptance Tests |
-
   And I should see the results of the User Acceptance Tests with heading "success" and version "abc123"
 
 @logged_in
 Scenario: Viewing a feature review
-  Given a ticket "JIRA-123" with summary "Urgent ticket" is started
-  And a commit "#abc" by "Alice" is created for app "frontend"
-  And a commit "#old" by "Bob" is created for app "backend"
-  And a commit "#def" by "Bob" is created for app "backend"
-  And a commit "#ghi" by "Carol" is created for app "mobile"
-  And a commit "#xyz" by "Wendy" is created for app "irrelevant"
-  And CircleCi "passes" for commit "#abc"
-  And CircleCi "fails" for commit "#def"
-  # Flaky tests, build retriggered.
-  And CircleCi "passes" for commit "#def"
-  And commit "#abc" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com"
-  And commit "#old" of "backend" is deployed by "Bob" to server "uat.fundingcircle.com"
-  And commit "#def" of "backend" is deployed by "Bob" to server "other-uat.fundingcircle.com"
-  And commit "#xyz" of "irrelevant" is deployed by "Wendy" to server "uat.fundingcircle.com"
-  And developer prepares review known as "FR_view" upto now for UAT "uat.fundingcircle.com" with apps
+  # 2014-10-04
+  Given a ticket "JIRA-123" with summary "Urgent ticket" is started at "2014-10-04 13:01:17"
+
+  # 2014-10-05
+  And a commit "#abc" by "Alice" is created at "2014-10-05 11:01:00" for app "frontend"
+  And a commit "#old" by "Bob" is created at "2014-10-05 11:02:00" for app "backend"
+  And a commit "#def" by "Bob" is created at "2014-10-05 11:03:00" for app "backend"
+  And a commit "#ghi" by "Carol" is created at "2014-10-05 11:04:00" for app "mobile"
+  And a commit "#xyz" by "Wendy" is created at "2014-10-05 11:05:00" for app "irrelevant"
+  And At "2014-10-05 12:00:00" CircleCi "passes" for commit "#abc"
+  And At "2014-10-05 12:05:00" CircleCi "fails" for commit "#def"
+  # Build retriggered and passes second time.
+  And At "2014-10-05 12:23:00" CircleCi "passes" for commit "#def"
+  And commit "#abc" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com" at "2014-10-05 13:00:00"
+  And commit "#old" of "backend" is deployed by "Bob" to server "uat.fundingcircle.com" at "2014-10-05 13:11:00"
+  And commit "#def" of "backend" is deployed by "Bob" to server "other-uat.fundingcircle.com" at "2014-10-05 13:48:00"
+  And commit "#xyz" of "irrelevant" is deployed by "Wendy" to server "uat.fundingcircle.com" at "2014-10-05 14:05:00"
+  And developer prepares review known as "FR_view" for UAT "uat.fundingcircle.com" with apps
     | app_name | version |
     | frontend | #abc    |
     | backend  | #def    |
     | mobile   | #ghi    |
-  And at time "00:00:01" adds link for review "FR_view" to comment for ticket "JIRA-123"
+  And at time "2014-10-05 16:00:01" adds link for review "FR_view" to comment for ticket "JIRA-123"
 
   When I visit the feature review known as "FR_view"
 
@@ -89,8 +99,6 @@ Scenario: Viewing a feature review
     | App      | Version | Correct |
     | frontend | #abc    | yes     |
     | backend  | #old    | no      |
-
-  And I should see the time when the Feature Review is for
 
 Scenario: QA rejects feature
   Given I am logged in as "foo@bar.com"

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -64,7 +64,7 @@ Scenario: Viewing a feature review
     | frontend | #abc    |
     | backend  | #def    |
     | mobile   | #ghi    |
-  And adds the link for review "FR_view" to a comment for ticket "JIRA-123"
+  And at time "00:00:01" adds link for review "FR_view" to comment for ticket "JIRA-123"
 
   When I visit the feature review known as "FR_view"
 

--- a/features/feature_review_search.feature
+++ b/features/feature_review_search.feature
@@ -2,24 +2,39 @@
 Feature: Auditor searches a Feature Review.
 
 Background:
+  # 2014-10-03
   Given an application called "frontend"
-  And a ticket "JIRA-123" with summary "Urgent ticket" is started
-  And a commit "#master1" with message "initial commit" is created at "13:01:17"
+  And a commit "#master1" with message "initial commit" is created at "2014-10-03 17:01:37"
+
+  # 2014-10-04
+  And a ticket "JIRA-123" with summary "Urgent ticket" is started at "2014-10-04 09:01:28"
+
+  # 2014-10-05
   And the branch "feature-one" is checked out
-  And a commit "#commit1" with message "first commit" is created at "14:01:17"
+  And a commit "#commit1" with message "first commit" is created at "2014-10-05 14:26:03"
   And developer prepares review known as "FR_search1" for UAT "http://uat.fundingcircle.com" with apps
     | app_name | version  |
     | frontend | #commit1 |
-  And at time "14:20:13" adds link for review "FR_search1" to comment for ticket "JIRA-123"
-  And a commit "#commit2" with message "second commit" is created at "15:04:19"
+  And at time "2014-10-05 14:20:13" adds link for review "FR_search1" to comment for ticket "JIRA-123"
+
+  # 2014-10-06
+  And the branch "feature-one" is checked out
+  And a commit "#commit2" with message "second commit" is created at "2014-10-06 15:04:19"
   And developer prepares review known as "FR_search2" for UAT "http://uat.fundingcircle.com" with apps
     | app_name | version  |
     | frontend | #commit2 |
-  And at time "15:21:34" adds link for review "FR_search2" to comment for ticket "JIRA-123"
-  And ticket "JIRA-123" is approved by "alice@fundingcircle.com" at "15:24:34"
+  And at time "2014-10-06 16:21:34" adds link for review "FR_search2" to comment for ticket "JIRA-123"
+
+  # 2014-10-07
+  And ticket "JIRA-123" is approved by "alice@fundingcircle.com" at "2014-10-07 09:44:34"
+
+  # 2014-10-08
   And the branch "master" is checked out
-  And a commit "#commit3" with message "recent commit" is created at "13:31:17"
-  And the branch "feature-one" is merged with merge commit "#merge" at "16:04:19"
+  And a commit "#commit3" with message "recent commit" is created at "2014-10-08 13:31:17"
+
+  # 2014-10-09
+  And the branch "master" is checked out
+  And the branch "feature-one" is merged with merge commit "#merge" at "2014-10-09 16:04:19"
 
 Scenario: Searching for a Feature Review
   When I look up feature reviews for "#commit1" on "frontend"

--- a/features/feature_review_search.feature
+++ b/features/feature_review_search.feature
@@ -10,12 +10,12 @@ Background:
   And developer prepares review known as "FR_search1" for UAT "http://uat.fundingcircle.com" with apps
     | app_name | version  |
     | frontend | #commit1 |
-  And adds the link for review "FR_search1" to a comment for ticket "JIRA-123"
+  And at time "14:20:13" adds link for review "FR_search1" to comment for ticket "JIRA-123"
   And a commit "#commit2" with message "second commit" is created at "15:04:19"
   And developer prepares review known as "FR_search2" for UAT "http://uat.fundingcircle.com" with apps
     | app_name | version  |
     | frontend | #commit2 |
-  And adds the link for review "FR_search2" to a comment for ticket "JIRA-123"
+  And at time "15:21:34" adds link for review "FR_search2" to comment for ticket "JIRA-123"
   And ticket "JIRA-123" is approved by "alice@fundingcircle.com" at "15:24:34"
   And the branch "master" is checked out
   And a commit "#commit3" with message "recent commit" is created at "13:31:17"

--- a/features/releases.feature
+++ b/features/releases.feature
@@ -55,13 +55,13 @@ Scenario: Viewing releases for an app
   When I view the releases for "frontend"
 
   Then I should see the "pending" releases
-    | version  | subject                        | feature reviews | review statuses     | approved | committed to master at |
-    | #merge   | Merged `feature` into `master` | FR_456          | approved            | yes      | 2014-10-06 17:04       |
-    | #branch2 | second commit                  | FR_456          | approved            | yes      | 2014-10-06 17:04       |
-    | #branch1 | first commit                   | FR_123, FR_456  | unapproved approved | yes      | 2014-10-06 17:04       |
+    | version  | subject                        | feature reviews | review statuses     | review times                             | approved | committed to master at |
+    | #merge   | Merged `feature` into `master` | FR_456          | approved            | 2014-10-04 15:24:34                      | yes      | 2014-10-06 17:04       |
+    | #branch2 | second commit                  | FR_456          | approved            | 2014-10-04 15:24:34                      | yes      | 2014-10-06 17:04       |
+    | #branch1 | first commit                   | FR_123, FR_456  | unapproved approved | 2014-10-06 17:04:19, 2014-10-04 15:24:34 | yes      | 2014-10-06 17:04       |
 
   And I should see the "deployed" releases
-    | version      | subject                    | feature reviews | review statuses     | approved | committed to master at | last deployed at |
-    | #master3     | sneaky commit              |                 |                     | no       | 2014-10-05 11:01       | 2014-10-05 11:54 |
-    | #master2     | historic commit            |                 |                     | no       | 2014-10-01 12:01       |                  |
-    | #master1     | initial commit             |                 |                     | no       | 2014-09-29 09:18       | 2014-09-29 11:37 |
+    | version      | subject                    | feature reviews | review statuses     | review times     | approved | committed to master at | last deployed at |
+    | #master3     | sneaky commit              |                 |                     | 2014-10-05 11:01 | no       | 2014-10-05 11:01       | 2014-10-05 11:54 |
+    | #master2     | historic commit            |                 |                     | 2014-10-01 12:01 | no       | 2014-10-01 12:01       |                  |
+    | #master1     | initial commit             |                 |                     | 2014-09-29 09:18 | no       | 2014-09-29 09:18       | 2014-09-29 11:37 |

--- a/features/releases.feature
+++ b/features/releases.feature
@@ -52,15 +52,16 @@ Scenario: Viewing releases for an app
   # 2014-10-04
   And ticket "JIRA-456" is approved by "bob@fundingcircle.com" at "2014-10-04 15:24:34"
 
-  # 2014-10-05
+  # 2014-10-05 - approved after commit to master and deploy
+  # allow developers to gain approval retrospectively
   And the branch "master" is checked out
   And a commit "#master3" with message "sneaky commit" is created at "2014-10-05 11:01:02"
   And developer prepares review known as "FR_789" for UAT "uat.example.com" with apps
     | app_name | version  |
     | frontend | #master3 |
   And at time "2014-10-05 11:02:00" adds link for review "FR_789" to comment for ticket "JIRA-789"
-  And ticket "JIRA-789" is approved by "jeff@fundingcircle.com" at "2014-10-05 11:03:45"
   And commit "#master3" of "frontend" is deployed by "Jeff" to production at "2014-10-05 11:54:20"
+  And ticket "JIRA-789" is approved by "jeff@fundingcircle.com" at "2014-10-05 11:03:45"
 
   # 2014-10-06
   And the branch "master" is checked out
@@ -69,15 +70,15 @@ Scenario: Viewing releases for an app
   When I view the releases for "frontend"
 
   Then I should see the "pending" releases
-    | version  | subject                         | feature reviews | review statuses     | review times                             | approved | committed to master at |
-    | #merge2  | Merged `feature2` into `master` | FR_456          | approved            | 2014-10-04 15:24:34                      | yes      | 2014-10-06 17:04       |
-    | #feat2_b | feat2 second commit             | FR_456          | approved            | 2014-10-04 15:24:34                      | yes      | 2014-10-06 17:04       |
-    | #feat2_a | feat2 first commit              | FR_123, FR_456  | unapproved approved | 2014-10-06 17:04:19, 2014-10-04 15:24:34 | yes      | 2014-10-06 17:04       |
+    | version  | subject                         | feature reviews | review statuses     | review times          | approved |
+    | #merge2  | Merged `feature2` into `master` | FR_456          | approved            | 2014-10-04 15:24:34   | yes      |
+    | #feat2_b | feat2 second commit             | FR_456          | approved            | 2014-10-04 15:24:34   | yes      |
+    | #feat2_a | feat2 first commit              | FR_123, FR_456  | unapproved approved | , 2014-10-04 15:24:34 | yes      |
 
   And I should see the "deployed" releases
-    | version  | subject                         | feature reviews | review statuses     | review times                             | approved | committed to master at | last deployed at |
-    | #master3 | sneaky commit                   |                 |                     |                                          | no       | 2014-10-05 11:01       | 2014-10-05 11:54 |
-    | #merge1  | Merged `feature1` into `master` | FR_ONE          | approved            | 2014-10-01 15:20:34                      | yes      | 2014-10-01 16:14       | 2014-10-01 17:34 |
-    | #feat1_a | feat1 first commit              | FR_ONE          | approved            | 2014-10-01 15:20:34                      | yes      | 2014-10-01 16:14       |                  |
-    | #master2 | historic commit                 |                 |                     |                                          | no       | 2014-09-30 12:01       |                  |
-    | #master1 | initial commit                  |                 |                     |                                          | no       | 2014-09-28 09:18       | 2014-09-28 11:37 |
+    | version  | subject                         | feature reviews | review statuses     | review times          | approved | last deployed at |
+    | #master3 | sneaky commit                   | FR_789          | approved            | 2014-10-05 11:03:45   | yes      | 2014-10-05 11:54 |
+    | #merge1  | Merged `feature1` into `master` | FR_ONE          | unapproved          |                       | no       | 2014-10-01 17:34 |
+    | #feat1_a | feat1 first commit              | FR_ONE          | unapproved          |                       | no       |                  |
+    | #master2 | historic commit                 |                 |                     |                       | no       |                  |
+    | #master1 | initial commit                  |                 |                     |                       | no       | 2014-09-28 11:37 |

--- a/features/releases.feature
+++ b/features/releases.feature
@@ -5,43 +5,63 @@ Feature: Viewing Releases
   So I know which versions are safe to deploy and which versions have already been deployed
 
 Scenario: Viewing releases for an app
+  # 2014-09-29
   Given an application called "frontend"
-  And a ticket "JIRA-789" with summary "Old ticket" is started
-  And a ticket "JIRA-123" with summary "Urgent ticket" is started
-  And a ticket "JIRA-456" with summary "Not so urgent ticket" is started
-  And a commit "#master1" with message "historic commit" is created at "00:01:17"
-  And developer prepares review known as "FR_789" for UAT "uat.example.com" with apps
-    | app_name | version  |
-    | frontend | #master1 |
-  And at time "01:02:00" adds link for review "FR_789" to comment for ticket "JIRA-789"
-  And ticket "JIRA-789" is approved by "jeff@fundingcircle.com" at "01:03:45"
+  And a commit "#master1" with message "initial commit" is created at "2014-09-29 09:18:57"
+  And commit "#master1" of "frontend" is deployed by "Fred" to production at "2014-09-29 11:37:13"
+
+  # 2014-09-30
+  And a ticket "JIRA-789" with summary "Old ticket" is started at "2014-09-30 13:01:17"
+  And a ticket "JIRA-123" with summary "Urgent ticket" is started at "2014-09-30 14:31:46"
+  And a ticket "JIRA-456" with summary "Not so urgent ticket" is started at "2014-09-30 15:02:00"
+
+  # 2014-10-01
+  And a commit "#master2" with message "historic commit" is created at "2014-10-01 12:01:17"
+
+  # 2014-10-02
   And the branch "feature" is checked out
-  And a commit "#branch1" with message "first commit" is created at "02:01:17"
-  And a commit "#branch2" with message "second commit" is created at "02:04:19"
-  And commit "#branch2" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com"
+  And a commit "#branch1" with message "first commit" is created at "2014-10-02 14:01:17"
   And developer prepares review known as "FR_123" for UAT "uat.fundingcircle.com" with apps
     | app_name | version  |
     | frontend | #branch1 |
-  And at time "03:12:45" adds link for review "FR_123" to comment for ticket "JIRA-123"
+  And at time "2014-10-02 15:12:45" adds link for review "FR_123" to comment for ticket "JIRA-123"
+
+  # 2014-10-03
+  And the branch "feature" is checked out
+  And a commit "#branch2" with message "second commit" is created at "2014-10-03 14:04:19"
+  And commit "#branch2" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com" at "2014-10-03 14:25:00"
   And developer prepares review known as "FR_456" for UAT "uat.example.com" with apps
     | app_name | version  |
     | frontend | #branch2 |
-  And at time "03:19:53" adds link for review "FR_456" to comment for ticket "JIRA-456"
-  And ticket "JIRA-456" is approved by "bob@fundingcircle.com" at "03:24:34"
+  And at time "2014-10-03 15:19:53" adds link for review "FR_456" to comment for ticket "JIRA-456"
+
+  # 2014-10-04
+  And ticket "JIRA-456" is approved by "bob@fundingcircle.com" at "2014-10-04 15:24:34"
+
+  # 2014-10-05
   And the branch "master" is checked out
-  And a commit "#master2" with message "sneaky commit" is created at "04:01:02"
-  And commit "#master2" of "frontend" is deployed by "Charlotte" to production at "04:54:20"
-  And the branch "feature" is merged with merge commit "#merge" at "05:04:19"
+  And a commit "#master3" with message "sneaky commit" is created at "2014-10-05 11:01:02"
+  And developer prepares review known as "FR_789" for UAT "uat.example.com" with apps
+    | app_name | version  |
+    | frontend | #master3 |
+  And at time "2014-10-05 11:02:00" adds link for review "FR_789" to comment for ticket "JIRA-789"
+  And ticket "JIRA-789" is approved by "jeff@fundingcircle.com" at "2014-10-05 11:03:45"
+  And commit "#master3" of "frontend" is deployed by "Jeff" to production at "2014-10-05 11:54:20"
+
+  # 2014-10-06
+  And the branch "master" is checked out
+  And the branch "feature" is merged with merge commit "#merge" at "2014-10-06 17:04:19"
 
   When I view the releases for "frontend"
 
   Then I should see the "pending" releases
     | version  | subject                        | feature reviews | review statuses     | approved | committed to master at |
-    | #merge   | Merged `feature` into `master` | FR_456          | approved            | yes      | 05:04                  |
-    | #branch2 | second commit                  | FR_456          | approved            | yes      | 05:04                  |
-    | #branch1 | first commit                   | FR_123, FR_456  | unapproved approved | yes      | 05:04                  |
+    | #merge   | Merged `feature` into `master` | FR_456          | approved            | yes      | 2014-10-06 17:04       |
+    | #branch2 | second commit                  | FR_456          | approved            | yes      | 2014-10-06 17:04       |
+    | #branch1 | first commit                   | FR_123, FR_456  | unapproved approved | yes      | 2014-10-06 17:04       |
 
   And I should see the "deployed" releases
     | version      | subject                    | feature reviews | review statuses     | approved | committed to master at | last deployed at |
-    | #master2     | sneaky commit              |                 |                     | no       | 04:01                  | 04:54            |
-    | #master1     | historic commit            |                 |                     | no       | 00:01                  |                  |
+    | #master3     | sneaky commit              |                 |                     | no       | 2014-10-05 11:01       | 2014-10-05 11:54 |
+    | #master2     | historic commit            |                 |                     | no       | 2014-10-01 12:01       |                  |
+    | #master1     | initial commit             |                 |                     | no       | 2014-09-29 09:18       | 2014-09-29 11:37 |

--- a/features/releases.feature
+++ b/features/releases.feature
@@ -5,34 +5,48 @@ Feature: Viewing Releases
   So I know which versions are safe to deploy and which versions have already been deployed
 
 Scenario: Viewing releases for an app
-  # 2014-09-29
+  # 2014-09-28 - application creation
   Given an application called "frontend"
-  And a commit "#master1" with message "initial commit" is created at "2014-09-29 09:18:57"
-  And commit "#master1" of "frontend" is deployed by "Fred" to production at "2014-09-29 11:37:13"
+  And a commit "#master1" with message "initial commit" is created at "2014-09-28 09:18:57"
+  And commit "#master1" of "frontend" is deployed by "Fred" to production at "2014-09-28 11:37:13"
+
+  # 2014-09-29 - ticket creation
+  And a ticket "JIRA-ONE" with summary "Ticket ONE" is started at "2014-09-29 09:13:00"
+  And a ticket "JIRA-789" with summary "Old ticket" is started at "2014-09-29 13:01:17"
+  And a ticket "JIRA-123" with summary "Urgent ticket" is started at "2014-09-29 14:31:46"
+  And a ticket "JIRA-456" with summary "Not so urgent ticket" is started at "2014-09-29 15:02:00"
 
   # 2014-09-30
-  And a ticket "JIRA-789" with summary "Old ticket" is started at "2014-09-30 13:01:17"
-  And a ticket "JIRA-123" with summary "Urgent ticket" is started at "2014-09-30 14:31:46"
-  And a ticket "JIRA-456" with summary "Not so urgent ticket" is started at "2014-09-30 15:02:00"
+  And a commit "#master2" with message "historic commit" is created at "2014-09-30 12:01:17"
 
-  # 2014-10-01
-  And a commit "#master2" with message "historic commit" is created at "2014-10-01 12:01:17"
+  # 2014-10-01 - reverting approval for release that has been merged and deployed
+  And the branch "feature1" is checked out
+  And a commit "#feat1_a" with message "feat1 first commit" is created at "2014-10-01 13:12:37"
+  And developer prepares review known as "FR_ONE" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version  |
+    | frontend | #feat1_a |
+  And at time "2014-10-01 14:52:45" adds link for review "FR_ONE" to comment for ticket "JIRA-ONE"
+  And ticket "JIRA-ONE" is approved by "bob@fundingcircle.com" at "2014-10-01 15:20:34"
+  And the branch "master" is checked out
+  And the branch "feature1" is merged with merge commit "#merge1" at "2014-10-01 16:14:39"
+  And commit "#merge1" of "frontend" is deployed by "Jeff" to production at "2014-10-01 17:34:20"
+  And ticket "JIRA-ONE" is moved from approved to unapproved by "bob@fundingcircle.com" at "2014-10-01 18:15:28"
 
   # 2014-10-02
-  And the branch "feature" is checked out
-  And a commit "#branch1" with message "first commit" is created at "2014-10-02 14:01:17"
+  And the branch "feature2" is checked out
+  And a commit "#feat2_a" with message "feat2 first commit" is created at "2014-10-02 14:01:17"
   And developer prepares review known as "FR_123" for UAT "uat.fundingcircle.com" with apps
     | app_name | version  |
-    | frontend | #branch1 |
+    | frontend | #feat2_a |
   And at time "2014-10-02 15:12:45" adds link for review "FR_123" to comment for ticket "JIRA-123"
 
   # 2014-10-03
-  And the branch "feature" is checked out
-  And a commit "#branch2" with message "second commit" is created at "2014-10-03 14:04:19"
-  And commit "#branch2" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com" at "2014-10-03 14:25:00"
+  And the branch "feature2" is checked out
+  And a commit "#feat2_b" with message "feat2 second commit" is created at "2014-10-03 14:04:19"
+  And commit "#feat2_b" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com" at "2014-10-03 14:25:00"
   And developer prepares review known as "FR_456" for UAT "uat.example.com" with apps
     | app_name | version  |
-    | frontend | #branch2 |
+    | frontend | #feat2_b |
   And at time "2014-10-03 15:19:53" adds link for review "FR_456" to comment for ticket "JIRA-456"
 
   # 2014-10-04
@@ -50,18 +64,20 @@ Scenario: Viewing releases for an app
 
   # 2014-10-06
   And the branch "master" is checked out
-  And the branch "feature" is merged with merge commit "#merge" at "2014-10-06 17:04:19"
+  And the branch "feature2" is merged with merge commit "#merge2" at "2014-10-06 17:04:19"
 
   When I view the releases for "frontend"
 
   Then I should see the "pending" releases
-    | version  | subject                        | feature reviews | review statuses     | review times                             | approved | committed to master at |
-    | #merge   | Merged `feature` into `master` | FR_456          | approved            | 2014-10-04 15:24:34                      | yes      | 2014-10-06 17:04       |
-    | #branch2 | second commit                  | FR_456          | approved            | 2014-10-04 15:24:34                      | yes      | 2014-10-06 17:04       |
-    | #branch1 | first commit                   | FR_123, FR_456  | unapproved approved | 2014-10-06 17:04:19, 2014-10-04 15:24:34 | yes      | 2014-10-06 17:04       |
+    | version  | subject                         | feature reviews | review statuses     | review times                             | approved | committed to master at |
+    | #merge2  | Merged `feature2` into `master` | FR_456          | approved            | 2014-10-04 15:24:34                      | yes      | 2014-10-06 17:04       |
+    | #feat2_b | feat2 second commit             | FR_456          | approved            | 2014-10-04 15:24:34                      | yes      | 2014-10-06 17:04       |
+    | #feat2_a | feat2 first commit              | FR_123, FR_456  | unapproved approved | 2014-10-06 17:04:19, 2014-10-04 15:24:34 | yes      | 2014-10-06 17:04       |
 
   And I should see the "deployed" releases
-    | version      | subject                    | feature reviews | review statuses     | review times     | approved | committed to master at | last deployed at |
-    | #master3     | sneaky commit              |                 |                     | 2014-10-05 11:01 | no       | 2014-10-05 11:01       | 2014-10-05 11:54 |
-    | #master2     | historic commit            |                 |                     | 2014-10-01 12:01 | no       | 2014-10-01 12:01       |                  |
-    | #master1     | initial commit             |                 |                     | 2014-09-29 09:18 | no       | 2014-09-29 09:18       | 2014-09-29 11:37 |
+    | version  | subject                         | feature reviews | review statuses     | review times                             | approved | committed to master at | last deployed at |
+    | #master3 | sneaky commit                   |                 |                     |                                          | no       | 2014-10-05 11:01       | 2014-10-05 11:54 |
+    | #merge1  | Merged `feature1` into `master` | FR_ONE          | approved            | 2014-10-01 15:20:34                      | yes      | 2014-10-01 16:14       | 2014-10-01 17:34 |
+    | #feat1_a | feat1 first commit              | FR_ONE          | approved            | 2014-10-01 15:20:34                      | yes      | 2014-10-01 16:14       |                  |
+    | #master2 | historic commit                 |                 |                     |                                          | no       | 2014-09-30 12:01       |                  |
+    | #master1 | initial commit                  |                 |                     |                                          | no       | 2014-09-28 09:18       | 2014-09-28 11:37 |

--- a/features/releases.feature
+++ b/features/releases.feature
@@ -9,39 +9,39 @@ Scenario: Viewing releases for an app
   And a ticket "JIRA-789" with summary "Old ticket" is started
   And a ticket "JIRA-123" with summary "Urgent ticket" is started
   And a ticket "JIRA-456" with summary "Not so urgent ticket" is started
-  And a commit "#master1" with message "historic commit" is created at "13:01:17"
+  And a commit "#master1" with message "historic commit" is created at "00:01:17"
   And developer prepares review known as "FR_789" for UAT "uat.example.com" with apps
     | app_name | version  |
     | frontend | #master1 |
-  And adds the link for review "FR_789" to a comment for ticket "JIRA-789"
-  And ticket "JIRA-789" is approved by "jeff@fundingcircle.com" at "13:02:45"
+  And at time "01:02:00" adds link for review "FR_789" to comment for ticket "JIRA-789"
+  And ticket "JIRA-789" is approved by "jeff@fundingcircle.com" at "01:03:45"
   And the branch "feature" is checked out
-  And a commit "#branch1" with message "first commit" is created at "14:01:17"
-  And a commit "#branch2" with message "second commit" is created at "15:04:19"
+  And a commit "#branch1" with message "first commit" is created at "02:01:17"
+  And a commit "#branch2" with message "second commit" is created at "02:04:19"
   And commit "#branch2" of "frontend" is deployed by "Alice" to server "uat.fundingcircle.com"
   And developer prepares review known as "FR_123" for UAT "uat.fundingcircle.com" with apps
     | app_name | version  |
     | frontend | #branch1 |
-  And adds the link for review "FR_123" to a comment for ticket "JIRA-123"
+  And at time "03:12:45" adds link for review "FR_123" to comment for ticket "JIRA-123"
   And developer prepares review known as "FR_456" for UAT "uat.example.com" with apps
     | app_name | version  |
     | frontend | #branch2 |
-  And adds the link for review "FR_456" to a comment for ticket "JIRA-456"
-  And ticket "JIRA-456" is approved by "bob@fundingcircle.com" at "15:24:34"
+  And at time "03:19:53" adds link for review "FR_456" to comment for ticket "JIRA-456"
+  And ticket "JIRA-456" is approved by "bob@fundingcircle.com" at "03:24:34"
   And the branch "master" is checked out
-  And a commit "#master2" with message "sneaky commit" is created at "13:31:17"
-  And commit "#master2" of "frontend" is deployed by "Charlotte" to production at "15:54:20"
-  And the branch "feature" is merged with merge commit "#merge" at "16:04:19"
+  And a commit "#master2" with message "sneaky commit" is created at "04:01:02"
+  And commit "#master2" of "frontend" is deployed by "Charlotte" to production at "04:54:20"
+  And the branch "feature" is merged with merge commit "#merge" at "05:04:19"
 
   When I view the releases for "frontend"
 
   Then I should see the "pending" releases
-    | version  | subject                        | feature reviews | review statuses     | approved |
-    | #merge   | Merged `feature` into `master` | FR_456          | approved            | yes      |
-    | #branch2 | second commit                  | FR_456          | approved            | yes      |
-    | #branch1 | first commit                   | FR_123, FR_456  | unapproved approved | yes      |
+    | version  | subject                        | feature reviews | review statuses     | approved | committed to master at |
+    | #merge   | Merged `feature` into `master` | FR_456          | approved            | yes      | 05:04                  |
+    | #branch2 | second commit                  | FR_456          | approved            | yes      | 05:04                  |
+    | #branch1 | first commit                   | FR_123, FR_456  | unapproved approved | yes      | 05:04                  |
 
   And I should see the "deployed" releases
-    | version      | subject           | feature reviews | review statuses | approved | last deployed at |
-    | #master2     | sneaky commit     |                 |                 | no       | 15:54            |
-    | #master1     | historic commit   | FR_789          | approved        | yes      |                  |
+    | version      | subject                    | feature reviews | review statuses     | approved | committed to master at | last deployed at |
+    | #master2     | sneaky commit              |                 |                     | no       | 04:01                  | 04:54            |
+    | #master1     | historic commit            |                 |                     | no       | 00:01                  |                  |

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -20,7 +20,7 @@ Given 'CircleCi "$outcome" for commit "$version"' do |outcome, version|
     version: scenario_context.resolve_version(version),
   ).details
 
-  post_event 'circleci-manual', payload
+  scenario_context.post_event 'circleci-manual', payload
 end
 
 Given 'commit "$version" of "$app" is deployed by "$name" to server "$server"' do |version, app, name, server|
@@ -32,7 +32,7 @@ Given 'commit "$version" of "$app" is deployed by "$name" to server "$server"' d
     deployed_by: name,
   ).details
 
-  post_event 'deploy', payload
+  scenario_context.post_event 'deploy', payload
 end
 
 Given 'commit "$ver" of "$app" is deployed by "$name" to production at "$time"' do |ver, app, name, time|
@@ -46,7 +46,7 @@ Given 'commit "$ver" of "$app" is deployed by "$name" to production at "$time"' 
   ).details
 
   travel_to Time.zone.parse(time) do
-    post_event 'deploy', payload
+    scenario_context.post_event 'deploy', payload
   end
 end
 
@@ -58,17 +58,5 @@ Given 'User Acceptance Tests at version "$sha" which "$outcome" on server "$serv
     server: server,
   ).details
 
-  post_event 'uat', payload
-end
-
-def post_event(type, payload)
-  OmniAuth.config.test_mode = true
-  OmniAuth.config.mock_auth[:event_token] = OmniAuth::AuthHash.new(
-    provider: 'event_token',
-    uid:      type,
-  )
-  url = "/events/#{type}"
-  post url, payload.to_json, 'CONTENT_TYPE' => 'application/json'
-
-  Repositories::Updater.from_rails_config.run
+  scenario_context.post_event 'uat', payload
 end

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -5,8 +5,8 @@ Given 'a ticket "$key" with summary "$summary" is started' do |key, summary|
   )
 end
 
-Given 'adds the link for review "$nickname" to a comment for ticket "$jira_key"' do |nickname, jira_key|
-  scenario_context.link_ticket_and_feature_review(jira_key, nickname)
+Given 'at time "$a" adds link for review "$b" to comment for ticket "$c"' do |time, nickname, jira_key|
+  scenario_context.link_ticket_and_feature_review(jira_key, nickname, time)
 end
 
 Given 'ticket "$key" is approved by "$approver_email" at "$time"' do |jira_key, approver_email, time|

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -18,6 +18,16 @@ Given 'ticket "$key" is approved by "$approver_email" at "$time"' do |jira_key, 
   scenario_context.approve_ticket(
     jira_key: jira_key,
     approver_email: approver_email,
+    approve: true,
+    time: time,
+  )
+end
+
+Given 'ticket "$key" is moved from approved to unapproved by "$email" at "$time"' do |jira_key, email, time|
+  scenario_context.approve_ticket(
+    jira_key: jira_key,
+    approver_email: email,
+    approve: false,
     time: time,
   )
 end

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -1,29 +1,41 @@
-Given 'a ticket "$key" with summary "$summary" is started' do |key, summary|
+Given 'a ticket "$key" with summary "$summary" is started at "$time"' do |key, summary, time|
   scenario_context.create_and_start_ticket(
     key: key,
     summary: summary,
+    time: time,
   )
 end
 
 Given 'at time "$a" adds link for review "$b" to comment for ticket "$c"' do |time, nickname, jira_key|
-  scenario_context.link_ticket_and_feature_review(jira_key, nickname, time)
+  scenario_context.link_ticket_and_feature_review(
+    jira_key: jira_key,
+    feature_review_nickname: nickname,
+    time: time,
+  )
 end
 
 Given 'ticket "$key" is approved by "$approver_email" at "$time"' do |jira_key, approver_email, time|
-  scenario_context.approve_ticket(jira_key, approver_email: approver_email, time: time)
+  scenario_context.approve_ticket(
+    jira_key: jira_key,
+    approver_email: approver_email,
+    time: time,
+  )
 end
 
-Given 'CircleCi "$outcome" for commit "$version"' do |outcome, version|
+Given 'At "$time" CircleCi "$outcome" for commit "$version"' do |time, outcome, version|
   payload = build(
     :circle_ci_manual_webhook_event,
     success?: outcome == 'passes',
     version: scenario_context.resolve_version(version),
   ).details
 
-  scenario_context.post_event 'circleci-manual', payload
+  travel_to Time.zone.parse(time) do
+    scenario_context.post_event 'circleci-manual', payload
+  end
 end
 
-Given 'commit "$version" of "$app" is deployed by "$name" to server "$server"' do |version, app, name, server|
+# rubocop:disable LineLength
+Given 'commit "$version" of "$app" is deployed by "$name" to server "$server" at "$time"' do |version, app, name, server, time|
   payload = build(
     :deploy_event,
     server: server,
@@ -32,8 +44,11 @@ Given 'commit "$version" of "$app" is deployed by "$name" to server "$server"' d
     deployed_by: name,
   ).details
 
-  scenario_context.post_event 'deploy', payload
+  travel_to Time.zone.parse(time) do
+    scenario_context.post_event 'deploy', payload
+  end
 end
+# rubocop:enable LineLength
 
 Given 'commit "$ver" of "$app" is deployed by "$name" to production at "$time"' do |ver, app, name, time|
   payload = build(
@@ -50,7 +65,8 @@ Given 'commit "$ver" of "$app" is deployed by "$name" to production at "$time"' 
   end
 end
 
-Given 'User Acceptance Tests at version "$sha" which "$outcome" on server "$server"' do |sha, outcome, server|
+# rubocop:disable LineLength
+Given 'User Acceptance Tests at version "$sha" which "$outcome" on server "$server" at "$time"' do |sha, outcome, server, time|
   payload = build(
     :uat_event,
     success: outcome == 'passed',
@@ -58,5 +74,8 @@ Given 'User Acceptance Tests at version "$sha" which "$outcome" on server "$serv
     server: server,
   ).details
 
-  scenario_context.post_event 'uat', payload
+  travel_to Time.zone.parse(time) do
+    scenario_context.post_event 'uat', payload
+  end
 end
+# rubocop:enable LineLength

--- a/features/step_definitions/feature_review_search_steps.rb
+++ b/features/step_definitions/feature_review_search_steps.rb
@@ -4,10 +4,14 @@ When 'I look up feature reviews for "$version" on "$app"' do |version, app|
 end
 
 Then 'I should see the feature review known as "$known_as" for' do |known_as, links_table|
-  links = links_table.hashes.map { |apps_hash|
-    scenario_context.prepare_review([apps_hash], apps_hash['uat'], known_as)
+  links = links_table.hashes.map { |row|
+    scenario_context.prepare_review(
+      [{ app_name: row['app_name'], version: row['version'] }],
+      row['uat'],
+      known_as,
+    )
+    scenario_context.review_url(feature_review_nickname: known_as)
   }
-
   expect(feature_review_search_page.links).to match_array(links)
 end
 

--- a/features/step_definitions/feature_review_search_steps.rb
+++ b/features/step_definitions/feature_review_search_steps.rb
@@ -10,7 +10,7 @@ Then 'I should see the feature review known as "$known_as" for' do |known_as, li
       row['uat'],
       known_as,
     )
-    scenario_context.review_url(feature_review_nickname: known_as)
+    scenario_context.review_path(feature_review_nickname: known_as)
   }
   expect(feature_review_search_page.links).to match_array(links)
 end

--- a/features/step_definitions/feature_review_steps.rb
+++ b/features/step_definitions/feature_review_steps.rb
@@ -24,11 +24,11 @@ Given 'developer prepares review known as "$a" for UAT "$b" with apps' do |known
 end
 
 When 'I visit the feature review known as "$known_as"' do |known_as|
-  visit scenario_context.review_url(feature_review_nickname: known_as)
+  visit scenario_context.review_path(feature_review_nickname: known_as)
 end
 
 When 'I visit feature review "$known_as" as at "$time"' do |known_as, time|
-  visit scenario_context.review_url(feature_review_nickname: known_as, time: time)
+  visit scenario_context.review_path(feature_review_nickname: known_as, time: time)
 end
 
 Then 'I should see the builds with heading "$status" and content' do |status, builds_table|

--- a/features/step_definitions/feature_review_steps.rb
+++ b/features/step_definitions/feature_review_steps.rb
@@ -23,12 +23,12 @@ Given 'developer prepares review known as "$a" for UAT "$b" with apps' do |known
   scenario_context.prepare_review(apps_table.hashes, uat_url, known_as)
 end
 
-Given 'developer prepares review known as "$a" upto now for UAT "$b" with apps' do |known_as, uat_url, table|
-  scenario_context.prepare_review(table.hashes, uat_url, known_as, 1.second.from_now)
+When 'I visit the feature review known as "$known_as"' do |known_as|
+  visit scenario_context.review_url(feature_review_nickname: known_as)
 end
 
-When 'I visit the feature review known as "$known_as"' do |known_as|
-  visit scenario_context.review_url(known_as)
+When 'I visit feature review "$known_as" as at "$time"' do |known_as, time|
+  visit scenario_context.review_url(feature_review_nickname: known_as, time: time)
 end
 
 Then 'I should see the builds with heading "$status" and content' do |status, builds_table|

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -8,7 +8,7 @@ end
 Given 'a commit "$version" by "$name" is created at "$time" for app "$app"' do |version, name, time, app|
   scenario_context.repository_for(app).create_commit(
     author_name: name,
-    time: Time.parse(time),
+    time: Time.zone.parse(time).utc,
     pretend_version: version,
   )
 end
@@ -17,7 +17,7 @@ Given 'a commit "$version" with message "$message" is created at "$time"' do |ve
   scenario_context.last_repository.create_commit(
     author_name: 'Alice',
     message: message,
-    time: Time.parse(time),
+    time: Time.zone.parse(time).utc,
     pretend_version: version,
   )
 end
@@ -32,6 +32,6 @@ Given 'the branch "$branch" is merged with merge commit "$version" at "$time' do
     branch_name: branch,
     pretend_version: version,
     author_name: 'Alice',
-    time: Time.parse(time),
+    time: Time.zone.parse(time).utc,
   )
 end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -5,8 +5,12 @@ Given 'an application called "$name"' do |name|
   scenario_context.setup_application(name)
 end
 
-Given 'a commit "$version" by "$name" is created for app "$app"' do |version, name, app|
-  scenario_context.repository_for(app).create_commit(author_name: name, pretend_version: version)
+Given 'a commit "$version" by "$name" is created at "$time" for app "$app"' do |version, name, time, app|
+  scenario_context.repository_for(app).create_commit(
+    author_name: name,
+    time: Time.parse(time),
+    pretend_version: version,
+  )
 end
 
 Given 'a commit "$version" with message "$message" is created at "$time"' do |version, message, time|

--- a/features/step_definitions/releases_steps.rb
+++ b/features/step_definitions/releases_steps.rb
@@ -9,10 +9,15 @@ Then 'I should see the "$deploy_status" releases' do |deploy_status, releases_ta
       'version' => scenario_context.resolve_version(release_line.fetch('version')).slice(0..6),
       'subject' => release_line.fetch('subject'),
       'feature_reviews' => release_line.fetch('review statuses'),
+      'feature_review_paths' => nil,
+      'committed_to_master_at' => nil,
     }
 
     nicknames = release_line.fetch('feature reviews').split(',')
     release['feature_review_paths'] = nicknames.map { |nickname| scenario_context.review_path(nickname) }
+
+    master_commit_time = release_line.fetch('committed to master at')
+    release['committed_to_master_at'] = Time.parse(master_commit_time) if master_commit_time
 
     if deploy_status == 'deployed'
       time = release_line.fetch('last deployed at')

--- a/features/step_definitions/releases_steps.rb
+++ b/features/step_definitions/releases_steps.rb
@@ -19,14 +19,14 @@ Then 'I should see the "$deploy_status" releases' do |deploy_status, releases_ta
     }
 
     master_commit_time = release_line.fetch('committed to master at')
-    release['committed_to_master_at'] = Time.parse(master_commit_time) if master_commit_time
+    release['committed_to_master_at'] = Time.zone.parse(master_commit_time) if master_commit_time
 
     if deploy_status == 'deployed'
       time = release_line.fetch('last deployed at')
       if time.empty?
         release['time'] = nil
       else
-        release['time'] = Time.parse(time)
+        release['time'] = Time.zone.parse(time)
       end
     end
 

--- a/features/step_definitions/releases_steps.rb
+++ b/features/step_definitions/releases_steps.rb
@@ -10,7 +10,6 @@ Then 'I should see the "$deploy_status" releases' do |deploy_status, releases_ta
       'subject' => release_line.fetch('subject'),
       'feature_reviews' => release_line.fetch('review statuses'),
       'feature_review_paths' => nil,
-      'committed_to_master_at' => nil,
     }
 
     nicknames = release_line.fetch('feature reviews').split(',').map(&:strip)
@@ -18,12 +17,9 @@ Then 'I should see the "$deploy_status" releases' do |deploy_status, releases_ta
     release['feature_review_paths'] = nicknames.zip(times).map { |nickname, time|
       scenario_context.review_path(
         feature_review_nickname: nickname,
-        time: Time.zone.parse(time),
+        time: time ? Time.zone.parse(time) : nil,
       )
     }
-
-    master_commit_time = release_line.fetch('committed to master at')
-    release['committed_to_master_at'] = Time.zone.parse(master_commit_time) if master_commit_time
 
     if deploy_status == 'deployed'
       time = release_line.fetch('last deployed at')

--- a/features/step_definitions/releases_steps.rb
+++ b/features/step_definitions/releases_steps.rb
@@ -14,8 +14,12 @@ Then 'I should see the "$deploy_status" releases' do |deploy_status, releases_ta
     }
 
     nicknames = release_line.fetch('feature reviews').split(',').map(&:strip)
-    release['feature_review_paths'] = nicknames.map { |nickname|
-      scenario_context.review_path(feature_review_nickname: nickname)
+    times = release_line.fetch('review times').split(',').map(&:strip)
+    release['feature_review_paths'] = nicknames.zip(times).map { |nickname, time|
+      scenario_context.review_path(
+        feature_review_nickname: nickname,
+        time: Time.zone.parse(time),
+      )
     }
 
     master_commit_time = release_line.fetch('committed to master at')

--- a/features/step_definitions/releases_steps.rb
+++ b/features/step_definitions/releases_steps.rb
@@ -13,8 +13,10 @@ Then 'I should see the "$deploy_status" releases' do |deploy_status, releases_ta
       'committed_to_master_at' => nil,
     }
 
-    nicknames = release_line.fetch('feature reviews').split(',')
-    release['feature_review_paths'] = nicknames.map { |nickname| scenario_context.review_path(nickname) }
+    nicknames = release_line.fetch('feature reviews').split(',').map(&:strip)
+    release['feature_review_paths'] = nicknames.map { |nickname|
+      scenario_context.review_path(feature_review_nickname: nickname)
+    }
 
     master_commit_time = release_line.fetch('committed to master at')
     release['committed_to_master_at'] = Time.parse(master_commit_time) if master_commit_time

--- a/features/support/pages/releases_page.rb
+++ b/features/support/pages/releases_page.rb
@@ -19,7 +19,8 @@ module Pages
           'version' => values.fetch(0).text,
           'subject' => values.fetch(1).text,
           'feature_reviews' => values.fetch(2).text,
-          'feature_review_paths' => extract_href_if_exists(values.fetch(2)),
+          'feature_review_paths' => extract_href(values.fetch(2)),
+          'committed_to_master_at' => extract_time(values.fetch(3)),
         }
       }
     end
@@ -28,24 +29,25 @@ module Pages
       verify!
       page.all('.deployed-release').map { |release_line|
         values = release_line.all('td').to_a
-        release = {
+        {
           'approved' => !release_line['class'].split.include?('danger'),
           'version' => values.fetch(0).text,
           'subject' => values.fetch(1).text,
           'feature_reviews' => values.fetch(2).text,
-          'feature_review_paths' => extract_href_if_exists(values.fetch(2)),
-          'time' => nil,
+          'feature_review_paths' => extract_href(values.fetch(2)),
+          'committed_to_master_at' => extract_time(values.fetch(3)),
+          'time' => extract_time(values.fetch(4)),
         }
-
-        deploy_time = values.fetch(3).text
-        release['time'] = Time.parse(deploy_time) unless deploy_time.empty?
-        release
       }
     end
 
     private
 
-    def extract_href_if_exists(element)
+    def extract_time(element)
+      Time.parse(element.text) unless element.text.empty?
+    end
+
+    def extract_href(element)
       element.all('a').map { |link| link['href'] }
     end
 

--- a/features/support/pages/releases_page.rb
+++ b/features/support/pages/releases_page.rb
@@ -20,7 +20,6 @@ module Pages
           'subject' => values.fetch(1).text,
           'feature_reviews' => values.fetch(2).text,
           'feature_review_paths' => extract_href(values.fetch(2)),
-          'committed_to_master_at' => extract_time(values.fetch(3)),
         }
       }
     end
@@ -35,8 +34,7 @@ module Pages
           'subject' => values.fetch(1).text,
           'feature_reviews' => values.fetch(2).text,
           'feature_review_paths' => extract_href(values.fetch(2)),
-          'committed_to_master_at' => extract_time(values.fetch(3)),
-          'time' => extract_time(values.fetch(4)),
+          'time' => extract_time(values.fetch(3)),
         }
       }
     end

--- a/features/support/pages/releases_page.rb
+++ b/features/support/pages/releases_page.rb
@@ -44,7 +44,7 @@ module Pages
     private
 
     def extract_time(element)
-      Time.parse(element.text) unless element.text.empty?
+      Time.zone.parse(element.text) unless element.text.empty?
     end
 
     def extract_href(element)

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -104,14 +104,6 @@ module Support
       url_to_path(r_url)
     end
 
-    def review_urls
-      @reviews.values.map { |review| build_url_for(review) }
-    end
-
-    def review_paths
-      review_urls.map { |r_url| url_to_path(r_url) }
-    end
-
     def post_event(type, payload)
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:event_token] = OmniAuth::AuthHash.new(

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -119,10 +119,6 @@ module Support
 
     include Rack::Test::Methods
 
-    def url_to_path(url)
-      URI.parse(url).request_uri
-    end
-
     def commit_from_pretend(pretend_commit)
       value = @repos.values.map { |r| r.commit_for_pretend_version(pretend_commit) }.compact.first
       fail "Could not find '#{pretend_commit}'" unless value

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -77,7 +77,7 @@ module Support
         updated: time,
       )
       event = build(:jira_event, ticket_details)
-      travel_to(time) do
+      travel_to Time.zone.parse(time) do
         post_event 'jira', event.details
       end
     end
@@ -89,7 +89,7 @@ module Support
         :approved,
         ticket_details.merge!(user_email: approver_email, updated: time),
       )
-      travel_to(time) do
+      travel_to Time.zone.parse(time) do
         post_event 'jira', event.details
       end
     end

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -71,9 +71,9 @@ module Support
     end
 
     def link_ticket_and_feature_review(jira_key:, feature_review_nickname:, time: nil)
-      url = review_url(feature_review_nickname: feature_review_nickname)
+      path = review_path(feature_review_nickname: feature_review_nickname)
       ticket_details = @tickets.fetch(jira_key).merge!(
-        comment_body: "Here you go: #{url}",
+        comment_body: "Here you go: #{path}",
         updated: time,
       )
       event = build(:jira_event, ticket_details)
@@ -94,14 +94,9 @@ module Support
       end
     end
 
-    def review_url(feature_review_nickname: nil, time: nil)
-      review = @reviews.fetch(feature_review_nickname)
-      build_url_for(review, time)
-    end
-
     def review_path(feature_review_nickname: nil, time: nil)
-      r_url = review_url(feature_review_nickname: feature_review_nickname, time: time)
-      url_to_path(r_url)
+      review = @reviews.fetch(feature_review_nickname)
+      build_path_for(review, time)
     end
 
     def post_event(type, payload)
@@ -133,7 +128,7 @@ module Support
       FactoryGirl.build(*args)
     end
 
-    def build_url_for(review, time = nil)
+    def build_path_for(review, time = nil)
       UrlBuilder.new(@host).build(review[:apps_hash], review[:uat_url], time)
     end
   end

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -71,9 +71,9 @@ module Support
     end
 
     def link_ticket_and_feature_review(jira_key:, feature_review_nickname:, time: nil)
-      path = review_path(feature_review_nickname: feature_review_nickname)
+      url = review_url(feature_review_nickname: feature_review_nickname)
       ticket_details = @tickets.fetch(jira_key).merge!(
-        comment_body: "Here you go: #{path}",
+        comment_body: "Here you go: #{url}",
         updated: time,
       )
       event = build(:jira_event, ticket_details)
@@ -94,9 +94,14 @@ module Support
       end
     end
 
+    def review_url(feature_review_nickname: nil, time: nil)
+      review = @reviews.fetch(feature_review_nickname)
+      feature_review_url(review[:apps_hash], review[:uat_url], time)
+    end
+
     def review_path(feature_review_nickname: nil, time: nil)
       review = @reviews.fetch(feature_review_nickname)
-      build_path_for(review, time)
+      feature_review_path(review[:apps_hash], review[:uat_url], time)
     end
 
     def post_event(type, payload)
@@ -126,10 +131,6 @@ module Support
 
     def build(*args)
       FactoryGirl.build(*args)
-    end
-
-    def build_path_for(review, time = nil)
-      UrlBuilder.new(@host).build(review[:apps_hash], review[:uat_url], time)
     end
   end
 

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -8,6 +8,7 @@ require 'factory_girl'
 module Support
   class ScenarioContext
     include Support::FeatureReviewHelpers
+    include ActiveSupport::Testing::TimeHelpers
 
     def initialize(app, host)
       @app = app # used by rack-test
@@ -96,6 +97,19 @@ module Support
 
     def review_paths
       review_urls.map { |review_url| url_to_path(review_url) }
+    end
+
+    def post_event(type, payload)
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:event_token] = OmniAuth::AuthHash.new(
+        provider: 'event_token',
+        uid:      type,
+      )
+      url = "/events/#{type}"
+
+      post url, payload.to_json, 'CONTENT_TYPE' => 'application/json'
+
+      Repositories::Updater.from_rails_config.run
     end
 
     private

--- a/spec/controllers/feature_reviews_controller_spec.rb
+++ b/spec/controllers/feature_reviews_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe FeatureReviewsController do
     context 'when the feature review form is valid' do
       before do
         allow(feature_review_form).to receive(:valid?).and_return(true)
-        allow(feature_review_form).to receive(:url).and_return('/the/url')
+        allow(feature_review_form).to receive(:path).and_return('/the/url')
       end
 
       it 'redirects to #show' do
@@ -125,7 +125,7 @@ RSpec.describe FeatureReviewsController do
     let(:repo) { instance_double(GitRepository) }
     let(:related_versions) { %w(abc def ghi) }
     let(:expected_links) { ['/somelink'] }
-    let(:expected_feature_reviews) { [instance_double(FeatureReview, url: '/somelink')] }
+    let(:expected_feature_reviews) { [instance_double(FeatureReview, path: '/somelink')] }
     let(:version) { 'abc123' }
 
     before do

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe FeatureReviewWithStatuses do
     end
   end
 
-  describe '#url' do
+  describe '#url_with_query_time' do
     let(:base_url) { 'http://localhost/feature_reviews' }
     let(:feature_review) {
       instance_double(FeatureReview,
@@ -296,16 +296,16 @@ RSpec.describe FeatureReviewWithStatuses do
 
     it 'returns the url for the feature review at the query time' do
       query = '?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com'
-      expect(decorator.url).to eq("#{base_url}#{query}")
+      expect(decorator.url_with_query_time).to eq("#{base_url}#{query}")
     end
   end
 
-  describe '#path' do
+  describe '#path_with_query_time' do
     before :each do
-      allow(decorator).to receive(:url).and_return('http://something.com/feature_reviews?uat_url=uat.com')
+      allow(decorator).to receive(:url_with_query_time).and_return('http://something.com/feature_reviews?uat_url=uat.com')
     end
 
-    subject { decorator.path }
+    subject { decorator.path_with_query_time }
     it { is_expected.to eq('/feature_reviews?uat_url=uat.com') }
   end
 

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe FeatureReviewWithStatuses do
     )
   }
 
-  let(:query_time) { Time.new(2014, 8, 10, 14, 40, 48) }
+  let(:query_time) { Time.parse('2014-08-10 14:40:48 UTC') }
   let(:time_now) { Time.now }
 
   let(:query_class) { class_double(Queries::FeatureReviewQuery, new: feature_review_query) }
@@ -295,7 +295,7 @@ RSpec.describe FeatureReviewWithStatuses do
     }
 
     it 'returns the url for the feature review at the query time' do
-      query = '?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com'
+      query = '?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com'
       expect(decorator.url).to eq("#{base_url}#{query}")
     end
   end
@@ -320,7 +320,7 @@ RSpec.describe FeatureReviewWithStatuses do
         instance_double(FeatureReview,
           uat_url: 'uat.com',
           versions: 'xxx',
-          approved_at: Time.new(2014, 4, 23, 11, 36, 32),
+          approved_at: Time.parse('2014-04-23 11:36:32 UTC'),
           base_url: base_url,
           query_hash: query_hash)
       }
@@ -330,7 +330,7 @@ RSpec.describe FeatureReviewWithStatuses do
       end
 
       it 'returns the url for the feature review at the approved_at time' do
-        query = '?apps%5Bapp1%5D=xxx&time=2014-04-23+11%3A36%3A32+%2B0100&uat_url=uat.com'
+        query = '?apps%5Bapp1%5D=xxx&time=2014-04-23+11%3A36%3A32+UTC&uat_url=uat.com'
         expect(decorator.approved_url).to eq("#{base_url}#{query}")
       end
 
@@ -348,7 +348,7 @@ RSpec.describe FeatureReviewWithStatuses do
         instance_double(FeatureReview,
           uat_url: 'uat.com',
           versions: 'xxx',
-          approved_at: Time.new(2014, 4, 23, 11, 36, 32),
+          approved_at: Time.parse('2014-04-23 11:36:32 UTC'),
           base_url: base_url,
           query_hash: query_hash)
       }

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -283,34 +283,25 @@ RSpec.describe FeatureReviewWithStatuses do
     end
   end
 
-  describe '#url_with_query_time' do
-    let(:base_url) { 'http://localhost/feature_reviews' }
+  describe '#path_with_query_time' do
+    let(:base_path) { '/feature_reviews' }
     let(:feature_review) {
       instance_double(FeatureReview,
-        base_url: base_url,
+        base_path: base_path,
         query_hash: {
           'apps' => { 'app1' => 'xxx', 'app2' => 'yyy' },
           'uat_url' => 'uat.com',
         })
     }
 
-    it 'returns the url for the feature review at the query time' do
+    it 'returns the path for the feature review at the query time' do
       query = '?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com'
-      expect(decorator.url_with_query_time).to eq("#{base_url}#{query}")
+      expect(decorator.path_with_query_time).to eq("#{base_path}#{query}")
     end
   end
 
-  describe '#path_with_query_time' do
-    before :each do
-      allow(decorator).to receive(:url_with_query_time).and_return('http://something.com/feature_reviews?uat_url=uat.com')
-    end
-
-    subject { decorator.path_with_query_time }
-    it { is_expected.to eq('/feature_reviews?uat_url=uat.com') }
-  end
-
-  describe '#approved_url' do
-    let(:base_url) { 'http://localhost/feature_reviews' }
+  describe '#approved_path' do
+    let(:base_path) { '/feature_reviews' }
     let(:query_hash) {
       { 'apps' => { 'app1' => 'xxx' }, 'uat_url' => 'uat.com' }
     }
@@ -321,7 +312,7 @@ RSpec.describe FeatureReviewWithStatuses do
           uat_url: 'uat.com',
           versions: 'xxx',
           approved_at: Time.parse('2014-04-23 11:36:32 UTC'),
-          base_url: base_url,
+          base_path: base_path,
           query_hash: query_hash)
       }
 
@@ -329,16 +320,16 @@ RSpec.describe FeatureReviewWithStatuses do
         allow(decorator).to receive(:approved?).and_return(true)
       end
 
-      it 'returns the url for the feature review at the approved_at time' do
+      it 'returns the path for the feature review at the approved_at time' do
         query = '?apps%5Bapp1%5D=xxx&time=2014-04-23+11%3A36%3A32+UTC&uat_url=uat.com'
-        expect(decorator.approved_url).to eq("#{base_url}#{query}")
+        expect(decorator.approved_path).to eq("#{base_path}#{query}")
       end
 
       context 'when the feature review does not have an approval time' do
         let(:feature_review) { instance_double(FeatureReview, approved_at: nil) }
 
         it 'returns nil' do
-          expect(decorator.approved_url).to be_nil
+          expect(decorator.approved_path).to be_nil
         end
       end
     end
@@ -349,7 +340,7 @@ RSpec.describe FeatureReviewWithStatuses do
           uat_url: 'uat.com',
           versions: 'xxx',
           approved_at: Time.parse('2014-04-23 11:36:32 UTC'),
-          base_url: base_url,
+          base_path: base_path,
           query_hash: query_hash)
       }
 
@@ -358,28 +349,8 @@ RSpec.describe FeatureReviewWithStatuses do
       end
 
       it 'returns nil' do
-        expect(decorator.approved_url).to be_nil
+        expect(decorator.approved_path).to be_nil
       end
-    end
-  end
-
-  describe '#approved_path' do
-    context 'when approved_url is NOT nil' do
-      before :each do
-        allow(decorator).to receive(:approved_url).and_return('http://something.com/feature_reviews?uat_url=uat.com')
-      end
-
-      subject { decorator.approved_path }
-      it { is_expected.to eq('/feature_reviews?uat_url=uat.com') }
-    end
-
-    context 'when approved_url is nil' do
-      before :each do
-        allow(decorator).to receive(:approved_url).and_return(nil)
-      end
-
-      subject { decorator.approved_path }
-      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/decorators/release_with_status_spec.rb
+++ b/spec/decorators/release_with_status_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe ReleaseWithStatus do
   let(:feature_review1) {
     instance_double(
       FeatureReview,
-      url: feature_review_url(frontend: 'abc', backend: 'xyx'),
+      path: feature_review_path(frontend: 'abc', backend: 'xyx'),
       versions: %w(commitsha1))
   }
 
   let(:feature_review2) {
     instance_double(
       FeatureReview,
-      url: feature_review_url(frontend: 'def', backend: 'uvw'),
+      path: feature_review_path(frontend: 'def', backend: 'uvw'),
       versions: %w(commitsha1 commitsha2))
   }
 

--- a/spec/decorators/release_with_status_spec.rb
+++ b/spec/decorators/release_with_status_spec.rb
@@ -64,43 +64,6 @@ RSpec.describe ReleaseWithStatus do
     expect(decorator.feature_reviews).to eq(release_query.feature_reviews)
   end
 
-  describe '#committed_to_master_at' do
-    let(:merge_time) { 1.day.ago }
-    let(:commit) { instance_double(GitCommit, time: release.time) }
-
-    before do
-      allow(git_repository).to receive(:commit_to_master_for)
-        .with('commitsha1')
-        .and_return(commit)
-    end
-
-    context 'when the commit is on master' do
-      let(:commit) { instance_double(GitCommit, time: time_now) }
-
-      it 'returns the commit time' do
-        expect(decorator.committed_to_master_at).to eq(time_now)
-      end
-    end
-
-    context 'when the commit is a feature branch commit' do
-      context 'when feature branch has been merged to master' do
-        let(:commit) { instance_double(GitCommit, time: merge_time) }
-
-        it 'returns the commit time of the subsequent merge commit' do
-          expect(decorator.committed_to_master_at).to eq(merge_time)
-        end
-      end
-
-      context 'when feature branch has NOT been merged to master' do
-        let(:commit) { nil }
-
-        it 'returns nil' do
-          expect(decorator.committed_to_master_at).to eq(nil)
-        end
-      end
-    end
-  end
-
   describe '#approved?' do
     it 'returns true if any of its feature reviews are approved' do
       allow(release_query).to receive(:feature_reviews).and_return([

--- a/spec/decorators/release_with_status_spec.rb
+++ b/spec/decorators/release_with_status_spec.rb
@@ -44,12 +44,6 @@ RSpec.describe ReleaseWithStatus do
       query_class: query_class)
   }
 
-  before :each do
-    allow(git_repository).to receive(:commit_to_master_for)
-      .with('commitsha1')
-      .and_return(nil)
-  end
-
   it 'delegates unknown messages to the release' do
     expect(decorator.version).to eq(release.version)
     expect(decorator.production_deploy_time).to eq(release.production_deploy_time)

--- a/spec/models/factories/feature_review_factory_spec.rb
+++ b/spec/models/factories/feature_review_factory_spec.rb
@@ -19,8 +19,14 @@ RSpec.describe Factories::FeatureReviewFactory do
 
     it 'returns an array of FeatureReviews for each URL in the given text' do
       expect(feature_reviews).to match_array([
-        FeatureReview.new(path: url1, versions: %w(a b)),
-        FeatureReview.new(path: url2, versions: %w(a)),
+        FeatureReview.new(
+          path: '/feature_reviews?apps%5Bapp1%5D=a&apps%5Bapp2%5D=b&other=true',
+          versions: %w(a b),
+        ),
+        FeatureReview.new(
+          path: '/feature_reviews?apps%5Bapp1%5D=a',
+          versions: %w(a),
+        ),
       ])
     end
 
@@ -51,23 +57,31 @@ RSpec.describe Factories::FeatureReviewFactory do
 
   context '#create_from_url_string' do
     it 'returns a FeatureReview with the attributes from the url' do
-      actual_url = full_url 'apps[a]' => '123',
-                            'apps[b]' => '456',
-                            'uat_url' => 'http://foo.com'
+      actual_url = full_url(
+        'apps[a]' => '123',
+        'apps[b]' => '456',
+        'uat_url' => 'http://foo.com',
+      )
+      expected_path = '/feature_reviews?apps%5Ba%5D=123&apps%5Bb%5D=456&uat_url=http%3A%2F%2Ffoo.com'
 
       feature_review = factory.create_from_url_string(actual_url)
       expect(feature_review.versions).to eq(%w(123 456))
       expect(feature_review.uat_url).to eq('http://foo.com')
+      expect(feature_review.path).to eq(expected_path)
     end
 
     it 'only captures non-blank versions in the url' do
-      actual_url = full_url 'apps[a]' => '123',
-                            'apps[b]' => '',
-                            'uat_url' => 'http://foo.com'
+      actual_url = full_url(
+        'apps[a]' => '123',
+        'apps[b]' => '',
+        'uat_url' => 'http://foo.com',
+      )
+      expected_path = '/feature_reviews?apps%5Ba%5D=123&apps%5Bb%5D=&uat_url=http%3A%2F%2Ffoo.com'
 
       feature_review = factory.create_from_url_string(actual_url)
       expect(feature_review.versions).to eq(['123'])
       expect(feature_review.uat_url).to eq('http://foo.com')
+      expect(feature_review.path).to eq(expected_path)
     end
   end
 

--- a/spec/models/factories/feature_review_factory_spec.rb
+++ b/spec/models/factories/feature_review_factory_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Factories::FeatureReviewFactory do
 
     it 'returns an array of FeatureReviews for each URL in the given text' do
       expect(feature_reviews).to match_array([
-        FeatureReview.new(url: url1, versions: %w(a b)),
-        FeatureReview.new(url: url2, versions: %w(a)),
+        FeatureReview.new(path: url1, versions: %w(a b)),
+        FeatureReview.new(path: url2, versions: %w(a)),
       ])
     end
 

--- a/spec/models/feature_review_spec.rb
+++ b/spec/models/feature_review_spec.rb
@@ -55,4 +55,25 @@ RSpec.describe FeatureReview do
 
     it { is_expected.to eq('app1' => 'xxx', 'app2' => 'yyy') }
   end
+
+  describe '#base_url' do
+    let(:url) { 'www.something.com/something?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy' }
+
+    subject { FeatureReview.new(url: url, versions: %w(xxx yyy)).base_url }
+
+    it { is_expected.to eq('www.something.com/something') }
+  end
+
+  describe '#query_hash' do
+    let(:url) { 'www.something.com/something?uat_url=uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy' }
+
+    subject { FeatureReview.new(url: url, versions: %w(xxx yyy)).query_hash }
+
+    it {
+      is_expected.to eq(
+        'apps' => { 'app1' => 'xxx', 'app2' => 'yyy' },
+        'uat_url' => 'uat.com',
+      )
+    }
+  end
 end

--- a/spec/models/feature_review_spec.rb
+++ b/spec/models/feature_review_spec.rb
@@ -2,72 +2,72 @@ require 'spec_helper'
 require 'feature_review'
 
 RSpec.describe FeatureReview do
-  let(:base_url) { 'http://localhost/feature_reviews' }
+  let(:base_path) { '/feature_reviews' }
 
   describe '#path' do
-    let(:url) { "#{base_url}?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
+    let(:path) { "#{base_path}?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
 
-    subject { FeatureReview.new(url: url, versions: %w(xxx yyy)).path }
+    subject { FeatureReview.new(path: path, versions: %w(xxx yyy)).path }
 
     it { is_expected.to eq('/feature_reviews?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy') }
   end
 
   describe '#uat_host' do
-    let(:url) { "#{base_url}?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
+    let(:path) { "#{base_path}?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
 
-    subject { FeatureReview.new(url: url, versions: %w(xxx yyy)).uat_host }
+    subject { FeatureReview.new(path: path, versions: %w(xxx yyy)).uat_host }
 
     it { is_expected.to eq('uat.com') }
 
     context 'when scheme is missing' do
-      let(:url) { "#{base_url}?uat_url=uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
+      let(:path) { "#{base_path}?uat_url=uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
       it { is_expected.to eq('uat.com') }
     end
 
     context 'when uat_url is missing' do
-      let(:url) { "#{base_url}?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
+      let(:path) { "#{base_path}?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
       it { is_expected.to be_nil }
     end
   end
 
   describe '#uat_url' do
-    let(:url) { "#{base_url}?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
+    let(:path) { "#{base_path}?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
 
-    subject { FeatureReview.new(url: url, versions: %w(xxx yyy)).uat_url }
+    subject { FeatureReview.new(path: path, versions: %w(xxx yyy)).uat_url }
 
     it { is_expected.to eq('http://uat.com') }
 
     context 'when scheme is missing' do
-      let(:url) { "#{base_url}?uat_url=uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
+      let(:path) { "#{base_path}?uat_url=uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
       it { is_expected.to eq('http://uat.com') }
     end
 
     context 'when uat_url is missing' do
-      let(:url) { "#{base_url}?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
+      let(:path) { "#{base_path}?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy" }
       it { is_expected.to be_nil }
     end
   end
 
   describe '#app_versions' do
-    let(:url) { "#{base_url}?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy&apps%5Bapp3%5D" }
+    let(:path) { "#{base_path}?apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy&apps%5Bapp3%5D" }
 
-    subject { FeatureReview.new(url: url, versions: %w(xxx yyy)).app_versions }
+    subject { FeatureReview.new(path: path, versions: %w(xxx yyy)).app_versions }
 
     it { is_expected.to eq('app1' => 'xxx', 'app2' => 'yyy') }
   end
 
-  describe '#base_url' do
-    let(:url) { 'www.something.com/something?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy' }
+  describe '#base_path' do
+    let(:path) { '/something?uat_url=http://uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy' }
 
-    subject { FeatureReview.new(url: url, versions: %w(xxx yyy)).base_url }
+    subject { FeatureReview.new(path: path, versions: %w(xxx yyy)).base_path }
 
-    it { is_expected.to eq('www.something.com/something') }
+    it { is_expected.to eq('/something') }
   end
 
   describe '#query_hash' do
-    let(:url) { 'www.something.com/something?uat_url=uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy' }
+    let(:path) { '/something?uat_url=uat.com&apps%5Bapp1%5D=xxx&apps%5Bapp2%5D=yyy' }
 
-    subject { FeatureReview.new(url: url, versions: %w(xxx yyy)).query_hash }
+    subject { FeatureReview.new(path: path, versions: %w(xxx yyy)).query_hash }
 
     it {
       is_expected.to eq(

--- a/spec/models/forms/feature_review_form_spec.rb
+++ b/spec/models/forms/feature_review_form_spec.rb
@@ -152,11 +152,11 @@ RSpec.describe Forms::FeatureReviewForm do
     end
   end
 
-  describe '#url' do
+  describe '#path' do
     let(:apps) { { frontend: 'abc', backend: 'def' } }
     let(:uat_url) { 'http://foobar.com/blah/blah' }
 
-    subject { feature_review_form.url }
+    subject { feature_review_form.path }
 
     it do
       is_expected.to eq(

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -362,66 +362,6 @@ RSpec.describe GitRepository do
     end
   end
 
-  describe '#commit_to_master_for' do
-    context 'when the given commit is on the master branch' do
-      context 'when commit is a merge commit' do
-        let(:git_diagram) do
-          <<-'EOS'
-               A-B
-              /   \
-            -o--o--C
-          EOS
-        end
-
-        let(:sha) { commit('C') }
-        it 'returns the commit itself' do
-          expect(repo.commit_to_master_for(sha).oid).to eq(commit('C'))
-        end
-      end
-
-      context 'when commit is a commit directly to master' do
-        let(:git_diagram) { '-o-A-B-C' }
-
-        let(:sha) { commit('B') }
-        it 'returns the commit itself' do
-          expect(repo.commit_to_master_for(sha).oid).to eq(commit('B'))
-        end
-      end
-    end
-
-    context 'when the given commit is on a feature branch' do
-      context 'when merged to master' do
-        let(:git_diagram) do
-          <<-'EOS'
-               A-B
-              /   \
-            -o--o--C
-          EOS
-        end
-
-        let(:sha) { commit('A') }
-        it 'returns nil' do
-          expect(repo.commit_to_master_for(sha).oid).to eq(commit('C'))
-        end
-      end
-
-      context 'when NOT merged to master' do
-        let(:git_diagram) do
-          <<-'EOS'
-               o-A-o
-              /
-            -o-----o
-          EOS
-        end
-
-        let(:sha) { commit('A') }
-        it 'returns nil' do
-          expect(repo.commit_to_master_for(sha)).to be_nil
-        end
-      end
-    end
-  end
-
   private
 
   def commit(version)

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -364,17 +364,28 @@ RSpec.describe GitRepository do
 
   describe '#commit_to_master_for' do
     context 'when the given commit is on the master branch' do
-      let(:git_diagram) do
-        <<-'EOS'
-             A-B
-            /   \
-          -o--o--C
-        EOS
+      context 'when commit is a merge commit' do
+        let(:git_diagram) do
+          <<-'EOS'
+               A-B
+              /   \
+            -o--o--C
+          EOS
+        end
+
+        let(:sha) { commit('C') }
+        it 'returns the commit itself' do
+          expect(repo.commit_to_master_for(sha).oid).to eq(commit('C'))
+        end
       end
 
-      let(:sha) { commit('C') }
-      it 'returns the merge commit on master' do
-        expect(repo.commit_to_master_for(sha).oid).to eq(commit('C'))
+      context 'when commit is a commit directly to master' do
+        let(:git_diagram) { '-o-A-B-C' }
+
+        let(:sha) { commit('B') }
+        it 'returns the commit itself' do
+          expect(repo.commit_to_master_for(sha).oid).to eq(commit('B'))
+        end
       end
     end
 

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -362,6 +362,55 @@ RSpec.describe GitRepository do
     end
   end
 
+  describe '#commit_to_master_for' do
+    context 'when the given commit is on the master branch' do
+      let(:git_diagram) do
+        <<-'EOS'
+             A-B
+            /   \
+          -o--o--C
+        EOS
+      end
+
+      let(:sha) { commit('C') }
+      it 'returns the merge commit on master' do
+        expect(repo.commit_to_master_for(sha).oid).to eq(commit('C'))
+      end
+    end
+
+    context 'when the given commit is on a feature branch' do
+      context 'when merged to master' do
+        let(:git_diagram) do
+          <<-'EOS'
+               A-B
+              /   \
+            -o--o--C
+          EOS
+        end
+
+        let(:sha) { commit('A') }
+        it 'returns nil' do
+          expect(repo.commit_to_master_for(sha).oid).to eq(commit('C'))
+        end
+      end
+
+      context 'when NOT merged to master' do
+        let(:git_diagram) do
+          <<-'EOS'
+               o-A-o
+              /
+            -o-----o
+          EOS
+        end
+
+        let(:sha) { commit('A') }
+        it 'returns nil' do
+          expect(repo.commit_to_master_for(sha)).to be_nil
+        end
+      end
+    end
+  end
+
   private
 
   def commit(version)

--- a/spec/models/projections/releases_projection_spec.rb
+++ b/spec/models/projections/releases_projection_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe Projections::ReleasesProjection do
   before do
     allow(Repositories::FeatureReviewRepository).to receive(:new).and_return(feature_review_repository)
     allow(git_repository).to receive(:recent_commits).with(50).and_return(commits)
+    allow(git_repository).to receive(:commit_to_master_for)
     allow(deploy_repository).to receive(:deploys_for_versions).with(versions, environment: 'production')
       .and_return(deploys)
   end

--- a/spec/models/projections/releases_projection_spec.rb
+++ b/spec/models/projections/releases_projection_spec.rb
@@ -41,51 +41,27 @@ RSpec.describe Projections::ReleasesProjection do
 
   describe '#pending_releases' do
     it 'returns list of releases not yet deployed to production' do
-      expect(projection.pending_releases.length).to eq(1)
-
-      release = projection.pending_releases.first
-      expect(release.version).to eq('abc')
-      expect(release.subject).to eq('commit on topic branch')
+      versions = projection.pending_releases.map(&:version)
+      expect(versions).to eq(['abc'])
     end
 
-    describe 'returned releases' do
-      it 'have feature_reviews' do
-        expect(projection.pending_releases).to all(respond_to(:feature_reviews))
-      end
-
-      it 'have an approval_status and know whether they are approved' do
-        expect(projection.pending_releases).to all(respond_to(:approved?))
-        expect(projection.pending_releases).to all(respond_to(:approval_status))
-      end
+    it 'have appropriate methods' do
+      expect(projection.pending_releases).to all(respond_to(:feature_reviews))
+      expect(projection.pending_releases).to all(respond_to(:approved?))
+      expect(projection.pending_releases).to all(respond_to(:approval_status))
     end
   end
 
   describe '#deployed_releases' do
     it 'returns list of releases deployed to production' do
-      expect(projection.deployed_releases.length).to eq(2)
-
-      expect(projection.deployed_releases.any? { |release|
-        release.version == 'def' && release.subject == 'commit on topic branch'
-      }).to be true
-
-      expect(projection.deployed_releases.any? { |release|
-        release.version == 'ghi' && release.subject == 'commit on master branch'
-      }).to be true
+      versions = projection.deployed_releases.map(&:version)
+      expect(versions).to eq(%w(def ghi))
     end
 
-    describe 'returned releases' do
-      it 'know production_deploy_time' do
-        expect(projection.deployed_releases).to all(respond_to(:production_deploy_time))
-      end
-
-      it 'have feature_reviews' do
-        expect(projection.deployed_releases).to all(respond_to(:feature_reviews))
-      end
-
-      it 'have an approval_status and know whether they are approved' do
-        expect(projection.deployed_releases).to all(respond_to(:approved?))
-        expect(projection.deployed_releases).to all(respond_to(:approval_status))
-      end
+    it 'have appropriate methods' do
+      expect(projection.deployed_releases).to all(respond_to(:feature_reviews))
+      expect(projection.deployed_releases).to all(respond_to(:approved?))
+      expect(projection.deployed_releases).to all(respond_to(:approval_status))
     end
   end
 end

--- a/spec/models/projections/releases_projection_spec.rb
+++ b/spec/models/projections/releases_projection_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Projections::ReleasesProjection do
   before do
     allow(Repositories::FeatureReviewRepository).to receive(:new).and_return(feature_review_repository)
     allow(git_repository).to receive(:recent_commits).with(50).and_return(commits)
-    allow(git_repository).to receive(:commit_to_master_for)
     allow(deploy_repository).to receive(:deploys_for_versions).with(versions, environment: 'production')
       .and_return(deploys)
   end

--- a/spec/models/projections/releases_projection_spec.rb
+++ b/spec/models/projections/releases_projection_spec.rb
@@ -30,35 +30,6 @@ RSpec.describe Projections::ReleasesProjection do
   let(:versions) { commits.map(&:id) }
   let(:deploy_time) { time - 1.hour }
   let(:deploys) { [Deploy.new(version: 'def', app_name: app_name, event_created_at: deploy_time)] }
-  let(:feature_reviews) {
-    [
-      Snapshots::FeatureReview.create!(
-        url: feature_review_url(frontend: 'abc', backend: 'NON1'),
-        versions: %w(NON1 abc),
-        event_created_at: 1.day.ago,
-      ),
-      Snapshots::FeatureReview.create!(
-        url: feature_review_url(frontend: 'NON2', backend: 'def'),
-        versions: %w(def NON2),
-        event_created_at: 3.days.ago,
-      ),
-      Snapshots::FeatureReview.create!(
-        url: feature_review_url(frontend: 'NON2', backend: 'NON3'),
-        versions: %w(NON3 NON2),
-        event_created_at: 5.days.ago,
-      ),
-      Snapshots::FeatureReview.create!(
-        url: feature_review_url(frontend: 'ghi', backend: 'NON3'),
-        versions: %w(NON3 ghi),
-        event_created_at: 7.days.ago,
-      ),
-      Snapshots::FeatureReview.create!(
-        url: feature_review_url(frontend: 'NON4', backend: 'NON5'),
-        versions: %w(NON5 NON4),
-        event_created_at: 9.days.ago,
-      ),
-    ]
-  }
 
   before do
     allow(Repositories::FeatureReviewRepository).to receive(:new).and_return(feature_review_repository)
@@ -116,15 +87,5 @@ RSpec.describe Projections::ReleasesProjection do
         expect(projection.deployed_releases).to all(respond_to(:approval_status))
       end
     end
-  end
-
-  private
-
-  def feature_review_comment(apps)
-    "please review\n#{feature_review_url(apps)}"
-  end
-
-  def feature_review_path(apps)
-    URI.parse(feature_review_url(apps)).request_uri
   end
 end

--- a/spec/models/projections/releases_projection_spec.rb
+++ b/spec/models/projections/releases_projection_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Projections::ReleasesProjection do
 
     describe 'returned releases' do
       it 'have feature_reviews' do
-        expect(projection.deployed_releases).to all(respond_to(:feature_reviews))
+        expect(projection.pending_releases).to all(respond_to(:feature_reviews))
       end
 
       it 'have an approval_status and know whether they are approved' do

--- a/spec/models/queries/feature_review_query_spec.rb
+++ b/spec/models/queries/feature_review_query_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Queries::FeatureReviewQuery do
 
     before do
       allow(ticket_repository).to receive(:tickets_for)
-        .with(feature_review_url: feature_review.url, at: time)
+        .with(feature_review_path: feature_review.path, at: time)
         .and_return(expected_tickets)
     end
 

--- a/spec/models/queries/release_query_spec.rb
+++ b/spec/models/queries/release_query_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Queries::ReleaseQuery do
           )
           .and_return([feature_review_for_E, feature_review_for_F, feature_review_for_G])
 
-        expect(query.feature_reviews.map(&:url)).to match_array(%w(
+        expect(query.feature_reviews.map(&:url_with_query_time)).to match_array(%w(
           base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FE
           base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FF
         ))
@@ -145,7 +145,7 @@ RSpec.describe Queries::ReleaseQuery do
           )
           .and_return([feature_review_for_A])
 
-        expect(query.feature_reviews.map(&:url)).to match_array(%w(
+        expect(query.feature_reviews.map(&:url_with_query_time)).to match_array(%w(
           base_url_for_A?apps%5Bapp1%5D=A&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FA
         ))
       end
@@ -162,7 +162,7 @@ RSpec.describe Queries::ReleaseQuery do
           )
           .and_return([feature_review_for_D])
 
-        expect(query.feature_reviews.map(&:url)).to match_array(%w(
+        expect(query.feature_reviews.map(&:url_with_query_time)).to match_array(%w(
           base_url_for_D?apps%5Bapp1%5D=D&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FD
         ))
       end
@@ -179,7 +179,7 @@ RSpec.describe Queries::ReleaseQuery do
           )
           .and_return([feature_review_for_C, feature_review_for_E, feature_review_for_F])
 
-        expect(query.feature_reviews.map(&:url)).to match_array(%w(
+        expect(query.feature_reviews.map(&:url_with_query_time)).to match_array(%w(
           base_url_for_C?apps%5Bapp1%5D=C&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FC
           base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FE
           base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FF

--- a/spec/models/queries/release_query_spec.rb
+++ b/spec/models/queries/release_query_spec.rb
@@ -26,14 +26,13 @@ RSpec.describe Queries::ReleaseQuery do
   let(:sha_for_E) { version_for('E') }
   let(:sha_for_F) { version_for('F') }
   let(:sha_for_G) { version_for('G') }
-  let(:base_url) { 'base_url_for_A' }
 
   let(:feature_review_for_A) {
     instance_double(
       FeatureReview,
-      url: 'url_of_feature_review_for_A',
+      path: 'url_of_feature_review_for_A',
       versions: [sha_for_A],
-      base_url: 'base_url_for_A',
+      base_path: '/base_path_for_A',
       query_hash: { 'apps' => { 'app1' => 'A' }, 'uat_url' => 'uat.com/A' },
     )
   }
@@ -41,9 +40,9 @@ RSpec.describe Queries::ReleaseQuery do
   let(:feature_review_for_C) {
     instance_double(
       FeatureReview,
-      url: 'url_of_feature_review_for_C',
+      path: 'url_of_feature_review_for_C',
       versions: [sha_for_C],
-      base_url: 'base_url_for_C',
+      base_path: '/base_path_for_C',
       query_hash: { 'apps' => { 'app1' => 'C' }, 'uat_url' => 'uat.com/C' },
     )
   }
@@ -51,9 +50,9 @@ RSpec.describe Queries::ReleaseQuery do
   let(:feature_review_for_D) {
     instance_double(
       FeatureReview,
-      url: 'url_of_feature_review_for_D',
+      path: 'url_of_feature_review_for_D',
       versions: [sha_for_D],
-      base_url: 'base_url_for_D',
+      base_path: '/base_path_for_D',
       query_hash: { 'apps' => { 'app1' => 'D' }, 'uat_url' => 'uat.com/D' },
     )
   }
@@ -61,9 +60,9 @@ RSpec.describe Queries::ReleaseQuery do
   let(:feature_review_for_E) {
     instance_double(
       FeatureReview,
-      url: 'url_of_feature_review_for_E',
+      path: 'url_of_feature_review_for_E',
       versions: [sha_for_E],
-      base_url: 'base_url_for_E',
+      base_path: '/base_path_for_E',
       query_hash: { 'apps' => { 'app1' => 'E' }, 'uat_url' => 'uat.com/E' },
     )
   }
@@ -71,9 +70,9 @@ RSpec.describe Queries::ReleaseQuery do
   let(:feature_review_for_F) {
     instance_double(
       FeatureReview,
-      url: 'url_of_feature_review_for_F',
+      path: 'url_of_feature_review_for_F',
       versions: [sha_for_F],
-      base_url: 'base_url_for_F',
+      base_path: '/base_path_for_F',
       query_hash: { 'apps' => { 'app1' => 'F' }, 'uat_url' => 'uat.com/F' },
     )
   }
@@ -81,9 +80,9 @@ RSpec.describe Queries::ReleaseQuery do
   let(:feature_review_for_G) {
     instance_double(
       FeatureReview,
-      url: 'url_of_feature_review_for_G',
+      path: 'url_of_feature_review_for_G',
       versions: [sha_for_G],
-      base_url: 'base_url_for_G',
+      base_path: '/base_path_for_G',
     )
   }
 
@@ -114,9 +113,9 @@ RSpec.describe Queries::ReleaseQuery do
           )
           .and_return([feature_review_for_E, feature_review_for_F, feature_review_for_G])
 
-        expect(query.feature_reviews.map(&:url_with_query_time)).to match_array(%w(
-          base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FE
-          base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FF
+        expect(query.feature_reviews.map(&:path_with_query_time)).to match_array(%w(
+          /base_path_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FE
+          /base_path_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FF
         ))
       end
     end
@@ -132,8 +131,8 @@ RSpec.describe Queries::ReleaseQuery do
           )
           .and_return([feature_review_for_A])
 
-        expect(query.feature_reviews.map(&:url_with_query_time)).to match_array(%w(
-          base_url_for_A?apps%5Bapp1%5D=A&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FA
+        expect(query.feature_reviews.map(&:path_with_query_time)).to match_array(%w(
+          /base_path_for_A?apps%5Bapp1%5D=A&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FA
         ))
       end
     end
@@ -149,8 +148,8 @@ RSpec.describe Queries::ReleaseQuery do
           )
           .and_return([feature_review_for_D])
 
-        expect(query.feature_reviews.map(&:url_with_query_time)).to match_array(%w(
-          base_url_for_D?apps%5Bapp1%5D=D&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FD
+        expect(query.feature_reviews.map(&:path_with_query_time)).to match_array(%w(
+          /base_path_for_D?apps%5Bapp1%5D=D&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FD
         ))
       end
     end
@@ -166,10 +165,10 @@ RSpec.describe Queries::ReleaseQuery do
           )
           .and_return([feature_review_for_C, feature_review_for_E, feature_review_for_F])
 
-        expect(query.feature_reviews.map(&:url_with_query_time)).to match_array(%w(
-          base_url_for_C?apps%5Bapp1%5D=C&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FC
-          base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FE
-          base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FF
+        expect(query.feature_reviews.map(&:path_with_query_time)).to match_array(%w(
+          /base_path_for_C?apps%5Bapp1%5D=C&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FC
+          /base_path_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FE
+          /base_path_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FF
         ))
       end
     end

--- a/spec/models/queries/release_query_spec.rb
+++ b/spec/models/queries/release_query_spec.rb
@@ -4,7 +4,7 @@ require 'support/git_test_repository'
 require 'support/repository_builder'
 
 RSpec.describe Queries::ReleaseQuery do
-  let(:query_time) { Time.new(2014, 8, 10, 14, 40, 48) }
+  let(:query_time) { Time.parse('2014-08-10 14:40:48 UTC') }
   let(:time_now) { Time.now }
 
   let(:git_diagram) {
@@ -128,8 +128,8 @@ RSpec.describe Queries::ReleaseQuery do
           .and_return([feature_review_for_E, feature_review_for_F, feature_review_for_G])
 
         expect(query.feature_reviews.map(&:url)).to match_array(%w(
-          base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FE
-          base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FF
+          base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FE
+          base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FF
         ))
       end
     end
@@ -146,7 +146,7 @@ RSpec.describe Queries::ReleaseQuery do
           .and_return([feature_review_for_A])
 
         expect(query.feature_reviews.map(&:url)).to match_array(%w(
-          base_url_for_A?apps%5Bapp1%5D=A&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FA
+          base_url_for_A?apps%5Bapp1%5D=A&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FA
         ))
       end
     end
@@ -163,7 +163,7 @@ RSpec.describe Queries::ReleaseQuery do
           .and_return([feature_review_for_D])
 
         expect(query.feature_reviews.map(&:url)).to match_array(%w(
-          base_url_for_D?apps%5Bapp1%5D=D&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FD
+          base_url_for_D?apps%5Bapp1%5D=D&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FD
         ))
       end
     end
@@ -180,9 +180,9 @@ RSpec.describe Queries::ReleaseQuery do
           .and_return([feature_review_for_C, feature_review_for_E, feature_review_for_F])
 
         expect(query.feature_reviews.map(&:url)).to match_array(%w(
-          base_url_for_C?apps%5Bapp1%5D=C&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FC
-          base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FE
-          base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FF
+          base_url_for_C?apps%5Bapp1%5D=C&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FC
+          base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FE
+          base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+UTC&uat_url=uat.com%2FF
         ))
       end
     end

--- a/spec/models/queries/release_query_spec.rb
+++ b/spec/models/queries/release_query_spec.rb
@@ -27,9 +27,6 @@ RSpec.describe Queries::ReleaseQuery do
   let(:sha_for_F) { version_for('F') }
   let(:sha_for_G) { version_for('G') }
   let(:base_url) { 'base_url_for_A' }
-  let(:query_hash) {
-    { 'apps' => { 'app1' => 'A' }, 'uat_url' => 'uat.com/A' }
-  }
 
   let(:feature_review_for_A) {
     instance_double(
@@ -38,16 +35,6 @@ RSpec.describe Queries::ReleaseQuery do
       versions: [sha_for_A],
       base_url: 'base_url_for_A',
       query_hash: { 'apps' => { 'app1' => 'A' }, 'uat_url' => 'uat.com/A' },
-    )
-  }
-
-  let(:feature_review_for_B) {
-    instance_double(
-      FeatureReview,
-      url: 'url_of_feature_review_for_B',
-      versions: [sha_for_B],
-      base_url: 'base_url_for_B',
-      query_hash: { 'apps' => { 'app1' => 'B' }, 'uat_url' => 'uat.com/B' },
     )
   }
 

--- a/spec/models/queries/release_query_spec.rb
+++ b/spec/models/queries/release_query_spec.rb
@@ -4,7 +4,7 @@ require 'support/git_test_repository'
 require 'support/repository_builder'
 
 RSpec.describe Queries::ReleaseQuery do
-  let(:query_time) { 2.days.ago }
+  let(:query_time) { Time.new(2014, 8, 10, 14, 40, 48) }
   let(:time_now) { Time.now }
 
   let(:git_diagram) {
@@ -26,54 +26,78 @@ RSpec.describe Queries::ReleaseQuery do
   let(:sha_for_E) { version_for('E') }
   let(:sha_for_F) { version_for('F') }
   let(:sha_for_G) { version_for('G') }
+  let(:base_url) { 'base_url_for_A' }
+  let(:query_hash) {
+    { 'apps' => { 'app1' => 'A' }, 'uat_url' => 'uat.com/A' }
+  }
 
   let(:feature_review_for_A) {
     instance_double(
       FeatureReview,
       url: 'url_of_feature_review_for_A',
-      versions: [sha_for_A])
+      versions: [sha_for_A],
+      base_url: 'base_url_for_A',
+      query_hash: { 'apps' => { 'app1' => 'A' }, 'uat_url' => 'uat.com/A' },
+    )
   }
 
   let(:feature_review_for_B) {
     instance_double(
       FeatureReview,
       url: 'url_of_feature_review_for_B',
-      versions: [sha_for_B])
+      versions: [sha_for_B],
+      base_url: 'base_url_for_B',
+      query_hash: { 'apps' => { 'app1' => 'B' }, 'uat_url' => 'uat.com/B' },
+    )
   }
 
   let(:feature_review_for_C) {
     instance_double(
       FeatureReview,
       url: 'url_of_feature_review_for_C',
-      versions: [sha_for_C])
+      versions: [sha_for_C],
+      base_url: 'base_url_for_C',
+      query_hash: { 'apps' => { 'app1' => 'C' }, 'uat_url' => 'uat.com/C' },
+    )
   }
 
   let(:feature_review_for_D) {
     instance_double(
       FeatureReview,
       url: 'url_of_feature_review_for_D',
-      versions: [sha_for_D])
+      versions: [sha_for_D],
+      base_url: 'base_url_for_D',
+      query_hash: { 'apps' => { 'app1' => 'D' }, 'uat_url' => 'uat.com/D' },
+    )
   }
 
   let(:feature_review_for_E) {
     instance_double(
       FeatureReview,
       url: 'url_of_feature_review_for_E',
-      versions: [sha_for_E])
+      versions: [sha_for_E],
+      base_url: 'base_url_for_E',
+      query_hash: { 'apps' => { 'app1' => 'E' }, 'uat_url' => 'uat.com/E' },
+    )
   }
 
   let(:feature_review_for_F) {
     instance_double(
       FeatureReview,
       url: 'url_of_feature_review_for_F',
-      versions: [sha_for_F])
+      versions: [sha_for_F],
+      base_url: 'base_url_for_F',
+      query_hash: { 'apps' => { 'app1' => 'F' }, 'uat_url' => 'uat.com/F' },
+    )
   }
 
   let(:feature_review_for_G) {
     instance_double(
       FeatureReview,
       url: 'url_of_feature_review_for_G',
-      versions: [sha_for_G])
+      versions: [sha_for_G],
+      base_url: 'base_url_for_G',
+    )
   }
 
   subject(:query) {
@@ -104,8 +128,8 @@ RSpec.describe Queries::ReleaseQuery do
           .and_return([feature_review_for_E, feature_review_for_F, feature_review_for_G])
 
         expect(query.feature_reviews.map(&:url)).to match_array(%w(
-          url_of_feature_review_for_E
-          url_of_feature_review_for_F
+          base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FE
+          base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FF
         ))
       end
     end
@@ -122,7 +146,7 @@ RSpec.describe Queries::ReleaseQuery do
           .and_return([feature_review_for_A])
 
         expect(query.feature_reviews.map(&:url)).to match_array(%w(
-          url_of_feature_review_for_A
+          base_url_for_A?apps%5Bapp1%5D=A&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FA
         ))
       end
     end
@@ -139,7 +163,7 @@ RSpec.describe Queries::ReleaseQuery do
           .and_return([feature_review_for_D])
 
         expect(query.feature_reviews.map(&:url)).to match_array(%w(
-          url_of_feature_review_for_D
+          base_url_for_D?apps%5Bapp1%5D=D&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FD
         ))
       end
     end
@@ -156,9 +180,9 @@ RSpec.describe Queries::ReleaseQuery do
           .and_return([feature_review_for_C, feature_review_for_E, feature_review_for_F])
 
         expect(query.feature_reviews.map(&:url)).to match_array(%w(
-          url_of_feature_review_for_C
-          url_of_feature_review_for_E
-          url_of_feature_review_for_F
+          base_url_for_C?apps%5Bapp1%5D=C&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FC
+          base_url_for_E?apps%5Bapp1%5D=E&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FE
+          base_url_for_F?apps%5Bapp1%5D=F&time=2014-08-10+14%3A40%3A48+%2B0100&uat_url=uat.com%2FF
         ))
       end
     end

--- a/spec/models/repositories/feature_review_repository_spec.rb
+++ b/spec/models/repositories/feature_review_repository_spec.rb
@@ -68,17 +68,17 @@ RSpec.describe Repositories::FeatureReviewRepository do
 
       [
         build(:jira_event,
-          comment_body: "Review: #{feature_review_path(frontend: 'abc', backend: 'NON1')}",
+          comment_body: "Review: #{feature_review_url(frontend: 'abc', backend: 'NON1')}",
           created_at: timestamp),
         build(:jira_event,
-          comment_body: "Review: #{feature_review_path(frontend: 'NON2', backend: 'def')}",
+          comment_body: "Review: #{feature_review_url(frontend: 'NON2', backend: 'def')}",
           created_at: timestamp),
         build(:jira_event,
-          comment_body: "Review: #{feature_review_path(frontend: 'NON2', backend: 'NON3')}",
+          comment_body: "Review: #{feature_review_url(frontend: 'NON2', backend: 'NON3')}",
           created_at: timestamp),
         build(:jira_event,
-          comment_body: "Review: #{feature_review_path(frontend: 'ghi', backend: 'NON3')} "\
-                        "and: #{feature_review_path(frontend: 'NON4', backend: 'NON5')}",
+          comment_body: "Review: #{feature_review_url(frontend: 'ghi', backend: 'NON3')} "\
+                        "and: #{feature_review_url(frontend: 'NON4', backend: 'NON5')}",
           created_at: timestamp),
       ].each do |event|
         repository.apply(event)
@@ -100,7 +100,7 @@ RSpec.describe Repositories::FeatureReviewRepository do
           )
 
           repository.apply(build(:jira_event, :approved,
-            comment_body: "Review: #{feature_review_path(frontend: 'abc')}",
+            comment_body: "Review: #{feature_review_url(frontend: 'abc')}",
             created_at: timestamp))
         end
       end
@@ -119,7 +119,7 @@ RSpec.describe Repositories::FeatureReviewRepository do
           )
 
           repository.apply(build(:jira_event, :approved,
-            comment_body: "Review: #{feature_review_path(frontend: 'abc')}",
+            comment_body: "Review: #{feature_review_url(frontend: 'abc')}",
             created_at: timestamp))
         end
       end
@@ -139,7 +139,7 @@ RSpec.describe Repositories::FeatureReviewRepository do
           )
 
           repository.apply(build(:jira_event, :approved,
-            comment_body: "Review: #{feature_review_path(frontend: 'abc')}",
+            comment_body: "Review: #{feature_review_url(frontend: 'abc')}",
             created_at: timestamp))
         end
       end
@@ -159,7 +159,7 @@ RSpec.describe Repositories::FeatureReviewRepository do
         )
 
         repository.apply(build(:jira_event, :rejected,
-          comment_body: "Review: #{feature_review_path(frontend: 'abc')}",
+          comment_body: "Review: #{feature_review_url(frontend: 'abc')}",
           created_at: timestamp))
       end
     end

--- a/spec/models/repositories/feature_review_repository_spec.rb
+++ b/spec/models/repositories/feature_review_repository_spec.rb
@@ -72,27 +72,32 @@ RSpec.describe Repositories::FeatureReviewRepository do
     let(:attrs_a) {
       { url: feature_review_url(frontend: 'abc', backend: 'NON1'),
         versions: %w(NON1 abc),
-        event_created_at: 1.day.ago }
+        event_created_at: 1.day.ago,
+        approved_at: nil }
     }
     let(:attrs_b) {
       { url: feature_review_url(frontend: 'NON2', backend: 'def'),
         versions: %w(def NON2),
-        event_created_at: 3.days.ago }
+        event_created_at: 3.days.ago,
+        approved_at: nil  }
     }
     let(:attrs_c) {
       { url: feature_review_url(frontend: 'NON2', backend: 'NON3'),
         versions: %w(NON3 NON2),
-        event_created_at: 5.days.ago }
+        event_created_at: 5.days.ago,
+        approved_at: nil  }
     }
     let(:attrs_d) {
       { url: feature_review_url(frontend: 'ghi', backend: 'NON3'),
         versions: %w(NON3 ghi),
-        event_created_at: 7.days.ago }
+        event_created_at: 7.days.ago,
+        approved_at: nil  }
     }
     let(:attrs_e) {
       { url: feature_review_url(frontend: 'NON4', backend: 'NON5'),
         versions: %w(NON5 NON4),
-        event_created_at: 9.days.ago }
+        event_created_at: 9.days.ago,
+        approved_at: nil  }
     }
 
     before :each do

--- a/spec/models/repositories/feature_review_repository_spec.rb
+++ b/spec/models/repositories/feature_review_repository_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Repositories::FeatureReviewRepository do
 
     let(:last_snapshot) {
       Snapshots::FeatureReview.create!(
-        url: feature_review_url(frontend: 'abc'),
+        path: feature_review_path(frontend: 'abc'),
         versions: %w(abc),
         event_created_at: timestamp - 2.days,
         approved_at: Time.parse('2014-09-19 00:00:00 UTC'),
@@ -34,33 +34,33 @@ RSpec.describe Repositories::FeatureReviewRepository do
 
     subject(:repository) { Repositories::FeatureReviewRepository.new(active_record_class) }
 
-    it 'creates a snapshot for each feature review url in the event comment' do
+    it 'creates a snapshot for each feature review path in the event comment' do
       expect(active_record_class).to receive(:create!).with(
-        url: feature_review_url(frontend: 'abc', backend: 'NON1'),
+        path: feature_review_path(frontend: 'abc', backend: 'NON1'),
         versions: %w(NON1 abc),
         event_created_at: timestamp,
         approved_at: nil,
       )
       expect(active_record_class).to receive(:create!).with(
-        url: feature_review_url(frontend: 'NON2', backend: 'def'),
+        path: feature_review_path(frontend: 'NON2', backend: 'def'),
         versions: %w(def NON2),
         event_created_at: timestamp,
         approved_at: nil,
       )
       expect(active_record_class).to receive(:create!).with(
-        url: feature_review_url(frontend: 'NON2', backend: 'NON3'),
+        path: feature_review_path(frontend: 'NON2', backend: 'NON3'),
         versions: %w(NON3 NON2),
         event_created_at: timestamp,
         approved_at: nil,
       )
       expect(active_record_class).to receive(:create!).with(
-        url: feature_review_url(frontend: 'ghi', backend: 'NON3'),
+        path: feature_review_path(frontend: 'ghi', backend: 'NON3'),
         versions: %w(NON3 ghi),
         event_created_at: timestamp,
         approved_at: nil,
       )
       expect(active_record_class).to receive(:create!).with(
-        url: feature_review_url(frontend: 'NON4', backend: 'NON5'),
+        path: feature_review_path(frontend: 'NON4', backend: 'NON5'),
         versions: %w(NON5 NON4),
         event_created_at: timestamp,
         approved_at: nil,
@@ -68,17 +68,17 @@ RSpec.describe Repositories::FeatureReviewRepository do
 
       [
         build(:jira_event,
-          comment_body: "Review: #{feature_review_url(frontend: 'abc', backend: 'NON1')}",
+          comment_body: "Review: #{feature_review_path(frontend: 'abc', backend: 'NON1')}",
           created_at: timestamp),
         build(:jira_event,
-          comment_body: "Review: #{feature_review_url(frontend: 'NON2', backend: 'def')}",
+          comment_body: "Review: #{feature_review_path(frontend: 'NON2', backend: 'def')}",
           created_at: timestamp),
         build(:jira_event,
-          comment_body: "Review: #{feature_review_url(frontend: 'NON2', backend: 'NON3')}",
+          comment_body: "Review: #{feature_review_path(frontend: 'NON2', backend: 'NON3')}",
           created_at: timestamp),
         build(:jira_event,
-          comment_body: "Review: #{feature_review_url(frontend: 'ghi', backend: 'NON3')} "\
-                        "and: #{feature_review_url(frontend: 'NON4', backend: 'NON5')}",
+          comment_body: "Review: #{feature_review_path(frontend: 'ghi', backend: 'NON3')} "\
+                        "and: #{feature_review_path(frontend: 'NON4', backend: 'NON5')}",
           created_at: timestamp),
       ].each do |event|
         repository.apply(event)
@@ -93,14 +93,14 @@ RSpec.describe Repositories::FeatureReviewRepository do
       context 'when the approved_at time is set on the last snapshot,' do
         it 'reuses the approved_at time from the last snapshot' do
           expect(active_record_class).to receive(:create!).with(
-            url: feature_review_url(frontend: 'abc'),
+            path: feature_review_path(frontend: 'abc'),
             versions: %w(abc),
             event_created_at: timestamp,
             approved_at: last_snapshot.approved_at,
           )
 
           repository.apply(build(:jira_event, :approved,
-            comment_body: "Review: #{feature_review_url(frontend: 'abc')}",
+            comment_body: "Review: #{feature_review_path(frontend: 'abc')}",
             created_at: timestamp))
         end
       end
@@ -112,14 +112,14 @@ RSpec.describe Repositories::FeatureReviewRepository do
 
         it 'sets the approved_at time to the event_created_at time' do
           expect(active_record_class).to receive(:create!).with(
-            url: feature_review_url(frontend: 'abc'),
+            path: feature_review_path(frontend: 'abc'),
             versions: %w(abc),
             event_created_at: timestamp,
             approved_at: timestamp,
           )
 
           repository.apply(build(:jira_event, :approved,
-            comment_body: "Review: #{feature_review_url(frontend: 'abc')}",
+            comment_body: "Review: #{feature_review_path(frontend: 'abc')}",
             created_at: timestamp))
         end
       end
@@ -132,14 +132,14 @@ RSpec.describe Repositories::FeatureReviewRepository do
 
         it 'sets the approved_at time to the event_created_at time' do
           expect(active_record_class).to receive(:create!).with(
-            url: feature_review_url(frontend: 'abc'),
+            path: feature_review_path(frontend: 'abc'),
             versions: %w(abc),
             event_created_at: timestamp,
             approved_at: timestamp,
           )
 
           repository.apply(build(:jira_event, :approved,
-            comment_body: "Review: #{feature_review_url(frontend: 'abc')}",
+            comment_body: "Review: #{feature_review_path(frontend: 'abc')}",
             created_at: timestamp))
         end
       end
@@ -152,14 +152,14 @@ RSpec.describe Repositories::FeatureReviewRepository do
 
       it 'nullifies the approved_at' do
         expect(active_record_class).to receive(:create!).with(
-          url: feature_review_url(frontend: 'abc'),
+          path: feature_review_path(frontend: 'abc'),
           versions: %w(abc),
           event_created_at: timestamp,
           approved_at: nil,
         )
 
         repository.apply(build(:jira_event, :rejected,
-          comment_body: "Review: #{feature_review_url(frontend: 'abc')}",
+          comment_body: "Review: #{feature_review_path(frontend: 'abc')}",
           created_at: timestamp))
       end
     end
@@ -167,31 +167,31 @@ RSpec.describe Repositories::FeatureReviewRepository do
 
   describe '#feature_reviews_for' do
     let(:attrs_a) {
-      { url: feature_review_url(frontend: 'abc', backend: 'NON1'),
+      { path: feature_review_path(frontend: 'abc', backend: 'NON1'),
         versions: %w(NON1 abc),
         event_created_at: 1.day.ago,
         approved_at: nil }
     }
     let(:attrs_b) {
-      { url: feature_review_url(frontend: 'NON2', backend: 'def'),
+      { path: feature_review_path(frontend: 'NON2', backend: 'def'),
         versions: %w(def NON2),
         event_created_at: 3.days.ago,
         approved_at: nil  }
     }
     let(:attrs_c) {
-      { url: feature_review_url(frontend: 'NON2', backend: 'NON3'),
+      { path: feature_review_path(frontend: 'NON2', backend: 'NON3'),
         versions: %w(NON3 NON2),
         event_created_at: 5.days.ago,
         approved_at: nil  }
     }
     let(:attrs_d) {
-      { url: feature_review_url(frontend: 'ghi', backend: 'NON3'),
+      { path: feature_review_path(frontend: 'ghi', backend: 'NON3'),
         versions: %w(NON3 ghi),
         event_created_at: 7.days.ago,
         approved_at: nil  }
     }
     let(:attrs_e) {
-      { url: feature_review_url(frontend: 'NON4', backend: 'NON5'),
+      { path: feature_review_path(frontend: 'NON4', backend: 'NON5'),
         versions: %w(NON5 NON4),
         event_created_at: 9.days.ago,
         approved_at: nil  }

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -14,15 +14,16 @@ RSpec.describe Repositories::TicketRepository do
   end
 
   describe '#tickets_for' do
-    let(:url) { 'http://foo.com/feature_reviews' }
+    let(:url) { feature_review_url(app: 'foo') }
+    let(:path) { feature_review_path(app: 'foo') }
 
     it 'projects latest associated tickets' do
       repository.apply(build(:jira_event, :created, key: 'JIRA-1', comment_body: url))
-      results = repository.tickets_for(feature_review_path: url)
+      results = repository.tickets_for(feature_review_path: path)
       expect(results).to eq([Ticket.new(key: 'JIRA-1', status: 'To Do', summary: '')])
 
       repository.apply(build(:jira_event, :started, key: 'JIRA-1'))
-      results = repository.tickets_for(feature_review_path: url)
+      results = repository.tickets_for(feature_review_path: path)
       expect(results).to eq([Ticket.new(key: 'JIRA-1', status: 'In Progress', summary: '')])
     end
 
@@ -36,7 +37,12 @@ RSpec.describe Repositories::TicketRepository do
         build(:jira_event, :development_completed, jira_1.merge(comment_body: "Review #{url}")),
 
         build(:jira_event, :created, key: 'JIRA-2'),
-        build(:jira_event, :created, key: 'JIRA-3', comment_body: "Review #{url}/extra/stuff"),
+        build(
+          :jira_event,
+          :created,
+          key: 'JIRA-3',
+          comment_body: 'Review http://example.com/feature_reviews/extra/stuff',
+        ),
 
         build(:jira_event, :created, jira_4),
         build(:jira_event, :started, jira_4),
@@ -47,7 +53,7 @@ RSpec.describe Repositories::TicketRepository do
         repository.apply(event)
       end
 
-      expect(repository.tickets_for(feature_review_path: url)).to match_array([
+      expect(repository.tickets_for(feature_review_path: path)).to match_array([
         Ticket.new(key: 'JIRA-1', summary: 'Ticket 1', status: 'Done'),
         Ticket.new(key: 'JIRA-4', summary: 'Ticket 4', status: 'Ready For Review'),
       ])
@@ -58,6 +64,8 @@ RSpec.describe Repositories::TicketRepository do
     end
 
     context 'when multiple feature reviews are referenced in the same JIRA ticket' do
+      let(:url1) { feature_review_url(app1: 'one') }
+      let(:url2) { feature_review_url(app2: 'two') }
       let(:path1) { feature_review_path(app1: 'one') }
       let(:path2) { feature_review_path(app2: 'two') }
 
@@ -66,8 +74,8 @@ RSpec.describe Repositories::TicketRepository do
 
       it 'projects the ticket referenced in the JIRA comments for each repository' do
         [
-          build(:jira_event, key: 'JIRA-1', comment_body: "Review #{path1}"),
-          build(:jira_event, key: 'JIRA-1', comment_body: "Review again #{path2}"),
+          build(:jira_event, key: 'JIRA-1', comment_body: "Review #{url1}"),
+          build(:jira_event, key: 'JIRA-1', comment_body: "Review again #{url2}"),
         ].each do |event|
           repository1.apply(event)
           repository2.apply(event)
@@ -96,7 +104,7 @@ RSpec.describe Repositories::TicketRepository do
           repository.apply(event)
         end
 
-        expect(repository.tickets_for(feature_review_path: url, at: t[2])).to match_array([
+        expect(repository.tickets_for(feature_review_path: path, at: t[2])).to match_array([
           Ticket.new(key: 'J-1', summary: 'Job', status: 'Ready for Deployment'),
         ])
       end

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Repositories::TicketRepository do
 
     it 'projects latest associated tickets' do
       repository.apply(build(:jira_event, :created, key: 'JIRA-1', comment_body: url))
-      results = repository.tickets_for(feature_review_url: url)
+      results = repository.tickets_for(feature_review_path: url)
       expect(results).to eq([Ticket.new(key: 'JIRA-1', status: 'To Do', summary: '')])
 
       repository.apply(build(:jira_event, :started, key: 'JIRA-1'))
-      results = repository.tickets_for(feature_review_url: url)
+      results = repository.tickets_for(feature_review_path: url)
       expect(results).to eq([Ticket.new(key: 'JIRA-1', status: 'In Progress', summary: '')])
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Repositories::TicketRepository do
         repository.apply(event)
       end
 
-      expect(repository.tickets_for(feature_review_url: url)).to match_array([
+      expect(repository.tickets_for(feature_review_path: url)).to match_array([
         Ticket.new(key: 'JIRA-1', summary: 'Ticket 1', status: 'Done'),
         Ticket.new(key: 'JIRA-4', summary: 'Ticket 4', status: 'Ready For Review'),
       ])
@@ -58,27 +58,27 @@ RSpec.describe Repositories::TicketRepository do
     end
 
     context 'when multiple feature reviews are referenced in the same JIRA ticket' do
-      let(:url1) { feature_review_url(app1: 'one') }
-      let(:url2) { feature_review_url(app2: 'two') }
+      let(:path1) { feature_review_path(app1: 'one') }
+      let(:path2) { feature_review_path(app2: 'two') }
 
       subject(:repository1) { Repositories::TicketRepository.new }
       subject(:repository2) { Repositories::TicketRepository.new }
 
       it 'projects the ticket referenced in the JIRA comments for each repository' do
         [
-          build(:jira_event, key: 'JIRA-1', comment_body: "Review #{url1}"),
-          build(:jira_event, key: 'JIRA-1', comment_body: "Review again #{url2}"),
+          build(:jira_event, key: 'JIRA-1', comment_body: "Review #{path1}"),
+          build(:jira_event, key: 'JIRA-1', comment_body: "Review again #{path2}"),
         ].each do |event|
           repository1.apply(event)
           repository2.apply(event)
         end
 
         expect(
-          repository1.tickets_for(feature_review_url: url1),
+          repository1.tickets_for(feature_review_path: path1),
         ).to eq([Ticket.new(key: 'JIRA-1')])
 
         expect(
-          repository2.tickets_for(feature_review_url: url2),
+          repository2.tickets_for(feature_review_path: path2),
         ).to eq([Ticket.new(key: 'JIRA-1')])
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe Repositories::TicketRepository do
           repository.apply(event)
         end
 
-        expect(repository.tickets_for(feature_review_url: url, at: t[2])).to match_array([
+        expect(repository.tickets_for(feature_review_path: url, at: t[2])).to match_array([
           Ticket.new(key: 'J-1', summary: 'Job', status: 'Ready for Deployment'),
         ])
       end

--- a/spec/performance/projections_spec.rb
+++ b/spec/performance/projections_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Projection performance', type: :request do
   describe 'Feature Review' do
     let(:apps) { { 'frontend' => 'abc', 'backend' => 'def' } }
     let(:server) { 'uat.fc.com' }
-    let(:url) { feature_review_url(apps, server) }
+    let(:url) { feature_review_path(apps, server) }
     let(:path) { URI.parse(url).request_uri }
 
     it 'measures the request time' do
@@ -39,7 +39,7 @@ RSpec.describe 'Projection performance', type: :request do
   describe 'Feature Review Search' do
     let(:apps) { { 'frontend' => version, 'backend' => 'def' } }
     let(:server) { 'uat.fc.com' }
-    let(:url) { feature_review_url(apps, server) }
+    let(:url) { feature_review_path(apps, server) }
 
     let(:repo_name) { 'frontend' }
     let(:test_git_repo) { Support::GitTestRepository.new }
@@ -71,7 +71,7 @@ RSpec.describe 'Projection performance', type: :request do
   describe 'Releases' do
     let(:apps) { { 'frontend' => version, 'backend' => 'def' } }
     let(:server) { 'uat.fc.com' }
-    let(:url) { feature_review_url(apps, server) }
+    let(:url) { feature_review_path(apps, server) }
 
     let(:repo_name) { 'frontend' }
     let(:test_git_repo) { Support::GitTestRepository.new }

--- a/spec/support/feature_review_helpers.rb
+++ b/spec/support/feature_review_helpers.rb
@@ -4,12 +4,12 @@ require 'factories/feature_review_factory'
 
 module Support
   module FeatureReviewHelpers
-    def feature_review_url(*args)
+    def feature_review_path(*args)
       UrlBuilder.build(*args)
     end
 
     def new_feature_review(*args)
-      new_feature_review_from_url(feature_review_url(*args))
+      new_feature_review_from_url(feature_review_path(*args))
     end
 
     def new_feature_review_from_url(url)

--- a/spec/support/feature_review_helpers.rb
+++ b/spec/support/feature_review_helpers.rb
@@ -4,12 +4,16 @@ require 'factories/feature_review_factory'
 
 module Support
   module FeatureReviewHelpers
+    def feature_review_url(*args)
+      UrlBuilder.build(*args).to_s
+    end
+
     def feature_review_path(*args)
-      UrlBuilder.build(*args)
+      UrlBuilder.build(*args).request_uri
     end
 
     def new_feature_review(*args)
-      new_feature_review_from_url(feature_review_path(*args))
+      new_feature_review_from_url(feature_review_url(*args))
     end
 
     def new_feature_review_from_url(url)
@@ -29,7 +33,7 @@ module Support
         hash = { apps: apps_hash }
         hash['uat_url'] = uat_url if uat_url
         hash['time'] = time if time
-        host.merge("/feature_reviews?#{hash.to_query}").to_s
+        host.merge("/feature_reviews?#{hash.to_query}")
       end
 
       private

--- a/spec/support/git_test_repository.rb
+++ b/spec/support/git_test_repository.rb
@@ -68,10 +68,6 @@ module Support
       commits[pretend_version]
     end
 
-    def commit?(version)
-      repo.exists?(version)
-    end
-
     def head_oid
       repo.head.target_id
     end

--- a/spec/support/repository_builder.rb
+++ b/spec/support/repository_builder.rb
@@ -205,6 +205,7 @@ Support::RepositoryBuilder.add_example(
   end,
 )
 
+# :nocov:
 Support::RepositoryBuilder.add_example(
   <<-'EOS'.strip_heredoc,
            o-o-o-o-o-A-B
@@ -225,6 +226,7 @@ Support::RepositoryBuilder.add_example(
     repo.merge_branch(branch_name: branch_name, pretend_version: 'C')
   end,
 )
+# :nocov:
 
 Support::RepositoryBuilder.add_example(
   '-o-A-B-C',


### PR DESCRIPTION
https://jira.fundingcircle.com/browse/ENG-220

The ticket originally asked for changing the Releases page to
- have approved releases link to the feature review at approval time
- have unapproved releases link to the feature review at merge time
- show the time when the release was committed to master

But after our sprint planning we decided to have the current Releases page focus on the developer persona (with another page being for the auditor/assistant persona). With this the story changed to
- show current status of a release
- have approved releases link to the feature review at approval time
- have unapproved releases link to the feature review at current time (no time specified)
