### PR TITLE
update github status copy and status

### DIFF
--- a/app/models/pull_request_status.rb
+++ b/app/models/pull_request_status.rb
@@ -86,28 +86,28 @@ class PullRequestStatus
   def not_reviewed_status
     {
       status: 'failure',
-      description: 'There are no feature reviews for this commit',
+      description: 'No Feature Review found',
     }
   end
 
   def approved_status
     {
       status: 'success',
-      description: 'There are approved feature reviews for this commit',
+      description: 'Approved Feature Review found',
     }
   end
 
   def unapproved_status
     {
-      status: 'failure',
-      description: 'No feature reviews for this commit have been approved',
+      status: 'pending',
+      description: 'Awaiting approval for Feature Review',
     }
   end
 
   def reset_status
     {
       status: 'pending',
-      description: 'Checking for feature reviews',
+      description: 'Searching for Feature Review',
     }
   end
 end

--- a/app/models/pull_request_status.rb
+++ b/app/models/pull_request_status.rb
@@ -41,9 +41,11 @@ class PullRequestStatus
 
   attr_reader :token, :routes, :ticket_repository, :feature_review_factory
 
-  def decorated_feature_reviews(commit)
-    tickets = ticket_repository.tickets_for_versions([commit])
-    feature_reviews = feature_review_factory.create_from_tickets(tickets)
+  def decorated_feature_reviews(sha)
+    tickets = ticket_repository.tickets_for_versions([sha])
+    feature_reviews = feature_review_factory
+                      .create_from_tickets(tickets)
+                      .select { |fr| fr.versions.include?(sha) }
     feature_reviews.map do |feature_review|
       FeatureReviewWithStatuses.new(
         feature_review,

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -12,6 +12,6 @@ Scenario: Opening a pull request
     | frontend | #branch1 |
   And a ticket "JIRA-100" with summary "Important ticket" is started at "2014-09-29 15:02:00"
   And at time "2014-09-29 16:32:10" adds link for review "Important-Review" to comment for ticket "JIRA-100"
-  Then all pull requests for "#branch1" should be updated to "failure" status
+  Then all pull requests for "#branch1" should be updated to "pending" status
   When ticket "JIRA-100" is approved by "alice@fundingcircle.com" at "2014-09-30 00:04:00"
   Then all pull requests for "#branch1" should be updated to "success" status

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -85,8 +85,8 @@ module Support
         comment_body: "Here you go: #{url}",
         updated: time,
       )
-      @stubbed_requests['failure'] = stub_request(:post, %r{https://api.github.com/.*})
-                                     .with(body: /"state":"failure"/)
+      @stubbed_requests['pending'] = stub_request(:post, %r{https://api.github.com/.*})
+                                     .with(body: /"state":"pending"/)
                                      .and_return(status: 201)
       event = build(:jira_event, ticket_details)
       travel_to Time.zone.parse(time) do

--- a/spec/models/pull_request_status_spec.rb
+++ b/spec/models/pull_request_status_spec.rb
@@ -57,9 +57,35 @@ RSpec.describe PullRequestStatus do
         pull_request_status.update(repo_url: repo_url, sha: sha)
         expect(stub).to have_been_requested
       end
+
+      context 'when the ticket references multiple feature reviews, but only one is for the commit' do
+        let(:ticket) {
+          Ticket.new(
+            versions: %w(abc123 def456 uvw),
+            paths: [
+              feature_review_path(app1: 'abc123', app2: 'xyz'),
+              feature_review_path(app1: 'def456'),
+            ],
+            status: 'Done',
+            approved_at: Time.current,
+          )
+        }
+        it 'posts status "success" with description and link to feature review' do
+          expected_body = {
+            context: 'shipment-tracker',
+            target_url: 'https://shipment-tracker.co.uk/feature_reviews?apps%5Bapp1%5D=abc123&apps%5Bapp2%5D=xyz',
+            description: 'Approved Feature Review found',
+            state: 'success',
+          }
+          stub = stub_request(:post, expected_url).with(body: expected_body)
+
+          pull_request_status.update(repo_url: repo_url, sha: sha)
+          expect(stub).to have_been_requested
+        end
+      end
     end
 
-    context 'when multiple feature reviews exist' do
+    context 'when multiple feature reviews exist for the same commit' do
       context 'when any feature reviews are approved' do
         let(:approved_ticket) {
           Ticket.new(
@@ -92,7 +118,7 @@ RSpec.describe PullRequestStatus do
             .and_return(search_url)
         end
 
-        it 'posts status "success" with description and link to feature review' do
+        it 'posts status "success" with description and to feature review search' do
           expected_body = {
             context: 'shipment-tracker',
             target_url: search_url,

--- a/spec/models/pull_request_status_spec.rb
+++ b/spec/models/pull_request_status_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PullRequestStatus do
         expected_body = {
           context: 'shipment-tracker',
           target_url: 'https://shipment-tracker.co.uk/feature_reviews?apps%5Bapp1%5D=abc123&apps%5Bapp2%5D=xyz',
-          description: 'There are approved feature reviews for this commit',
+          description: 'Approved Feature Review found',
           state: 'success',
         }
         stub = stub_request(:post, expected_url).with(body: expected_body, headers: expected_headers)
@@ -96,7 +96,7 @@ RSpec.describe PullRequestStatus do
           expected_body = {
             context: 'shipment-tracker',
             target_url: search_url,
-            description: 'There are approved feature reviews for this commit',
+            description: 'Approved Feature Review found',
             state: 'success',
           }
           stub = stub_request(:post, expected_url).with(body: expected_body)
@@ -138,12 +138,12 @@ RSpec.describe PullRequestStatus do
             .and_return(search_url)
         end
 
-        it 'posts status "failure" with description and link to feature review search' do
+        it 'posts status "pending" with description and link to feature review search' do
           expected_body = {
             context: 'shipment-tracker',
             target_url: search_url,
-            description: 'No feature reviews for this commit have been approved',
-            state: 'failure',
+            description: 'Awaiting approval for Feature Review',
+            state: 'pending',
           }
           stub = stub_request(:post, expected_url).with(body: expected_body)
 
@@ -165,7 +165,7 @@ RSpec.describe PullRequestStatus do
         expected_body = {
           context: 'shipment-tracker',
           target_url: new_feature_review_url,
-          description: 'There are no feature reviews for this commit',
+          description: 'No Feature Review found',
           state: 'failure',
         }
         stub = stub_request(:post, expected_url).with(body: expected_body)
@@ -181,7 +181,7 @@ RSpec.describe PullRequestStatus do
       expected_body = {
         context: 'shipment-tracker',
         target_url: nil,
-        description: 'Checking for feature reviews',
+        description: 'Searching for Feature Review',
         state: 'pending',
       }
       stub = stub_request(:post, expected_url).with(body: expected_body, headers: expected_headers)


### PR DESCRIPTION
update copy for all statuses
change status to pending when a Feature Review is found, but not approved. 