### PR TITLE
Made feature status clear on the feature reviews page

### DIFF
--- a/app/helpers/feature_reviews_helper.rb
+++ b/app/helpers/feature_reviews_helper.rb
@@ -52,9 +52,9 @@ module FeatureReviewsHelper
 
   def item_class(status)
     case status
-    when true, :success
+    when true, :success, :approved
       'success'
-    when false, :failure
+    when false, :failure, :unapproved
       'danger'
     else
       'warning'

--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -3,6 +3,21 @@
   .lead.time= "Projecting events up to #{@feature_review_with_statuses.time}"
 
 .row
+  .col-lg-12
+    - panel(heading: "Feature Status: #{@feature_review_with_statuses.approved? ? 'APPROVED' : 'NOT APPROVED'}", status: @feature_review_with_statuses.approval_status, klass: 'feature-status') do
+      - if @feature_review_with_statuses.tickets.empty?
+        .panel-body No tickets found
+      - else
+        - table(headers: %w(Ticket Summary Status)) do
+          - @feature_review_with_statuses.tickets.each do |ticket|
+            %tr.ticket
+              %td= ticket.key
+              %td= ticket.summary
+              %td
+                - icon(item_status_icon_class(ticket.approved?))
+                = ticket.status
+
+.row
   .col-lg-6
     - panel(heading: 'Summary', status: @feature_review_with_statuses.summary_status, klass: 'summary') do
       %ul.list-group
@@ -36,19 +51,6 @@
             %strong.uat-url= to_link(@feature_review_with_statuses.uat_url, target: '_blank')
           - else
             No UAT specified
-
-.row
-  .col-lg-12
-    - panel(heading: 'Associated Tickets', klass: 'tickets') do
-      - if @feature_review_with_statuses.tickets.empty?
-        .panel-body No tickets found
-      - else
-        - table(headers: %w(Key Summary Status)) do
-          - @feature_review_with_statuses.tickets.each do |ticket|
-            %tr.ticket
-              %td= ticket.key
-              %td= ticket.summary
-              %td= ticket.status
 
 .row
   .col-lg-6

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -86,7 +86,7 @@ Scenario: Viewing a feature review
     | warning | User Acceptance Tests |
 
   And I should only see the ticket
-    | Key      | Summary       | Status      |
+    | Ticket   | Summary       | Status      |
     | JIRA-123 | Urgent ticket | In Progress |
 
   And I should see the builds with heading "warning" and content

--- a/features/support/pages/feature_review_page.rb
+++ b/features/support/pages/feature_review_page.rb
@@ -69,7 +69,7 @@ module Pages
 
     def tickets
       verify!
-      Sections::TableSection.new(page.find('.tickets table')).items
+      Sections::TableSection.new(page.find('.feature-status table')).items
     end
 
     def uatest_panel

--- a/features/support/sections/table_section.rb
+++ b/features/support/sections/table_section.rb
@@ -30,12 +30,15 @@ module Sections
     end
 
     def cell_text(cell_element)
-      icon_element = cell_element.first('.glyphicon')
-      if icon_element
-        icon_translation_for(icon_element)
-      else
-        cell_element.text
+      if use_icon_translations?
+        icon_element = cell_element.first('.glyphicon')
+        return icon_translation_for(icon_element) if icon_element
       end
+      cell_element.text
+    end
+
+    def use_icon_translations?
+      !icon_translations.empty?
     end
 
     def icon_translation_for(icon_element)


### PR DESCRIPTION
JIRA: https://jira.fundingcircle.com/browse/ENG-225

Here's what I did:

1. Pulled jira tickets up to the top
2. Made the top panel show green if FR is approved

After this change, approved feature reviews look like this:

![screen shot 2015-09-17 at 15 26 01](https://cloud.githubusercontent.com/assets/111963/9935782/8eb36c8a-5d50-11e5-8181-6703529997fd.png)

Unapproved reviews look like this:

![screen shot 2015-09-17 at 15 26 03](https://cloud.githubusercontent.com/assets/111963/9935784/986e1c66-5d50-11e5-9940-c6d4761dbccc.png)
