### PR TITLE
ensure uat-url protocol is stripped out

### DIFF
--- a/app/models/forms/feature_review_form.rb
+++ b/app/models/forms/feature_review_form.rb
@@ -17,7 +17,7 @@ module Forms
     def initialize(apps:, git_repository_loader: nil, uat_url:)
       @apps = apps
       @git_repository_loader = git_repository_loader
-      @uat_url = uat_url
+      @uat_url = Addressable::URI.heuristic_parse(uat_url, scheme: 'http').try(:host)
     end
 
     def valid?

--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -46,7 +46,7 @@
             %span.title User Acceptance Tests
 
   .col-lg-6
-    - panel(heading: 'Apps Under Review', klass: 'app-info', button_link: { text: 'Modify', url: edit_url(@feature_review_with_statuses.app_versions, @feature_review_with_statuses.uat_url)}) do
+    - panel(heading: 'Apps Under Review', klass: 'app-info', button_link: { text: 'Modify', url: edit_url(@feature_review_with_statuses.app_versions, @feature_review_with_statuses.uat_host)}) do
       %ul.list-group
         - @feature_review_with_statuses.app_versions.each do |app_name, version|
           %li.list-group-item.app

--- a/spec/models/forms/feature_review_form_spec.rb
+++ b/spec/models/forms/feature_review_form_spec.rb
@@ -56,9 +56,16 @@ RSpec.describe Forms::FeatureReviewForm do
   end
 
   describe '#uat_url' do
-    let(:uat_url) { double }
+    let(:uat_url) { 'http://foo.com/bar' }
     it 'returns the uat_url' do
-      expect(feature_review_form.uat_url).to eql(uat_url)
+      expect(feature_review_form.uat_url).to eql('foo.com')
+    end
+
+    context 'when uat not given' do
+      let(:uat_url) { nil }
+      it 'returns the uat_url' do
+        expect(feature_review_form.uat_url).to eql(nil)
+      end
     end
   end
 
@@ -165,7 +172,7 @@ RSpec.describe Forms::FeatureReviewForm do
         '/feature_reviews?'\
         'apps%5Bbackend%5D=def&'\
         'apps%5Bfrontend%5D=abc&'\
-        'uat_url=http%3A%2F%2Ffoobar.com%2Fblah%2Fblah',
+        'uat_url=foobar.com',
       )
     end
 
@@ -180,7 +187,7 @@ RSpec.describe Forms::FeatureReviewForm do
       let(:apps) { { frontend: 'abc', backend: '' } }
       let(:uat_url) { 'http://foobar.com' }
 
-      it { is_expected.to eq('/feature_reviews?apps%5Bfrontend%5D=abc&uat_url=http%3A%2F%2Ffoobar.com') }
+      it { is_expected.to eq('/feature_reviews?apps%5Bfrontend%5D=abc&uat_url=foobar.com') }
     end
 
     context 'with lots of apps' do


### PR DESCRIPTION
This will give consistency when creating and editing feature reviews. 
The change also strips out the path as not relevant in the context of a uat url. 