### PR TITLE
Re-enable CircleCI webhook event type

### DIFF
--- a/config/initializers/event_types.rb
+++ b/config/initializers/event_types.rb
@@ -1,9 +1,8 @@
 Rails.application.config.event_types = [
-  # Waiting on CircleCI to support SNI on SSL webhooks
-  # EventType.new(
-  #   name: 'CircleCI (webhook)',
-  #   endpoint: 'circleci',
-  #   event_class: Events::CircleCiEvent),
+  EventType.new(
+    name: 'CircleCI (webhook)',
+    endpoint: 'circleci',
+    event_class: Events::CircleCiEvent),
   EventType.new(
     name: 'CircleCI',
     endpoint: 'circleci-manual',


### PR DESCRIPTION
This will enable "CircleCI (webhook)" as a *Source* option on the Tokens page.

Before we can stop using the circleci-manual event type, we need to
verify that the CircleCI webhook now works in production, and then
switch over all audited repos to use the official webhook.

Discussion about why the manual CircleCI webhooks exist: https://jira.fundingcircle.com/browse/ENG-86