### PR TITLE
only post Github status updates if repository is under audit

### DIFF
--- a/app/controllers/github_notifications_controller.rb
+++ b/app/controllers/github_notifications_controller.rb
@@ -47,7 +47,12 @@ class GithubNotificationsController < ApplicationController
   end
 
   def relevant_pull_request?
-    payload.action == 'opened' || payload.action == 'synchronize'
+    (payload.action == 'opened' || payload.action == 'synchronize') && audited_repo?
+  end
+
+  def audited_repo?
+    inferred_repo_name = payload.base_repo_url.split('/').last
+    GitRepositoryLocation.uris.any? { |uri| uri.include?(inferred_repo_name) }
   end
 
   def payload

--- a/app/models/git_repository_location.rb
+++ b/app/models/git_repository_location.rb
@@ -13,6 +13,10 @@ class GitRepositoryLocation < ActiveRecord::Base
     all.order(name: :asc).pluck(:name)
   end
 
+  def self.uris
+    all.pluck(:uri)
+  end
+
   def self.update_from_github_notification(payload)
     ssh_url = payload.fetch('repository', {}).fetch('ssh_url', nil)
     git_repository_location = find_by_github_ssh_url(ssh_url)

--- a/spec/controllers/github_notifications_controller_spec.rb
+++ b/spec/controllers/github_notifications_controller_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 
 RSpec.describe GithubNotificationsController do
   describe 'POST #create', :logged_in do
+    let(:repo_location_uri) { 'ssh://git@github.com/FundingCircle/hello_world_rails.git' }
+
     context 'when event is a pull request' do
       before do
         request.env['HTTP_X_GITHUB_EVENT'] = 'pull_request'
+        GitRepositoryLocation.create(uri: repo_location_uri)
       end
 
       context 'when the pull request is newly opened' do
@@ -57,6 +60,19 @@ RSpec.describe GithubNotificationsController do
         let(:sha) { '12345' }
         let(:repo_url) { 'https://github.com/FundingCircle/hello_world_rails' }
         let(:payload) { github_pr_payload(action: 'reopened', repo_url: repo_url, sha: sha) }
+
+        it 'does not set the pull request status' do
+          expect(PullRequestStatus).to_not receive(:new)
+
+          post :create, github_notification: payload
+        end
+      end
+
+      context 'when the pull request is not for an audited repo' do
+        let(:repo_location_uri) { 'ssh://git@github.com/FundingCircle/another_repo.git' }
+        let(:sha) { '12345' }
+        let(:repo_url) { 'https://github.com/FundingCircle/hello_world_rails' }
+        let(:payload) { github_pr_payload(action: 'opened', repo_url: repo_url, sha: sha) }
 
         it 'does not set the pull request status' do
           expect(PullRequestStatus).to_not receive(:new)

--- a/spec/models/git_repository_location_spec.rb
+++ b/spec/models/git_repository_location_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe GitRepositoryLocation do
     end
   end
 
+  describe '.uris' do
+    let(:uris) { %w(ssh://git@github.com/some/some-repo.git ssh://git@github.com/some/some-repo.git) }
+    it 'returns an array of uris' do
+      uris.each do |uri|
+        GitRepositoryLocation.create(uri: uri)
+      end
+
+      expect(GitRepositoryLocation.uris).to match_array(uris)
+    end
+  end
+
   describe '.from_github_notification' do
     let(:github_payload) {
       JSON.parse(<<-END)


### PR DESCRIPTION
At current all FundingCircle repositories get status updates on pull requests form Github. With this change we assert that the repo is under audit* before we post a status update. 

\* we assume it's under audit if listed as GitRepositoryLocation
