### PR TITLE
Auto detect UAT URL when auto-preparing a Feature Review

### DIFF
--- a/app/models/pull_request_status.rb
+++ b/app/models/pull_request_status.rb
@@ -13,7 +13,7 @@ class PullRequestStatus
   end
 
   def update(repo_url:, sha:)
-    repo_url = repo_url.sub(/\.git$/, '')
+    repo_url = repo_url.chomp('.git')
     feature_reviews = decorated_feature_reviews(sha)
     status, description = *status_for(feature_reviews).values_at(:status, :description)
     target_url = target_url_for(

--- a/app/models/pull_request_status.rb
+++ b/app/models/pull_request_status.rb
@@ -13,7 +13,6 @@ class PullRequestStatus
   end
 
   def update(repo_url:, sha:)
-    repo_url = repo_url.chomp('.git')
     feature_reviews = decorated_feature_reviews(sha)
     status, description = status_for(feature_reviews).values_at(:status, :description)
 

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -22,6 +22,11 @@ module Repositories
       }
     end
 
+    def last_staging_deploy_for_version(version)
+      last_matching_non_prod_deploy = store.where.not(environment: 'production').where(version: version).last
+      Deploy.new(last_matching_non_prod_deploy.attributes) if last_matching_non_prod_deploy
+    end
+
     def apply(event)
       return unless event.is_a?(Events::DeployEvent)
 

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -99,7 +99,7 @@ module Repositories
       array_of_app_versions.map(&:invert).reduce({}, :merge).each do |version, app_name|
         repository_location = git_repository_location.find_by_name(app_name)
         PullRequestUpdateJob.perform_later(
-          repo_url: repository_location.uri,
+          repo_url: repository_location.uri.chomp('.git'),
           sha: version,
         ) if repository_location
       end

--- a/spec/factories/circle_ci_event.rb
+++ b/spec/factories/circle_ci_event.rb
@@ -1,3 +1,5 @@
+require 'events/circle_ci_event'
+
 # rubocop:disable Style/BlockDelimiters
 FactoryGirl.define do
   factory :circle_ci_event, class: Events::CircleCiEvent do

--- a/spec/factories/circle_ci_manual_webhook_event.rb
+++ b/spec/factories/circle_ci_manual_webhook_event.rb
@@ -1,3 +1,5 @@
+require 'events/circle_ci_manual_webhook_event'
+
 # rubocop:disable Style/BlockDelimiters
 FactoryGirl.define do
   factory :circle_ci_manual_webhook_event, class: Events::CircleCiManualWebhookEvent do

--- a/spec/factories/deploy_event.rb
+++ b/spec/factories/deploy_event.rb
@@ -1,3 +1,5 @@
+require 'events/deploy_event'
+
 # rubocop:disable Style/BlockDelimiters
 FactoryGirl.define do
   factory :deploy_event, class: Events::DeployEvent do

--- a/spec/factories/git_commit.rb
+++ b/spec/factories/git_commit.rb
@@ -1,3 +1,5 @@
+require 'git_commit'
+
 # rubocop:disable Style/BlockDelimiters
 FactoryGirl.define do
   factory :git_commit do

--- a/spec/factories/jenkins_event.rb
+++ b/spec/factories/jenkins_event.rb
@@ -1,3 +1,5 @@
+require 'events/jenkins_event'
+
 # rubocop:disable Style/BlockDelimiters
 FactoryGirl.define do
   factory :jenkins_event, class: Events::JenkinsEvent do

--- a/spec/factories/jira_event.rb
+++ b/spec/factories/jira_event.rb
@@ -1,3 +1,5 @@
+require 'events/jira_event'
+
 # rubocop:disable Style/BlockDelimiters
 FactoryGirl.define do
   factory :jira_event, class: Events::JiraEvent do

--- a/spec/factories/manual_test_event.rb
+++ b/spec/factories/manual_test_event.rb
@@ -1,3 +1,5 @@
+require 'events/manual_test_event'
+
 # rubocop:disable Style/BlockDelimiters
 FactoryGirl.define do
   factory :manual_test_event, class: Events::ManualTestEvent do

--- a/spec/factories/uat_event.rb
+++ b/spec/factories/uat_event.rb
@@ -1,3 +1,5 @@
+require 'events/uat_event'
+
 # rubocop:disable Style/BlockDelimiters
 FactoryGirl.define do
   factory :uat_event, class: Events::UatEvent do

--- a/spec/models/pull_request_status_spec.rb
+++ b/spec/models/pull_request_status_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe PullRequestStatus do
     }
   }
 
+  let!(:stub) { stub_request(:post, expected_url).with(body: expected_body, headers: expected_headers) }
+
   describe '#update' do
     let(:ticket_repository) { instance_double(Repositories::TicketRepository) }
 
@@ -53,8 +55,6 @@ RSpec.describe PullRequestStatus do
       let(:state) { 'success' }
 
       it 'posts status "success" with description and link to feature review' do
-        stub = stub_request(:post, expected_url).with(body: expected_body, headers: expected_headers)
-
         pull_request_status.update(repo_url: repo_url, sha: sha)
         expect(stub).to have_been_requested
       end
@@ -75,8 +75,6 @@ RSpec.describe PullRequestStatus do
         }
 
         it 'posts status "success" with description and link to feature review' do
-          stub = stub_request(:post, expected_url).with(body: expected_body)
-
           pull_request_status.update(repo_url: repo_url, sha: sha)
           expect(stub).to have_been_requested
         end
@@ -110,8 +108,6 @@ RSpec.describe PullRequestStatus do
         let(:state) { 'success' }
 
         it 'posts status "success" with description and to feature review search' do
-          stub = stub_request(:post, expected_url).with(body: expected_body)
-
           pull_request_status.update(repo_url: repo_url, sha: sha)
           expect(stub).to have_been_requested
         end
@@ -143,8 +139,6 @@ RSpec.describe PullRequestStatus do
         let(:state) { 'pending' }
 
         it 'posts status "pending" with description and link to feature review search' do
-          stub = stub_request(:post, expected_url).with(body: expected_body)
-
           pull_request_status.update(repo_url: repo_url, sha: sha)
           expect(stub).to have_been_requested
         end
@@ -165,8 +159,6 @@ RSpec.describe PullRequestStatus do
       end
 
       it 'posts status "failure" with description and link to view a feature review' do
-        stub = stub_request(:post, expected_url).with(body: expected_body)
-
         pull_request_status.update(repo_url: repo_url, sha: sha)
         expect(stub).to have_been_requested
       end
@@ -177,8 +169,6 @@ RSpec.describe PullRequestStatus do
           let(:target_url) { 'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc&uat_url=uat.com' }
 
           it 'includes the UAT URL in the link' do
-            stub = stub_request(:post, expected_url).with(body: expected_body)
-
             pull_request_status.update(repo_url: repo_url, sha: sha)
             expect(stub).to have_been_requested
           end
@@ -188,8 +178,6 @@ RSpec.describe PullRequestStatus do
           let(:deploy) { nil }
 
           it 'does not include the UAT URL in the link' do
-            stub = stub_request(:post, expected_url).with(body: expected_body)
-
             pull_request_status.update(repo_url: repo_url, sha: sha)
             expect(stub).to have_been_requested
           end
@@ -204,8 +192,6 @@ RSpec.describe PullRequestStatus do
     let(:state) { 'pending' }
 
     it 'posts status "pending" with description and no link' do
-      stub = stub_request(:post, expected_url).with(body: expected_body, headers: expected_headers)
-
       pull_request_status.reset(repo_url: repo_url, sha: sha)
       expect(stub).to have_been_requested
     end

--- a/spec/models/pull_request_status_spec.rb
+++ b/spec/models/pull_request_status_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe PullRequestStatus do
 
   let(:ticket_repository) { instance_double(Repositories::TicketRepository) }
   let(:sha) { 'abc123' }
-  let(:repo_url) { 'ssh://github.com/some/app_name' }
-  let(:expected_url) { 'https://api.github.com/repos/some/app_name/statuses/abc123' }
+  let(:repo_url) { 'ssh://github.com/some/repo.git' }
+  let(:expected_url) { 'https://api.github.com/repos/some/repo/statuses/abc123' }
 
   let(:expected_headers) {
     {
@@ -106,7 +106,7 @@ RSpec.describe PullRequestStatus do
           )
         }
 
-        let(:search_url) { 'https://localhost/feature_reviews/search?application=app_name&version=abc123' }
+        let(:search_url) { 'https://localhost/feature_reviews/search?application=repo&version=abc123' }
 
         before do
           allow(ticket_repository)
@@ -148,7 +148,7 @@ RSpec.describe PullRequestStatus do
           )
         }
 
-        let(:search_url) { 'https://localhost/feature_reviews/search?application=app_name&version=abc123' }
+        let(:search_url) { 'https://localhost/feature_reviews/search?application=repo&version=abc123' }
 
         before do
           allow(ticket_repository)
@@ -171,7 +171,7 @@ RSpec.describe PullRequestStatus do
     end
 
     context 'when no feature review exists' do
-      let(:feature_review_url) { 'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc123' }
+      let(:feature_review_url) { 'https://localhost/feature_reviews?apps%5Brepo%5D=abc123' }
 
       before do
         allow(ticket_repository).to receive(:tickets_for_versions).with([sha]).and_return([])

--- a/spec/models/pull_request_status_spec.rb
+++ b/spec/models/pull_request_status_spec.rb
@@ -193,6 +193,8 @@ RSpec.describe PullRequestStatus do
   end
 
   describe '#reset' do
+    let(:html_url) { 'http://github.com/some/repo' }
+
     it 'posts status "pending" with description and no link' do
       expected_body = {
         context: 'shipment-tracker',
@@ -202,7 +204,7 @@ RSpec.describe PullRequestStatus do
       }
       stub = stub_request(:post, expected_url).with(body: expected_body, headers: expected_headers)
 
-      pull_request_status.reset(repo_url: repo_url, sha: sha)
+      pull_request_status.reset(repo_url: html_url, sha: sha)
       expect(stub).to have_been_requested
     end
   end

--- a/spec/models/pull_request_status_spec.rb
+++ b/spec/models/pull_request_status_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe PullRequestStatus do
   let(:token) { 'a-token' }
   let(:routes) { double(:routes) }
 
-  let(:sha) { 'abc123' }
+  let(:sha) { 'abc' }
   let(:repo_url) { 'ssh://github.com/some/app_name' }
-  let(:expected_url) { 'https://api.github.com/repos/some/app_name/statuses/abc123' }
 
+  let(:expected_url) { 'https://api.github.com/repos/some/app_name/statuses/abc' }
   let(:expected_headers) {
     {
       'Accept' => 'application/vnd.github.v3+json',
@@ -19,7 +19,14 @@ RSpec.describe PullRequestStatus do
       'User-Agent' => 'Octokit Ruby Gem 4.1.0',
     }
   }
-
+  let(:expected_body) {
+    {
+      context: 'shipment-tracker',
+      target_url: target_url,
+      description: description,
+      state: state,
+    }
+  }
 
   describe '#update' do
     let(:ticket_repository) { instance_double(Repositories::TicketRepository) }
@@ -33,21 +40,19 @@ RSpec.describe PullRequestStatus do
       let(:tickets) {
         [
           Ticket.new(
-            versions: %w(abc123 xyz),
-            paths: [feature_review_path(app1: 'abc123', app2: 'xyz')],
+            versions: %w(abc xyz),
+            paths: [feature_review_path(app1: 'abc', app2: 'xyz')],
             status: 'Done',
             approved_at: Time.current,
-          )
+          ),
         ]
       }
 
+      let(:target_url) { 'https://localhost/feature_reviews?apps%5Bapp1%5D=abc&apps%5Bapp2%5D=xyz' }
+      let(:description) { 'Approved Feature Review found' }
+      let(:state) { 'success' }
+
       it 'posts status "success" with description and link to feature review' do
-        expected_body = {
-          context: 'shipment-tracker',
-          target_url: 'https://localhost/feature_reviews?apps%5Bapp1%5D=abc123&apps%5Bapp2%5D=xyz',
-          description: 'Approved Feature Review found',
-          state: 'success',
-        }
         stub = stub_request(:post, expected_url).with(body: expected_body, headers: expected_headers)
 
         pull_request_status.update(repo_url: repo_url, sha: sha)
@@ -58,24 +63,18 @@ RSpec.describe PullRequestStatus do
         let(:tickets) {
           [
             Ticket.new(
-              versions: %w(abc123 def456 uvw),
+              versions: %w(abc def456 uvw),
               paths: [
-                feature_review_path(app1: 'abc123', app2: 'xyz'),
+                feature_review_path(app1: 'abc', app2: 'xyz'),
                 feature_review_path(app1: 'def456'),
               ],
               status: 'Done',
               approved_at: Time.current,
-            )
+            ),
           ]
         }
 
         it 'posts status "success" with description and link to feature review' do
-          expected_body = {
-            context: 'shipment-tracker',
-            target_url: 'https://localhost/feature_reviews?apps%5Bapp1%5D=abc123&apps%5Bapp2%5D=xyz',
-            description: 'Approved Feature Review found',
-            state: 'success',
-          }
           stub = stub_request(:post, expected_url).with(body: expected_body)
 
           pull_request_status.update(repo_url: repo_url, sha: sha)
@@ -89,32 +88,28 @@ RSpec.describe PullRequestStatus do
         let(:tickets) {
           [
             Ticket.new(
-              versions: %w(abc123 uvw),
+              versions: %w(abc uvw),
               paths: [
-                feature_review_path(app1: 'abc123', app2: 'uvw'),
-                feature_review_path(app1: 'abc123'),
+                feature_review_path(app1: 'abc', app2: 'uvw'),
+                feature_review_path(app1: 'abc'),
               ],
               status: 'Done',
               approved_at: Time.current,
             ),
             Ticket.new(
-              versions: %w(abc123 uvw),
-              paths: [feature_review_path(app1: 'abc123', app2: 'uvw')],
+              versions: %w(abc uvw),
+              paths: [feature_review_path(app1: 'abc', app2: 'uvw')],
               status: 'In Progress',
               approved_at: nil,
             ),
           ]
         }
 
-        let(:search_url) { 'https://localhost/feature_reviews/search?application=app_name&version=abc123' }
+        let(:target_url) { 'https://localhost/feature_reviews/search?application=app_name&version=abc' }
+        let(:description) { 'Approved Feature Review found' }
+        let(:state) { 'success' }
 
         it 'posts status "success" with description and to feature review search' do
-          expected_body = {
-            context: 'shipment-tracker',
-            target_url: search_url,
-            description: 'Approved Feature Review found',
-            state: 'success',
-          }
           stub = stub_request(:post, expected_url).with(body: expected_body)
 
           pull_request_status.update(repo_url: repo_url, sha: sha)
@@ -126,32 +121,28 @@ RSpec.describe PullRequestStatus do
         let(:tickets) {
           [
             Ticket.new(
-              versions: %w(abc123 uvw),
+              versions: %w(abc uvw),
               paths: [
-                feature_review_path(app1: 'abc123', app2: 'uvw'),
-                feature_review_path(app1: 'abc123'),
+                feature_review_path(app1: 'abc', app2: 'uvw'),
+                feature_review_path(app1: 'abc'),
               ],
               status: 'In Progress',
               approved_at: Time.current,
             ),
             Ticket.new(
-              versions: %w(abc123 uvw),
-              paths: [feature_review_path(app1: 'abc123', app2: 'uvw')],
+              versions: %w(abc uvw),
+              paths: [feature_review_path(app1: 'abc', app2: 'uvw')],
               status: 'Done',
               approved_at: nil,
             ),
           ]
         }
 
-        let(:search_url) { 'https://localhost/feature_reviews/search?application=app_name&version=abc123' }
+        let(:target_url) { 'https://localhost/feature_reviews/search?application=app_name&version=abc' }
+        let(:description) { 'Awaiting approval for Feature Review' }
+        let(:state) { 'pending' }
 
         it 'posts status "pending" with description and link to feature review search' do
-          expected_body = {
-            context: 'shipment-tracker',
-            target_url: search_url,
-            description: 'Awaiting approval for Feature Review',
-            state: 'pending',
-          }
           stub = stub_request(:post, expected_url).with(body: expected_body)
 
           pull_request_status.update(repo_url: repo_url, sha: sha)
@@ -161,10 +152,12 @@ RSpec.describe PullRequestStatus do
     end
 
     context 'when no feature review exists' do
-      let(:feature_review_url) { 'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc123' }
       let(:deploy_repository) { instance_double(Repositories::DeployRepository) }
       let(:deploy) { nil }
       let(:tickets) { [] }
+      let(:target_url) { 'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc' }
+      let(:description) { "No Feature Review found. Click 'Details' to create one." }
+      let(:state) { 'failure' }
 
       before do
         allow(Repositories::DeployRepository).to receive(:new).and_return(deploy_repository)
@@ -172,12 +165,6 @@ RSpec.describe PullRequestStatus do
       end
 
       it 'posts status "failure" with description and link to view a feature review' do
-        expected_body = {
-          context: 'shipment-tracker',
-          target_url: feature_review_url,
-          description: "No Feature Review found. Click 'Details' to create one.",
-          state: 'failure',
-        }
         stub = stub_request(:post, expected_url).with(body: expected_body)
 
         pull_request_status.update(repo_url: repo_url, sha: sha)
@@ -187,17 +174,9 @@ RSpec.describe PullRequestStatus do
       context 'when there are deploys for the app version under review' do
         context 'when the deploy is a staging deploy' do
           let(:deploy) { instance_double(Deploy, server: 'uat.com') }
-          let(:feature_review_url) {
-            'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc123&uat_url=uat.com'
-          }
+          let(:target_url) { 'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc&uat_url=uat.com' }
 
           it 'includes the UAT URL in the link' do
-            expected_body = {
-              context: 'shipment-tracker',
-              target_url: feature_review_url,
-              description: "No Feature Review found. Click 'Details' to create one.",
-              state: 'failure',
-            }
             stub = stub_request(:post, expected_url).with(body: expected_body)
 
             pull_request_status.update(repo_url: repo_url, sha: sha)
@@ -209,12 +188,6 @@ RSpec.describe PullRequestStatus do
           let(:deploy) { nil }
 
           it 'does not include the UAT URL in the link' do
-            expected_body = {
-              context: 'shipment-tracker',
-              target_url: feature_review_url,
-              description: "No Feature Review found. Click 'Details' to create one.",
-              state: 'failure',
-            }
             stub = stub_request(:post, expected_url).with(body: expected_body)
 
             pull_request_status.update(repo_url: repo_url, sha: sha)
@@ -226,13 +199,11 @@ RSpec.describe PullRequestStatus do
   end
 
   describe '#reset' do
+    let(:target_url) { nil }
+    let(:description) { 'Searching for Feature Review' }
+    let(:state) { 'pending' }
+
     it 'posts status "pending" with description and no link' do
-      expected_body = {
-        context: 'shipment-tracker',
-        target_url: nil,
-        description: 'Searching for Feature Review',
-        state: 'pending',
-      }
       stub = stub_request(:post, expected_url).with(body: expected_body, headers: expected_headers)
 
       pull_request_status.reset(repo_url: repo_url, sha: sha)

--- a/spec/models/pull_request_status_spec.rb
+++ b/spec/models/pull_request_status_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe PullRequestStatus do
   end
 
   describe '#update' do
-    let(:deploy_repository) { instance_double(Repositories::DeployRepository) }
-    let(:deploy) { nil }
-
-    before do
-      allow(Repositories::DeployRepository).to receive(:new).and_return(deploy_repository)
-      allow(deploy_repository).to receive(:last_staging_deploy_for_version).with(sha).and_return(deploy)
-   end
-
     context 'when a single feature review exists' do
       let(:ticket) {
         Ticket.new(
@@ -178,8 +170,12 @@ RSpec.describe PullRequestStatus do
 
     context 'when no feature review exists' do
       let(:feature_review_url) { 'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc123' }
+      let(:deploy_repository) { instance_double(Repositories::DeployRepository) }
+      let(:deploy) { nil }
 
       before do
+        allow(Repositories::DeployRepository).to receive(:new).and_return(deploy_repository)
+        allow(deploy_repository).to receive(:last_staging_deploy_for_version).with(sha).and_return(deploy)
         allow(ticket_repository).to receive(:tickets_for_versions).with([sha]).and_return([])
       end
 
@@ -199,7 +195,9 @@ RSpec.describe PullRequestStatus do
       context 'when there are deploys for the app version under review' do
         context 'when the deploy is a staging deploy' do
           let(:deploy) { instance_double(Deploy, server: 'uat.com') }
-          let(:feature_review_url) { 'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc123&uat_url=uat.com' }
+          let(:feature_review_url) {
+            'https://localhost/feature_reviews?apps%5Bapp_name%5D=abc123&uat_url=uat.com'
+          }
 
           it 'includes the UAT URL in the link' do
             expected_body = {

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Repositories::TicketRepository do
     let(:approval_time) { Time.current.change(usec: 0) }
     let(:ticket_defaults) { { paths: [path], versions: %w(foo) } }
     let(:repository_location) {
-      instance_double(GitRepositoryLocation, uri: 'http://github.com/owner/frontend')
+      instance_double(GitRepositoryLocation, uri: 'ssh://git@github.com/owner/frontend.git')
     }
 
     before do
@@ -280,11 +280,11 @@ RSpec.describe Repositories::TicketRepository do
 
           it 'schedules an update to the pull request for each version' do
             expect(PullRequestUpdateJob).to receive(:perform_later).with(
-              repo_url: 'http://github.com/owner/frontend',
+              repo_url: 'ssh://git@github.com/owner/frontend',
               sha: 'abc',
             )
             expect(PullRequestUpdateJob).to receive(:perform_later).with(
-              repo_url: 'http://github.com/owner/frontend',
+              repo_url: 'ssh://git@github.com/owner/frontend',
               sha: 'def',
             )
             repository.apply(event)
@@ -333,7 +333,7 @@ RSpec.describe Repositories::TicketRepository do
 
         it 'schedules an update to the pull request for each version' do
           expect(PullRequestUpdateJob).to receive(:perform_later).with(
-            repo_url: 'http://github.com/owner/frontend',
+            repo_url: 'ssh://git@github.com/owner/frontend',
             sha: 'abc',
           )
           repository.apply(approval_event)
@@ -355,7 +355,7 @@ RSpec.describe Repositories::TicketRepository do
 
         it 'schedules an update to the pull request for each version' do
           expect(PullRequestUpdateJob).to receive(:perform_later).with(
-            repo_url: 'http://github.com/owner/frontend',
+            repo_url: 'ssh://git@github.com/owner/frontend',
             sha: 'abc',
           )
           repository.apply(unapproval_event)


### PR DESCRIPTION
When Shipment Tracker auto-prepares a Feature Review for GitHub Statuses, it will now attempt to find the URL of the relevant UAT environment.

It does this by searching for the latest non-production deploy with the head sha.