### PR TITLE
Improve messaging for UAT environment

### DIFF
--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -60,8 +60,10 @@
 .row
   .col-lg-6
     - panel(heading: 'UAT Environment', klass: 'deploys', status: @feature_review_with_statuses.deploy_status) do
-      - if @feature_review_with_statuses.deploys.empty?
-        .panel-body No deploys found
+      - if @feature_review_with_statuses.uat_url.blank?
+        .panel-body Please specify a UAT Environment
+      - elsif @feature_review_with_statuses.deploys.empty?
+        .panel-body Could not find any deploys to #{@feature_review_with_statuses.uat_url}
       - else
         - table(headers: %w(Correct App Version)) do
           - @feature_review_with_statuses.deploys.each do |deploy|


### PR DESCRIPTION
**Before**
The same message when no UAT was given or when there were no deploy events for the given UAT.
![screen shot 2015-10-15 at 17 30 32](https://cloud.githubusercontent.com/assets/497458/10520537/78bdbcaa-7362-11e5-9718-b6882f64d1d5.png)

**After**
When no UAT specified.
![screen shot 2015-10-15 at 17 33 18](https://cloud.githubusercontent.com/assets/497458/10520590/db499632-7362-11e5-9d32-6d2f515add77.png)

When UAT specified but no deploy events exist for that UAT.
![screen shot 2015-10-15 at 17 33 05](https://cloud.githubusercontent.com/assets/497458/10520594/e0a819a0-7362-11e5-8fad-c0e3a67cd114.png)
