### PR TITLE
Show the flash message when appropriate on Search page

### DIFF
--- a/app/controllers/feature_reviews_controller.rb
+++ b/app/controllers/feature_reviews_controller.rb
@@ -34,7 +34,7 @@ class FeatureReviewsController < ApplicationController
     tickets = Repositories::TicketRepository.new.tickets_for_versions(versions)
 
     @links = factory.create_from_tickets(tickets).map(&:path)
-    flash[:error] = 'No Feature Reviews found.' if @links.empty?
+    flash.now[:error] = 'No Feature Reviews found.' if @links.empty?
   end
 
   private


### PR DESCRIPTION
Currently the error message still shows on the next page load (even when search returns results) because the flash is expecting a redirect to be done.