### PR TITLE
Normalize the Feature Review URL in the Feature Review Factory

### DIFF
--- a/app/models/factories/feature_review_factory.rb
+++ b/app/models/factories/feature_review_factory.rb
@@ -15,8 +15,12 @@ module Factories
         .map { |url| create_from_url_string(url) }
     end
 
+    def create_from_tickets(tickets)
+      map_paths(tickets).map { |path| create_from_url_string(path) }
+    end
+
     def create_from_url_string(url)
-      uri = Addressable::URI.parse(url)
+      uri = Addressable::URI.parse(url).normalize
       query_hash = Rack::Utils.parse_nested_query(uri.query)
       versions = query_hash.fetch('apps', {}).values.reject(&:blank?)
       create(
@@ -25,15 +29,11 @@ module Factories
       )
     end
 
+    private
+
     def create(attrs)
       FeatureReview.new(attrs)
     end
-
-    def create_from_tickets(tickets)
-      map_paths(tickets).map { |path| create_from_url_string(path) }
-    end
-
-    private
 
     def whitelisted_path(uri, query_hash)
       "#{uri.path}?#{query_hash.extract!(*QUERY_PARAM_WHITELIST).to_query}"

--- a/spec/models/factories/feature_review_factory_spec.rb
+++ b/spec/models/factories/feature_review_factory_spec.rb
@@ -146,15 +146,6 @@ RSpec.describe Factories::FeatureReviewFactory do
     end
   end
 
-  describe '#create' do
-    let(:attributes) { { some: 'values' } }
-
-    it 'creates a feature review' do
-      expect(FeatureReview).to receive(:new).with(attributes)
-      factory.create(attributes)
-    end
-  end
-
   private
 
   def full_url(query_values)


### PR DESCRIPTION
As all creations for Feature Reviews should happen through the factory, this ensures that the URL is always properly normalized.

We normalize URLs in case we have the same URL but with different encoding, so they are not treated as two different URLs.