### PR TITLE
Improve feedback for UAT panel

### DIFF
--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -63,7 +63,7 @@
   .col-lg-6
     - panel(heading: 'UAT Environment', klass: 'deploys', status: @feature_review_with_statuses.deploy_status) do
       - if @feature_review_with_statuses.uat_url.blank?
-        .panel-body Please specify a UAT Environment
+        .panel-body No UAT Environment specified
       - elsif @feature_review_with_statuses.deploys.empty?
         .panel-body Could not find any deploys to #{@feature_review_with_statuses.uat_url}
       - else


### PR DESCRIPTION
Changes 'Please specify UAT Environment' to 'No UAT environment specified' so that it does not look like a mandatory field. Based on some feedback, the wording was confusing.