### PR TITLE
set default heroku deploy locale

### DIFF
--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -25,7 +25,7 @@ module Events
     end
 
     def locale
-      details.fetch('locale', heroku_locale).try(:downcase) || Rails.configuration.default_deploy_locale
+      details.fetch('locale', heroku_locale).try(:downcase) || default_locale
     end
 
     private
@@ -36,6 +36,18 @@ module Events
 
     def heroku_locale
       app_name_prefix if Rails.configuration.available_deploy_regions.include?(app_name_prefix)
+    end
+
+    def default_locale
+      if deployed_to_heroku?
+        Rails.configuration.default_heroku_deploy_locale
+      else
+        Rails.configuration.default_deploy_locale
+      end
+    end
+
+    def deployed_to_heroku?
+      details.fetch('url', '').split('.')[-2] == 'herokuapp'
     end
 
     def app_name_extension

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,10 +42,14 @@ module ShipmentTracker
     config.data_maintenance_mode = ENV['DATA_MAINTENANCE'] == 'true'
 
     # default value needed for older events without locale
-    # value is 'gb' and not 'uk' to comply with 'ISO 3166-1 alpha-2'
     config.default_deploy_locale = ENV.fetch('DEFAULT_DEPLOY_LOCALE', 'gb')
 
+    # default value needed as not all heroku app names have the local as perfix
+    config.default_heroku_deploy_locale = ENV.fetch('DEFAULT_HEROKU_DEPLOY_LOCALE', 'us')
+
     config.default_deploy_region = ENV.fetch('DEFAULT_DEPLOY_REGION', 'gb')
+
+    # value is 'gb' and not 'uk' to comply with 'ISO 3166-1 alpha-2'
     config.available_deploy_regions = ENV.fetch('available_deploy_region', %w(gb us))
   end
 end

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -59,7 +59,9 @@ RSpec.describe Events::DeployEvent do
       end
 
       context 'when the app name does not have the environment in lowercase' do
-        let(:payload) { { 'app' => 'nameless-forest-UAT' } }
+        before do
+          payload['app'] = 'nameless-forest-UAT'
+        end
 
         it 'downcases the environment' do
           expect(subject.environment).to eq('uat')
@@ -67,15 +69,19 @@ RSpec.describe Events::DeployEvent do
       end
 
       context 'when the app name does not have the locale prefix in lowercase' do
-        let(:payload) { { 'app' => 'US-nameless-forest-uat' } }
+        before do
+          payload['app'] = 'GB-nameless-forest'
+        end
 
         it 'downcases the environment' do
-          expect(subject.locale).to eq('us')
+          expect(subject.locale).to eq('gb')
         end
       end
 
       context 'when the app name does not include the environment at the end' do
-        let(:payload) { { 'app' => 'nameless-forest' } }
+        before do
+          payload['app'] = 'nameless-forest'
+        end
 
         it 'sets the environment to nil' do
           expect(subject.environment).to be nil
@@ -83,10 +89,12 @@ RSpec.describe Events::DeployEvent do
       end
 
       context 'when the app name does not include the locale prefix' do
-        let(:payload) { { 'app' => 'nameless-forest' } }
+        before do
+          payload['app'] = 'nameless-forest'
+        end
 
         it 'sets the environment to nil' do
-          expect(subject.locale).to eq('gb')
+          expect(subject.locale).to eq('us')
         end
       end
     end


### PR DESCRIPTION
not all apps hosted on Heroku have the locale as name prefix. With this change we allowing it to be set ot a default locale with env var `DEFAULT_HEROKU_DEPLOY_LOCALE`, defaults to `us`. 