### PR TITLE
Handle Heroku deploy payload

### DIFF
--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -2,6 +2,8 @@ require 'events/base_event'
 
 module Events
   class DeployEvent < Events::BaseEvent
+    ENVIRONMENTS = %w(uat staging production)
+
     def app_name
       details.fetch('app_name', details.fetch('app', nil)).try(:downcase)
     end
@@ -19,10 +21,22 @@ module Events
     end
 
     def environment
-      details.fetch('environment', nil)
+      details.fetch('environment', heroku_environment)
     end
 
     private
+
+    def heroku_environment
+      if ENVIRONMENTS.include?(heroku_name)
+        heroku_name
+      else
+        nil
+      end
+    end
+
+    def heroku_name
+      app_name.try(:split, '-').try(:last)
+    end
 
     def servers
       details.fetch('servers', servers_fallback)

--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -3,7 +3,7 @@ require 'events/base_event'
 module Events
   class DeployEvent < Events::BaseEvent
     def app_name
-      details.fetch('app_name', nil).try(:downcase)
+      details.fetch('app_name', details.fetch('app', nil)).try(:downcase)
     end
 
     def server
@@ -11,11 +11,11 @@ module Events
     end
 
     def version
-      details.fetch('version', nil)
+      details.fetch('version', details.fetch('head_long', nil))
     end
 
     def deployed_by
-      details.fetch('deployed_by', nil)
+      details.fetch('deployed_by', details.fetch('user', nil))
     end
 
     def environment
@@ -29,7 +29,7 @@ module Events
     end
 
     def servers_fallback
-      [details.fetch('server', nil)].compact
+      [details.fetch('server', details.fetch('url', nil))].compact
     end
   end
 end

--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -5,7 +5,7 @@ module Events
     ENVIRONMENTS = %w(uat staging production)
 
     def app_name
-      details.fetch('app_name', details.fetch('app', nil)).try(:downcase)
+      (details['app_name'] || details['app']).try(:downcase)
     end
 
     def server
@@ -13,11 +13,11 @@ module Events
     end
 
     def version
-      details.fetch('version', details.fetch('head_long', nil))
+      details['version'] || details['head_long']
     end
 
     def deployed_by
-      details.fetch('deployed_by', details.fetch('user', nil))
+      details['deployed_by'] || details['user']
     end
 
     def environment
@@ -27,15 +27,12 @@ module Events
     private
 
     def heroku_environment
-      if ENVIRONMENTS.include?(heroku_name)
-        heroku_name
-      else
-        nil
-      end
+      app_name_extension if ENVIRONMENTS.include?(app_name_extension)
     end
 
-    def heroku_name
-      app_name.try(:split, '-').try(:last)
+    def app_name_extension
+      return nil unless app_name
+      app_name.split('-').last
     end
 
     def servers
@@ -43,7 +40,7 @@ module Events
     end
 
     def servers_fallback
-      [details.fetch('server', details.fetch('url', nil))].compact
+      [details['server'] || details['url']].compact
     end
   end
 end

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -7,18 +7,27 @@ RSpec.describe Events::DeployEvent do
     context 'when the payload comes from Heroku' do
       let(:payload) {
         {
-          'app' => 'nameless-forest',
+          'app' => 'nameless-forest-uat',
           'user' => 'user@example.com',
-          'url' => 'http://nameless-forest.herokuapp.com',
+          'url' => 'http://nameless-forest-uat.herokuapp.com',
           'head_long' => '123abc',
         }
       }
 
       it 'returns the correct values' do
-        expect(subject.app_name).to eq('nameless-forest')
-        expect(subject.server).to eq('http://nameless-forest.herokuapp.com')
+        expect(subject.app_name).to eq('nameless-forest-uat')
+        expect(subject.server).to eq('http://nameless-forest-uat.herokuapp.com')
         expect(subject.version).to eq('123abc')
         expect(subject.deployed_by).to eq('user@example.com')
+        expect(subject.environment).to eq('uat')
+      end
+
+      context 'when the app name does not include the environment at the end' do
+        let(:payload) { { 'app' => 'nameless-forest' } }
+
+        it 'sets the environment to nil' do
+          expect(subject.environment).to be nil
+        end
       end
     end
 
@@ -28,6 +37,7 @@ RSpec.describe Events::DeployEvent do
         'servers' => ['prod1.example.com', 'prod2.example.com'],
         'version' => '123abc',
         'deployed_by' => 'bob',
+        'environment' => 'staging'
       }
     }
 
@@ -36,6 +46,7 @@ RSpec.describe Events::DeployEvent do
       expect(subject.server).to eq('prod1.example.com')
       expect(subject.version).to eq('123abc')
       expect(subject.deployed_by).to eq('bob')
+      expect(subject.environment).to eq('staging')
     end
 
     context 'when the payload structure is deprecated' do
@@ -65,10 +76,11 @@ RSpec.describe Events::DeployEvent do
     }
 
     it 'returns the correct values' do
-      expect(subject.app_name).to be_nil
-      expect(subject.server).to be_nil
-      expect(subject.version).to be_nil
-      expect(subject.deployed_by).to be_nil
+      expect(subject.app_name).to be nil
+      expect(subject.server).to be nil
+      expect(subject.version).to be nil
+      expect(subject.deployed_by).to be nil
+      expect(subject.environment).to be nil
     end
   end
 end

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -4,6 +4,24 @@ RSpec.describe Events::DeployEvent do
   subject { Events::DeployEvent.new(details: payload) }
 
   context 'when given a valid payload' do
+    let(:payload) {
+      {
+        'app_name' => 'soMeApp',
+        'servers' => ['prod1.example.com', 'prod2.example.com'],
+        'version' => '123abc',
+        'deployed_by' => 'bob',
+        'environment' => 'staging',
+      }
+    }
+
+    it 'returns the correct values' do
+      expect(subject.app_name).to eq('someapp')
+      expect(subject.server).to eq('prod1.example.com')
+      expect(subject.version).to eq('123abc')
+      expect(subject.deployed_by).to eq('bob')
+      expect(subject.environment).to eq('staging')
+    end
+
     context 'when the payload comes from Heroku' do
       let(:payload) {
         {
@@ -29,24 +47,6 @@ RSpec.describe Events::DeployEvent do
           expect(subject.environment).to be nil
         end
       end
-    end
-
-    let(:payload) {
-      {
-        'app_name' => 'soMeApp',
-        'servers' => ['prod1.example.com', 'prod2.example.com'],
-        'version' => '123abc',
-        'deployed_by' => 'bob',
-        'environment' => 'staging'
-      }
-    }
-
-    it 'returns the correct values' do
-      expect(subject.app_name).to eq('someapp')
-      expect(subject.server).to eq('prod1.example.com')
-      expect(subject.version).to eq('123abc')
-      expect(subject.deployed_by).to eq('bob')
-      expect(subject.environment).to eq('staging')
     end
 
     context 'when the payload structure is deprecated' do

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -1,14 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Events::DeployEvent do
-  subject { described_class.new(details: payload) }
+  subject { Events::DeployEvent.new(details: payload) }
 
   context 'when given a valid payload' do
+    context 'when the payload comes from Heroku' do
+      let(:payload) {
+        {
+          'app' => 'nameless-forest',
+          'user' => 'user@example.com',
+          'url' => 'http://nameless-forest.herokuapp.com',
+          'head_long' => '123abc',
+        }
+      }
+
+      it 'returns the correct values' do
+        expect(subject.app_name).to eq('nameless-forest')
+        expect(subject.server).to eq('http://nameless-forest.herokuapp.com')
+        expect(subject.version).to eq('123abc')
+        expect(subject.deployed_by).to eq('user@example.com')
+      end
+    end
+
     let(:payload) {
       {
         'app_name' => 'soMeApp',
         'servers' => ['prod1.example.com', 'prod2.example.com'],
-        'version' => '123',
+        'version' => '123abc',
         'deployed_by' => 'bob',
       }
     }
@@ -16,7 +34,7 @@ RSpec.describe Events::DeployEvent do
     it 'returns the correct values' do
       expect(subject.app_name).to eq('someapp')
       expect(subject.server).to eq('prod1.example.com')
-      expect(subject.version).to eq('123')
+      expect(subject.version).to eq('123abc')
       expect(subject.deployed_by).to eq('bob')
     end
 
@@ -25,7 +43,7 @@ RSpec.describe Events::DeployEvent do
         {
           'app_name' => 'soMeApp',
           'server' => 'uat.example.com',
-          'version' => '123',
+          'version' => '123abc',
           'deployed_by' => 'bob',
         }
       }
@@ -33,7 +51,7 @@ RSpec.describe Events::DeployEvent do
       it 'returns the correct values' do
         expect(subject.app_name).to eq('someapp')
         expect(subject.server).to eq('uat.example.com')
-        expect(subject.version).to eq('123')
+        expect(subject.version).to eq('123abc')
         expect(subject.deployed_by).to eq('bob')
       end
     end


### PR DESCRIPTION
* Map Heroku fields to standard deploy event fields
  because we cannot change parameters sent by Heroku

Signed-off-by: Molly Huerster <molly.huerster@fundingcircle.com>