### PR TITLE
Clarify difference between the two CircleCI event types

### DIFF
--- a/config/initializers/event_types.rb
+++ b/config/initializers/event_types.rb
@@ -4,7 +4,7 @@ Rails.application.config.event_types = [
     endpoint: 'circleci',
     event_class: Events::CircleCiEvent),
   EventType.new(
-    name: 'CircleCI',
+    name: 'CircleCI (post test)',
     endpoint: 'circleci-manual',
     event_class: Events::CircleCiManualWebhookEvent),
   EventType.new(


### PR DESCRIPTION
There are now two ways to get build results from CircleCI.

1. As a webhook (new way)
1. As a post test command (old way)

Both options now show up in the Tokens page dropdown list for event source.

Related to https://github.com/FundingCircle/tech-playbook/pull/95