### PR TITLE
Handle inconsistent letter case for deploy event environments

### DIFF
--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -21,7 +21,7 @@ module Events
     end
 
     def environment
-      details.fetch('environment', heroku_environment)
+      details.fetch('environment', heroku_environment).try(:downcase)
     end
 
     private
@@ -32,7 +32,7 @@ module Events
 
     def app_name_extension
       return nil unless app_name
-      app_name.split('-').last
+      app_name.split('-').last.downcase
     end
 
     def servers

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Events::DeployEvent do
         expect(subject.environment).to eq('uat')
       end
 
+      context 'when the app name does not have the environment in lowercase' do
+        let(:payload) { { 'app' => 'nameless-forest-UAT' } }
+
+        it 'downcases the environment' do
+          expect(subject.environment).to eq('uat')
+        end
+      end
+
       context 'when the app name does not include the environment at the end' do
         let(:payload) { { 'app' => 'nameless-forest' } }
 
@@ -56,14 +64,16 @@ RSpec.describe Events::DeployEvent do
           'server' => 'uat.example.com',
           'version' => '123abc',
           'deployed_by' => 'bob',
+          'environment' => 'UAT',
         }
       }
 
-      it 'returns the correct values' do
+      it 'returns the correct downcased values' do
         expect(subject.app_name).to eq('someapp')
         expect(subject.server).to eq('uat.example.com')
         expect(subject.version).to eq('123abc')
         expect(subject.deployed_by).to eq('bob')
+        expect(subject.environment).to eq('uat')
       end
     end
   end


### PR DESCRIPTION
Ensures the environment of deploy events are correctly stored. Ideally we fix the casing at the source before the payload is sent, but this is a necessary fallback.

@FundingCircle/black-bat 