### PR TITLE
Multi region Releases page

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -4,6 +4,7 @@ class ReleasesController < ApplicationController
   end
 
   def show
+    redirect_to release_path(app_name, region: region) unless params[:region]
     projection = build_projection
     @pending_releases = projection.pending_releases
     @deployed_releases = projection.deployed_releases
@@ -18,12 +19,17 @@ class ReleasesController < ApplicationController
   def build_projection
     Queries::ReleasesQuery.new(
       per_page: 50,
+      region: region,
       git_repo: git_repository,
       app_name: app_name)
   end
 
   def app_name
     params[:id]
+  end
+
+  def region
+    params[:region] || Rails.configuration.default_deploy_region
   end
 
   def git_repository

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -4,6 +4,7 @@ class ReleasesController < ApplicationController
   end
 
   def show
+    update_cookies
     redirect_to release_path(app_name, region: region) unless params[:region]
     projection = build_projection
     @pending_releases = projection.pending_releases
@@ -29,7 +30,12 @@ class ReleasesController < ApplicationController
   end
 
   def region
-    params[:region] || Rails.configuration.default_deploy_region
+    cookies[:deploy_region]
+  end
+
+  def update_cookies
+    cookies.permanent[:deploy_region] ||= Rails.configuration.default_deploy_region
+    cookies.permanent[:deploy_region] = params[:region] if params[:region]
   end
 
   def git_repository

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -3,10 +3,11 @@ class Deploy
 
   values do
     attribute :app_name, String
-    attribute :server, String
-    attribute :version, String
-    attribute :deployed_by, String
     attribute :correct, Boolean
+    attribute :deployed_by, String
     attribute :event_created_at, DateTime
+    attribute :server, String
+    attribute :region, String
+    attribute :version, String
   end
 end

--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -25,9 +25,7 @@ module Events
     end
 
     def locale
-      # default value needed for older events without locale
-      # value is 'gb' and not 'uk' to comply with 'ISO 3166-1 alpha-2'
-      details.fetch('locale', 'gb')
+      details.fetch('locale', heroku_locale).try(:downcase) || Rails.configuration.default_deploy_locale
     end
 
     private
@@ -36,9 +34,18 @@ module Events
       app_name_extension if ENVIRONMENTS.include?(app_name_extension)
     end
 
+    def heroku_locale
+      app_name_prefix if Rails.configuration.available_deploy_regions.include?(app_name_prefix)
+    end
+
     def app_name_extension
       return nil unless app_name
       app_name.split('-').last.downcase
+    end
+
+    def app_name_prefix
+      return nil unless app_name
+      app_name.split('-').first.downcase
     end
 
     def servers

--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -24,6 +24,12 @@ module Events
       details.fetch('environment', heroku_environment).try(:downcase)
     end
 
+    def locale
+      # default value needed for older events without locale
+      # value is 'gb' and not 'uk' to comply with 'ISO 3166-1 alpha-2'
+      details.fetch('locale', 'gb')
+    end
+
     private
 
     def heroku_environment

--- a/app/models/queries/releases_query.rb
+++ b/app/models/queries/releases_query.rb
@@ -4,8 +4,9 @@ module Queries
   class ReleasesQuery
     attr_reader :pending_releases, :deployed_releases
 
-    def initialize(per_page:, git_repo:, app_name:)
+    def initialize(per_page:, region:, git_repo:, app_name:)
       @per_page = per_page
+      @region = region
       @git_repository = git_repo
       @app_name = app_name
 
@@ -28,7 +29,8 @@ module Queries
     attr_reader :app_name, :deploy_repository, :feature_review_factory, :git_repository, :ticket_repository
 
     def production_deploys
-      @production_deploys ||= deploy_repository.deploys_for_versions(versions, environment: 'production')
+      @production_deploys ||= deploy_repository
+                              .deploys_for_versions(versions, environment: 'production', region: @region)
     end
 
     def commits

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -13,10 +13,11 @@ module Repositories
       deploys(apps, server, at)
     end
 
-    def deploys_for_versions(versions, environment:)
+    def deploys_for_versions(versions, environment:, region:)
       query = store.select('DISTINCT ON (version) *')
       query = query.where(store.arel_table['version'].in(versions))
       query = query.where(environment: environment)
+      query = query.where(region: region)
       query.order('version, id DESC').map { |deploy_record|
         Deploy.new(deploy_record.attributes)
       }

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -33,6 +33,7 @@ module Repositories
       store.create!(
         app_name: event.app_name,
         server: event.server,
+        region: event.locale,
         environment: event.environment,
         version: event.version,
         deployed_by: event.deployed_by,

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,6 @@ module ShipmentTracker
     config.git_repository_cache_dir = Dir.tmpdir
     config.github_access_token = ENV['GITHUB_REPO_STATUS_ACCESS_TOKEN']
     config.data_maintenance_mode = ENV['DATA_MAINTENANCE'] == 'true'
+    config.default_deploy_region = ENV.fetch('DEFAULT_DEPLOY_REGION', 'gb')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,12 @@ module ShipmentTracker
     config.git_repository_cache_dir = Dir.tmpdir
     config.github_access_token = ENV['GITHUB_REPO_STATUS_ACCESS_TOKEN']
     config.data_maintenance_mode = ENV['DATA_MAINTENANCE'] == 'true'
+
+    # default value needed for older events without locale
+    # value is 'gb' and not 'uk' to comply with 'ISO 3166-1 alpha-2'
+    config.default_deploy_locale = ENV.fetch('DEFAULT_DEPLOY_LOCALE', 'gb')
+
     config.default_deploy_region = ENV.fetch('DEFAULT_DEPLOY_REGION', 'gb')
+    config.available_deploy_regions = ENV.fetch('available_deploy_region', %w(gb us))
   end
 end

--- a/db/migrate/20160209134817_add_region_to_deploys.rb
+++ b/db/migrate/20160209134817_add_region_to_deploys.rb
@@ -1,0 +1,5 @@
+class AddRegionToDeploys < ActiveRecord::Migration
+  def change
+    add_column :deploys, :region, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150930111438) do
+ActiveRecord::Schema.define(version: 20160209134817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20150930111438) do
     t.string   "deployed_by"
     t.datetime "event_created_at"
     t.string   "environment"
+    t.string   "region"
   end
 
   add_index "deploys", ["server", "app_name"], name: "index_deploys_on_server_and_app_name", using: :btree

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -50,6 +50,7 @@ Given 'commit "$version" of "$app" is deployed by "$name" to server "$server" at
     :deploy_event,
     server: server,
     app_name: app,
+    locale: 'gb',
     version: scenario_context.resolve_version(version),
     deployed_by: name,
   ).details
@@ -66,6 +67,7 @@ Given 'commit "$ver" of "$app" is deployed by "$name" to production at "$time"' 
     server: "#{app}.example.com",
     environment: 'production',
     app_name: app,
+    locale: 'gb',
     version: scenario_context.resolve_version(ver),
     deployed_by: name,
   ).details

--- a/spec/controllers/releases_controller_spec.rb
+++ b/spec/controllers/releases_controller_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ReleasesController do
       allow(GitRepositoryLocation).to receive(:github_url_for_app).with(app_name).and_return(github_url)
       allow(Queries::ReleasesQuery).to receive(:new).with(
         per_page: 50,
+        region: 'gb',
         git_repo: repository,
         app_name: app_name,
       ).and_return(releases_query)
@@ -50,7 +51,7 @@ RSpec.describe ReleasesController do
     end
 
     it 'shows the list of commits for an app' do
-      get :show, id: app_name
+      get :show, id: app_name, region: 'gb'
 
       expect(response).to have_http_status(:success)
       expect(assigns(:app_name)).to eq(app_name)
@@ -65,9 +66,17 @@ RSpec.describe ReleasesController do
       end
 
       it 'responds with a 404' do
-        get :show, id: 'hokus-pokus'
+        get :show, id: 'hokus-pokus', region: 'gp'
 
         expect(response).to be_not_found
+      end
+    end
+
+    context 'when no region is passed in' do
+      it 'redirects to region "gb"' do
+        get :show, id: app_name
+        expect(response).to have_http_status(:redirect)
+        expect(response.redirect_url).to eq('http://test.host/releases/frontend?region=gb')
       end
     end
   end

--- a/spec/factories/deploy_event.rb
+++ b/spec/factories/deploy_event.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
       server 'uat.example.com'
       sequence(:version) { |n| "abc#{n}" }
       app_name 'hello_world'
+      locale 'us'
       deployed_at { Time.now.utc.to_i }
       deployed_by 'frank@example.com'
       environment 'uat'
@@ -17,6 +18,7 @@ FactoryGirl.define do
         'server' => server,
         'version' => version,
         'app_name' => app_name,
+        'locale' => locale,
         'deployed_at' => deployed_at,
         'deployed_by' => deployed_by,
         'environment' => environment,

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -37,19 +37,25 @@ RSpec.describe Events::DeployEvent do
     context 'when the payload comes from Heroku' do
       let(:payload) {
         {
-          'app' => 'nameless-forest-uat',
+          'app' => 'us-nameless-forest-uat',
+          'app_uuid' => '8d1e4aff-eac8-4ced-90c8-bf97f8334a4c',
+          'git_log' => '',
+          'head' => '2beae04',
+          'head_long' => '2beae049a22c053883661771551f914d2d3de6e5',
+          'prev_head' => '7650eb713bcaae1e4c03637eae2e333fc4fb5a74',
+          'release' => 'v189',
+          'url' => 'http://us-nameless-forest-uat.herokuapp.com',
           'user' => 'user@example.com',
-          'url' => 'http://nameless-forest-uat.herokuapp.com',
-          'head_long' => '123abc',
         }
       }
 
       it 'returns the correct values' do
-        expect(subject.app_name).to eq('nameless-forest-uat')
-        expect(subject.server).to eq('http://nameless-forest-uat.herokuapp.com')
-        expect(subject.version).to eq('123abc')
+        expect(subject.app_name).to eq('us-nameless-forest-uat')
         expect(subject.deployed_by).to eq('user@example.com')
         expect(subject.environment).to eq('uat')
+        expect(subject.locale).to eq('us')
+        expect(subject.server).to eq('http://us-nameless-forest-uat.herokuapp.com')
+        expect(subject.version).to eq('2beae049a22c053883661771551f914d2d3de6e5')
       end
 
       context 'when the app name does not have the environment in lowercase' do
@@ -60,11 +66,27 @@ RSpec.describe Events::DeployEvent do
         end
       end
 
+      context 'when the app name does not have the locale prefix in lowercase' do
+        let(:payload) { { 'app' => 'US-nameless-forest-uat' } }
+
+        it 'downcases the environment' do
+          expect(subject.locale).to eq('us')
+        end
+      end
+
       context 'when the app name does not include the environment at the end' do
         let(:payload) { { 'app' => 'nameless-forest' } }
 
         it 'sets the environment to nil' do
           expect(subject.environment).to be nil
+        end
+      end
+
+      context 'when the app name does not include the locale prefix' do
+        let(:payload) { { 'app' => 'nameless-forest' } }
+
+        it 'sets the environment to nil' do
+          expect(subject.locale).to eq('gb')
         end
       end
     end

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -3,23 +3,35 @@ require 'rails_helper'
 RSpec.describe Events::DeployEvent do
   subject { Events::DeployEvent.new(details: payload) }
 
-  context 'when given a valid payload' do
-    let(:payload) {
-      {
-        'app_name' => 'soMeApp',
-        'servers' => ['prod1.example.com', 'prod2.example.com'],
-        'version' => '123abc',
-        'deployed_by' => 'bob',
-        'environment' => 'staging',
-      }
+  let(:payload) {
+    {
+      'app_name' => 'soMeApp',
+      'servers' => ['prod1.example.com', 'prod2.example.com'],
+      'version' => '123abc',
+      'deployed_by' => 'bob',
+      'locale' => 'us',
+      'environment' => 'staging',
     }
+  }
 
+  context 'when given a valid payload' do
     it 'returns the correct values' do
       expect(subject.app_name).to eq('someapp')
       expect(subject.server).to eq('prod1.example.com')
       expect(subject.version).to eq('123abc')
       expect(subject.deployed_by).to eq('bob')
       expect(subject.environment).to eq('staging')
+      expect(subject.locale).to eq('us')
+    end
+
+    context 'when the payload does not have locale' do
+      before do
+        payload.delete('locale')
+      end
+
+      it 'uses default locale "gb"' do
+        expect(subject.locale).to eq('gb')
+      end
     end
 
     context 'when the payload comes from Heroku' do

--- a/spec/models/queries/releases_query_spec.rb
+++ b/spec/models/queries/releases_query_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Queries::ReleasesQuery do
   subject(:releases_query) {
     Queries::ReleasesQuery.new(
       per_page: 50,
+      region: 'gb',
       git_repo: git_repository,
       app_name: app_name,
     )
@@ -55,7 +56,8 @@ RSpec.describe Queries::ReleasesQuery do
     allow(Repositories::DeployRepository).to receive(:new).and_return(deploy_repository)
     allow(Repositories::TicketRepository).to receive(:new).and_return(ticket_repository)
     allow(git_repository).to receive(:recent_commits_on_main_branch).with(50).and_return(commits)
-    allow(deploy_repository).to receive(:deploys_for_versions).with(versions, environment: 'production')
+    allow(deploy_repository).to receive(:deploys_for_versions)
+      .with(versions, environment: 'production', region: 'gb')
       .and_return(deploys)
     allow(ticket_repository).to receive(:tickets_for_versions).with(associated_versions)
       .and_return(tickets)
@@ -88,7 +90,7 @@ RSpec.describe Queries::ReleasesQuery do
 
   describe '#deployed_releases' do
     subject(:deployed_releases) { releases_query.deployed_releases }
-    it 'returns list of releases deployed to production' do
+    it 'returns list of releases deployed to production in region "gb"' do
       approved_feature_review = FeatureReview.new(
         versions: approved_ticket.versions,
         path: approved_ticket.paths.first,

--- a/spec/models/repositories/deploy_repository_spec.rb
+++ b/spec/models/repositories/deploy_repository_spec.rb
@@ -51,46 +51,43 @@ RSpec.describe Repositories::DeployRepository do
     let(:server) { 'uat.fundingcircle.com' }
 
     let(:defaults) {
-      { app_name: 'frontend', server: server, deployed_by: 'Bob', version: 'abc', region: 'gb' }
-    }
-    let(:defaults_evt) {
       { app_name: 'frontend', server: server, deployed_by: 'Bob', version: 'abc', locale: 'gb' }
     }
 
     it 'projects last deploy' do
-      repository.apply(build(:deploy_event, defaults_evt.merge(version: 'abc')))
+      repository.apply(build(:deploy_event, defaults.merge(version: 'abc')))
       results = repository.deploys_for(apps: apps, server: server)
       expect(results).to eq([Deploy.new(defaults.merge(version: 'abc', correct: true, region: 'gb'))])
 
-      repository.apply(build(:deploy_event, defaults_evt.merge(version: 'def')))
+      repository.apply(build(:deploy_event, defaults.merge(version: 'def')))
       results = repository.deploys_for(apps: apps, server: server)
       expect(results).to eq([Deploy.new(defaults.merge(version: 'def', correct: false, region: 'gb'))])
     end
 
     it 'is case insensitive when a repo name and the event app name do not match in case' do
-      repository.apply(build(:deploy_event, defaults_evt.merge(app_name: 'Frontend')))
+      repository.apply(build(:deploy_event, defaults.merge(app_name: 'Frontend')))
 
       results = repository.deploys_for(apps: apps, server: server)
       expect(results).to eq([Deploy.new(defaults.merge(app_name: 'frontend', correct: true, region: 'gb'))])
     end
 
     it 'ignores the deploys event when it is for another server' do
-      repository.apply(build(:deploy_event, defaults_evt.merge(server: 'other.fundingcircle.com')))
+      repository.apply(build(:deploy_event, defaults.merge(server: 'other.fundingcircle.com')))
 
       expect(repository.deploys_for(apps: apps, server: server)).to eq([])
     end
 
     it 'ignores the deploy event when it is for an app that is not under review' do
-      repository.apply(build(:deploy_event, defaults_evt.merge(app_name: 'irrelevant_app')))
+      repository.apply(build(:deploy_event, defaults.merge(app_name: 'irrelevant_app')))
 
       expect(repository.deploys_for(apps: apps, server: server)).to eq([])
     end
 
     it 'reports an incorrect version deployed to the UAT when event is for a different app version' do
-      repository.apply(build(:deploy_event, defaults_evt))
+      repository.apply(build(:deploy_event, defaults))
       expect(repository.deploys_for(apps: apps, server: server).map(&:correct)).to eq([true])
 
-      repository.apply(build(:deploy_event, defaults_evt.merge(version: 'def')))
+      repository.apply(build(:deploy_event, defaults.merge(version: 'def')))
       expect(repository.deploys_for(apps: apps, server: server).map(&:correct)).to eq([false])
     end
 
@@ -98,8 +95,8 @@ RSpec.describe Repositories::DeployRepository do
       let(:apps) { { 'frontend' => 'abc', 'backend' => 'abc' } }
 
       it 'returns multiple deploys' do
-        repository.apply(build(:deploy_event, defaults_evt.merge(app_name: 'frontend')))
-        repository.apply(build(:deploy_event, defaults_evt.merge(app_name: 'backend')))
+        repository.apply(build(:deploy_event, defaults.merge(app_name: 'frontend')))
+        repository.apply(build(:deploy_event, defaults.merge(app_name: 'backend')))
 
         expect(repository.deploys_for(apps: apps, server: server)).to match_array([
           Deploy.new(defaults.merge(app_name: 'frontend', correct: true, region: 'gb')),
@@ -168,7 +165,7 @@ RSpec.describe Repositories::DeployRepository do
   describe '#last_staging_deploy_for_version' do
     let(:version) { 'abc' }
     let(:defaults) { { app_name: 'frontend', deployed_by: 'Bob', region: 'de' } }
-    let(:defaults_evt) { { app_name: 'frontend', deployed_by: 'Bob', locale: 'de' } }
+    let(:defaults) { { app_name: 'frontend', deployed_by: 'Bob', locale: 'de' } }
 
     context 'when no deploy exist' do
       it 'returns nil' do
@@ -179,9 +176,9 @@ RSpec.describe Repositories::DeployRepository do
     context 'when no deploys exist for the version under review' do
       before do
         [
-          build(:deploy_event, defaults_evt.merge(server: 'a', environment: 'uat', version: 'def')),
-          build(:deploy_event, defaults_evt.merge(server: 'b', environment: 'uat', version: 'ghi')),
-          build(:deploy_event, defaults_evt.merge(server: 'c', environment: 'production', version: 'xyz')),
+          build(:deploy_event, defaults.merge(server: 'a', environment: 'uat', version: 'def')),
+          build(:deploy_event, defaults.merge(server: 'b', environment: 'uat', version: 'ghi')),
+          build(:deploy_event, defaults.merge(server: 'c', environment: 'production', version: 'xyz')),
         ].each do |deploy|
           repository.apply(deploy)
         end
@@ -195,10 +192,10 @@ RSpec.describe Repositories::DeployRepository do
     context 'when a deploy exists for the version under review' do
       before do
         [
-          build(:deploy_event, defaults_evt.merge(server: 'a', environment: 'uat', version: version)),
-          build(:deploy_event, defaults_evt.merge(server: 'b', environment: 'uat', version: version)),
-          build(:deploy_event, defaults_evt.merge(server: 'b', environment: 'uat', version: 'def')),
-          build(:deploy_event, defaults_evt.merge(server: 'c', environment: 'production', version: version)),
+          build(:deploy_event, defaults.merge(server: 'a', environment: 'uat', version: version)),
+          build(:deploy_event, defaults.merge(server: 'b', environment: 'uat', version: version)),
+          build(:deploy_event, defaults.merge(server: 'b', environment: 'uat', version: 'def')),
+          build(:deploy_event, defaults.merge(server: 'c', environment: 'production', version: version)),
         ].each do |deploy|
           repository.apply(deploy)
         end
@@ -212,7 +209,7 @@ RSpec.describe Repositories::DeployRepository do
 
       it 'looks for any non-production environments' do
         repository.apply(
-          build(:deploy_event, defaults_evt.merge(server: 'c', environment: 'staging', version: version)),
+          build(:deploy_event, defaults.merge(server: 'c', environment: 'staging', version: version)),
         )
 
         expect(repository.last_staging_deploy_for_version(version)).to eq(


### PR DESCRIPTION
Support displaying deploys for multiple Regions e.g. UK, US, CE.

When no filter is provided in query parameters, the default Region is UK, this is for backward compatibility.

Default locale for snapshots is set in environment variable DEFAULT_LOCALE given that older deploy events didn't have a locale assigned to it.

The selected locale/region is set in the cookie for better user experience.