### PR TITLE
Prefer flat_map over map.flatten

### DIFF
--- a/app/models/factories/feature_review_factory.rb
+++ b/app/models/factories/feature_review_factory.rb
@@ -40,7 +40,7 @@ module Factories
     end
 
     def map_paths(tickets)
-      tickets.map(&:paths).flatten.uniq
+      tickets.flat_map(&:paths).uniq
     end
 
     def parse_uri(uri)

--- a/app/models/queries/releases_query.rb
+++ b/app/models/queries/releases_query.rb
@@ -44,7 +44,7 @@ module Queries
     end
 
     def associated_versions
-      commits.map(&:associated_ids).flatten.uniq
+      commits.flat_map(&:associated_ids).uniq
     end
 
     def production_deploy_for_commit(commit)

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -89,7 +89,7 @@ module Repositories
     end
 
     def feature_review_versions(feature_reviews)
-      feature_reviews.map(&:versions).flatten
+      feature_reviews.flat_map(&:versions)
     end
 
     def update_pull_requests_for(ticket_hash)


### PR DESCRIPTION
Just learned about [`Enumerable#flat_map`](http://ruby-doc.org/core/Enumerable.html#method-i-flat_map) which can give us a minor performance improvement.

```
Calculating -------------------------------------
         map.flatten   312.000  i/100ms
            flat_map   639.000  i/100ms
-------------------------------------------------
         map.flatten      3.189k (± 2.7%) i/s -     16.224k
            flat_map      6.438k (± 2.3%) i/s -     32.589k

Comparison:
            flat_map:     6437.7 i/s
         map.flatten:     3189.1 i/s - 2.02x slower
```

```ruby
require 'benchmark/ips'

class Foo
  def bar
    [1, 2, 3]
  end
end

foos = Array.new(1000) { Foo.new }

Benchmark.ips do |x|
  x.report 'map.flatten' do
    foos.map(&:bar).flatten
  end

  x.report 'flat_map' do
    foos.flat_map(&:bar)
  end

  x.compare!
end
```
