### PR TITLE
Rake tasks to get statistics on past releases

### DIFF
--- a/app/models/queries/releases_query.rb
+++ b/app/models/queries/releases_query.rb
@@ -76,6 +76,7 @@ module Queries
         production_deploy_time: deploy.try(:event_created_at),
         subject: commit.subject_line,
         feature_reviews: decorated_feature_reviews,
+        deployed_by: deploy.try(:deployed_by),
       )
     end
 

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -8,6 +8,7 @@ class Release
     attribute :production_deploy_time, Time
     attribute :subject, String
     attribute :feature_reviews, Array
+    attribute :deployed_by, String
   end
 
   def version

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -9,8 +9,7 @@ namespace :stats do
     puts "STATS INFO: Evaluating releases from #{from_date.strftime('%F')} until #{to_date.strftime('%F')}"
     puts "STATS INFO: Incursion-depth: last #{per_page} commits"
 
-    no_approval_count_all_apps = 0
-    approval_pending_count_all_apps = 0
+    unapproved_count_all_apps = 0
     total_count_all_apps = 0
 
     GitRepositoryLocation.app_names.each do |app_name|
@@ -20,7 +19,19 @@ namespace :stats do
       releases = Queries::ReleasesQuery
                  .new(per_page: per_page, git_repo: git_repo, app_name: app_name)
                  .deployed_releases
-      releases_in_time = releases.select { |r|
+
+      releases_with_inherit = []
+
+      releases.each do |release|
+        if release.production_deploy_time.present?
+          releases_with_inherit << release
+        elsif !release.approved? && !releases_with_inherit.empty?
+          last_release = releases_with_inherit.pop
+          releases_with_inherit << Release.new(last_release.attributes.merge(feature_reviews: []))
+        end
+      end
+
+      releases_in_time = releases_with_inherit.select { |r|
         r.production_deploy_time.present? &&
         r.production_deploy_time >= from_date &&
         r.production_deploy_time < to_date
@@ -30,26 +41,22 @@ namespace :stats do
       end
 
       total_count = releases_in_time.count
-      no_approval_count = releases_in_time.select { |r| r.feature_reviews.empty? }.count
       unapproved_releases = releases_in_time.select { |r| !r.approved? }
-      approval_pending_count = unapproved_releases.count - no_approval_count
+      unapproved_count = unapproved_releases.count
 
       puts "STATS INFO: Total releases: #{total_count}"
-      puts "STATS INFO: Aproval pending: #{approval_pending_count}"
-      puts "STATS INFO: No approval sought: #{no_approval_count}"
+      puts "STATS INFO: Unapproved releases: #{unapproved_count}"
       unapproved_releases.each do |release|
         puts "STATS INFO: #{release.version} released by #{release.deployed_by}" if release.deployed_by
       end
       puts 'STATS INFO: *****************'
 
       total_count_all_apps += total_count
-      approval_pending_count_all_apps += approval_pending_count
-      no_approval_count_all_apps += no_approval_count
+      unapproved_count_all_apps += unapproved_count
     end
 
     puts 'STATS INFO: App: all'
     puts "STATS INFO: Total releases: #{total_count_all_apps}"
-    puts "STATS INFO: Aproval pending: #{approval_pending_count_all_apps}"
-    puts "STATS INFO: No approval sought: #{no_approval_count_all_apps}"
+    puts "STATS INFO: Unapproved releases: #{unapproved_count_all_apps}"
   end
 end

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,0 +1,55 @@
+namespace :stats do
+  desc 'Counts releases'
+  task :approved_releases, [:from_date, :to_date, :per_page] => :environment do |_, args|
+    args.with_defaults(date_from: nil, date_to: nil, per_page: 50)
+    from_date = args.from_date ? Time.parse(args.from_date) : Time.current.beginning_of_day - 7.days
+    to_date = args.to_date ? Time.parse(args.to_date) : from_date - 7.days
+    per_page = args.per_page.to_i
+
+    puts "STATS INFO: Evaluating releases from #{from_date.strftime('%F')} until #{to_date.strftime('%F')}"
+    puts "STATS INFO: Incursion-depth: last #{per_page} commits"
+
+    no_approval_count_all_apps = 0
+    approval_pending_count_all_apps = 0
+    total_count_all_apps = 0
+
+    GitRepositoryLocation.app_names.each do |app_name|
+      puts "STATS INFO: Evaluating app: #{app_name}"
+      git_repo = GitRepositoryLoader.from_rails_config.load(app_name)
+
+      releases = Queries::ReleasesQuery
+                 .new(per_page: per_page, git_repo: git_repo, app_name: app_name)
+                 .deployed_releases
+      releases_in_time = releases.select { |r|
+        r.production_deploy_time.present? &&
+        r.production_deploy_time >= from_date &&
+        r.production_deploy_time < to_date
+      }
+      if releases_in_time.count == releases.count
+        puts "STATS WARNING: There maybe more releases for #{app_name}. Increase the incursion-depth."
+      end
+
+      total_count = releases_in_time.count
+      no_approval_count = releases_in_time.select { |r| r.feature_reviews.empty? }.count
+      unapproved_releases = releases_in_time.select { |r| !r.approved? }
+      approval_pending_count = unapproved_releases.count - no_approval_count
+
+      puts "STATS INFO: Total releases: #{total_count}"
+      puts "STATS INFO: Aproval pending: #{approval_pending_count}"
+      puts "STATS INFO: No approval sought: #{no_approval_count}"
+      unapproved_releases.each do |release|
+        puts "STATS INFO: #{release.version} released by #{release.deployed_by}" if release.deployed_by
+      end
+      puts 'STATS INFO: *****************'
+
+      total_count_all_apps += total_count
+      approval_pending_count_all_apps += approval_pending_count
+      no_approval_count_all_apps += no_approval_count
+    end
+
+    puts 'STATS INFO: App: all'
+    puts "STATS INFO: Total releases: #{total_count_all_apps}"
+    puts "STATS INFO: Aproval pending: #{approval_pending_count_all_apps}"
+    puts "STATS INFO: No approval sought: #{no_approval_count_all_apps}"
+  end
+end

--- a/spec/models/queries/releases_query_spec.rb
+++ b/spec/models/queries/releases_query_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe Queries::ReleasesQuery do
   let(:deploy_time) { time - 1.hour }
   let(:approval_time) { time - 2.hours }
 
-  let(:deploys) { [Deploy.new(version: 'def', app_name: app_name, event_created_at: deploy_time)] }
+  let(:deploys) { [
+    Deploy.new(version: 'def', app_name: app_name, event_created_at: deploy_time, deployed_by: 'auser'),
+  ] }
   let(:approved_ticket) {
     Ticket.new(
       versions: %w(xyz uvw),
@@ -68,6 +70,7 @@ RSpec.describe Queries::ReleasesQuery do
       expect(pending_releases.map(&:version)).to eq(['abc'])
       expect(pending_releases.map(&:subject)).to eq(['new commit on master'])
       expect(pending_releases.map(&:production_deploy_time)).to eq([nil])
+      expect(pending_releases.map(&:deployed_by)).to eq([nil])
       expect(pending_releases.map(&:approved?)).to eq([false])
       expect(pending_releases.map(&:feature_reviews)).to eq([[not_approved_feature_review]])
       expect(pending_releases.map(&:feature_reviews).flatten.first.approved?).to eq(false)
@@ -85,6 +88,7 @@ RSpec.describe Queries::ReleasesQuery do
       expect(deployed_releases.map(&:version)).to eq(%w(def ghi))
       expect(deployed_releases.map(&:subject)).to eq(['merge commit', 'first commit on master branch'])
       expect(deployed_releases.map(&:production_deploy_time)).to eq([deploy_time, nil])
+      expect(deployed_releases.map(&:deployed_by)).to eq(['auser', nil])
       expect(deployed_releases.map(&:approved?)).to eq([true, false])
       expect(deployed_releases.map(&:feature_reviews)).to eq([[approved_feature_review], []])
       expect(deployed_releases.map(&:feature_reviews).flatten.first.approved_at).to eq(approval_time)

--- a/spec/models/queries/releases_query_spec.rb
+++ b/spec/models/queries/releases_query_spec.rb
@@ -30,9 +30,11 @@ RSpec.describe Queries::ReleasesQuery do
   let(:deploy_time) { time - 1.hour }
   let(:approval_time) { time - 2.hours }
 
-  let(:deploys) { [
-    Deploy.new(version: 'def', app_name: app_name, event_created_at: deploy_time, deployed_by: 'auser'),
-  ] }
+  let(:deploys) {
+    [
+      Deploy.new(version: 'def', app_name: app_name, event_created_at: deploy_time, deployed_by: 'auser'),
+    ]
+  }
   let(:approved_ticket) {
     Ticket.new(
       versions: %w(xyz uvw),


### PR DESCRIPTION
This change will add a rake task to allow basic reporting on past releases. It is thought to be a spike approach: if we are happy with the report output against production data, we are looking to properly test and implement the reporting feature. 

sample command: 

`bundle exec rake stats:approved_releases['2013-01-01','2015-10-30',100]`

sample output

```
STATS INFO: Evaluating releases from 2013-01-01 until 2015-10-30
STATS INFO: Incursion-depth: last 100 commits
STATS INFO: Evaluating app: hello_world_rails
STATS INFO: Total releases: 7
STATS INFO: Unapproved releases: 3
STATS INFO: 4f1a54e0d0fc99d0c92f8db9eb8e9118ea2c1ed0 released by cwan
STATS INFO: f63a0d271eb793c38de9b8c50e95afa900b5e2d1 released by dideler
STATS INFO: 821aa152c04b982916ebce2b611030b8acf4cd84 released by andi
STATS INFO: *****************
STATS INFO: Evaluating app: shipment_tracker
STATS INFO: Total releases: 3
STATS INFO: Unapproved releases: 3
STATS INFO: 24a34c67fa181a8af3554225c3d62c3bb9fa1aa1 released by astuder
STATS INFO: 2396f62535fb24762f71c7fa1a468843d09895d5 released by astuder
STATS INFO: *****************
STATS INFO: App: all
STATS INFO: Total releases: 10
STATS INFO: Unapproved releases: 6
```