### PR TITLE
Feature Review requires reapproval

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Please make sure the following command runs every few minutes:
 bundle exec rake jobs:update_git
 ```
 
+This can be done with the cron job (via whenever gem) specified in [`config/schedule.rb`](config/schedule.rb).
+
 *Warning:* This recurring task should run on **every** server that your application is running on.
 
 ### Enable GitHub Webhooks

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -62,6 +62,15 @@ class FeatureReviewWithStatuses < SimpleDelegator
     end
   end
 
+  def authorised?
+    return false if tickets.empty?
+
+    tickets.each do |ticket|
+      return false if ticket.approved_at.nil? || ticket.approved_at < ticket.event_created_at
+    end
+    true
+  end
+
   def approved_at
     return unless approved?
     @approved_at ||= tickets.map(&:approved_at).max

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -67,7 +67,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def authorisation_status
-    return :not_approved unless approved?
+    return :not_approved unless tickets_approved?
 
     if authorised?
       :approved
@@ -77,11 +77,11 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def approved_at
-    return unless approved?
+    return unless tickets_approved?
     @approved_at ||= tickets.map(&:approved_at).max
   end
 
-  def approved?
+  def tickets_approved?
     @approved ||= tickets.present? && tickets.all?(&:approved?)
   end
 

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -63,7 +63,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def authorised?
-    @authorised ||= tickets.present? && tickets.all?(&:authorised?)
+    @authorised ||= tickets.present? && tickets.all? { |t| t.authorised?(versions) }
   end
 
   def authorisation_status
@@ -83,10 +83,6 @@ class FeatureReviewWithStatuses < SimpleDelegator
 
   def approved?
     @approved ||= tickets.present? && tickets.all?(&:approved?)
-  end
-
-  def approval_status
-    approved? ? :approved : :not_approved
   end
 
   def approved_path

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -76,7 +76,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
     end
   end
 
-  def approved_at
+  def tickets_approved_at
     return unless tickets_approved?
     @approved_at ||= tickets.map(&:approved_at).max
   end
@@ -86,6 +86,6 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def approved_path
-    "#{base_path}?#{query_hash.merge(time: approved_at.utc).to_query}" if authorised?
+    "#{base_path}?#{query_hash.merge(time: tickets_approved_at.utc).to_query}" if authorised?
   end
 end

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -90,6 +90,6 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def approved_path
-    "#{base_path}?#{query_hash.merge(time: approved_at.utc).to_query}" if approved?
+    "#{base_path}?#{query_hash.merge(time: approved_at.utc).to_query}" if authorised?
   end
 end

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -63,12 +63,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def authorised?
-    return false if tickets.empty?
-
-    tickets.each do |ticket|
-      return false if ticket.approved_at.nil? || ticket.approved_at < ticket.event_created_at
-    end
-    true
+    @authorised ||= tickets.present? && tickets.all?(&:authorised?)
   end
 
   def approved_at

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -66,6 +66,16 @@ class FeatureReviewWithStatuses < SimpleDelegator
     @authorised ||= tickets.present? && tickets.all?(&:authorised?)
   end
 
+  def authorisation_status
+    return :not_approved unless approved?
+
+    if authorised?
+      :approved
+    else
+      :requires_reapproval
+    end
+  end
+
   def approved_at
     return unless approved?
     @approved_at ||= tickets.map(&:approved_at).max

--- a/app/helpers/feature_reviews_helper.rb
+++ b/app/helpers/feature_reviews_helper.rb
@@ -45,7 +45,7 @@ module FeatureReviewsHelper
 
   def feature_status(feature_review)
     status = "Feature Status: #{feature_review.authorisation_status.to_s.humanize}"
-    status << " at #{feature_review.approved_at}" if feature_review.authorised?
+    status << " at #{feature_review.tickets_approved_at}" if feature_review.authorised?
     status
   end
 

--- a/app/helpers/feature_reviews_helper.rb
+++ b/app/helpers/feature_reviews_helper.rb
@@ -32,7 +32,7 @@ module FeatureReviewsHelper
     case status
     when true, :success, :approved
       'success'
-    when false, :failure, :not_approved
+    when false, :failure, :not_approved, :requires_reapproval
       'danger'
     else
       'warning'
@@ -44,8 +44,8 @@ module FeatureReviewsHelper
   end
 
   def feature_status(feature_review)
-    status = "Feature Status: #{feature_review.approval_status.to_s.humanize}"
-    status << " at #{feature_review.approved_at}" if feature_review.approved? && feature_review.approved_at
+    status = "Feature Status: #{feature_review.authorisation_status.to_s.humanize}"
+    status << " at #{feature_review.approved_at}" if feature_review.authorised? && feature_review.approved_at
     status
   end
 

--- a/app/helpers/feature_reviews_helper.rb
+++ b/app/helpers/feature_reviews_helper.rb
@@ -45,7 +45,7 @@ module FeatureReviewsHelper
 
   def feature_status(feature_review)
     status = "Feature Status: #{feature_review.authorisation_status.to_s.humanize}"
-    status << " at #{feature_review.approved_at}" if feature_review.authorised? && feature_review.approved_at
+    status << " at #{feature_review.approved_at}" if feature_review.authorised?
     status
   end
 

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -2,13 +2,13 @@ module ReleasesHelper
   def feature_review_link(feature_review)
     if feature_review.approved_path
       link_to(
-        feature_review.approval_status.to_s.humanize,
+        feature_review.authorisation_status.to_s.humanize,
         feature_review.approved_path,
         data: { toggle: 'tooltip' },
         title: 'View Feature Review at approval time',
       )
     else
-      link_to(feature_review.approval_status.to_s.humanize, feature_review.path)
+      link_to(feature_review.authorisation_status.to_s.humanize, feature_review.path)
     end
   end
 end

--- a/app/models/pull_request_status.rb
+++ b/app/models/pull_request_status.rb
@@ -96,11 +96,20 @@ class PullRequestStatus
   def status_for(feature_reviews)
     if feature_reviews.empty?
       not_found_status
-    elsif feature_reviews.any?(&:approved?)
+    elsif feature_reviews.any?(&:authorised?)
       approved_status
+    elsif feature_reviews.any?(&:approved?)
+      reapproval_status
     else
       not_approved_status
     end
+  end
+
+  def searching_status
+    {
+      status: 'pending',
+      description: 'Searching for Feature Review',
+    }
   end
 
   def not_found_status
@@ -117,17 +126,17 @@ class PullRequestStatus
     }
   end
 
+  def reapproval_status
+    {
+      status: 'pending',
+      description: 'Re-approval required for Feature Review',
+    }
+  end
+
   def not_approved_status
     {
       status: 'pending',
       description: 'Awaiting approval for Feature Review',
-    }
-  end
-
-  def searching_status
-    {
-      status: 'pending',
-      description: 'Searching for Feature Review',
     }
   end
 end

--- a/app/models/pull_request_status.rb
+++ b/app/models/pull_request_status.rb
@@ -98,7 +98,7 @@ class PullRequestStatus
       not_found_status
     elsif feature_reviews.any?(&:authorised?)
       approved_status
-    elsif feature_reviews.any?(&:approved?)
+    elsif feature_reviews.any?(&:tickets_approved?)
       reapproval_status
     else
       not_approved_status

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -15,7 +15,7 @@ class Release
     commit.id
   end
 
-  def approved?
-    feature_reviews.any?(&:approved?)
+  def authorised?
+    feature_reviews.any?(&:authorised?)
   end
 end

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -2,8 +2,6 @@ require 'events/jira_event'
 require 'snapshots/ticket'
 require 'ticket'
 
-require 'addressable/uri'
-
 module Repositories
   class TicketRepository
     def initialize(store = Snapshots::Ticket,

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -72,9 +72,9 @@ module Repositories
 
     def merge_version_timestamps(ticket, feature_reviews, event)
       old_version_timestamps = ticket.fetch('version_timestamps', {})
-      new_version_timestamps = feature_reviews.flat_map(&:versions).each_with_object({}) do |version, hash|
-                                 hash[version] = event.created_at
-                               end
+      new_version_timestamps = feature_reviews.flat_map(&:versions).each_with_object({}) { |version, hash|
+        hash[version] = event.created_at
+      }
       new_version_timestamps.merge!(old_version_timestamps)
     end
 

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -66,7 +66,16 @@ module Repositories
         'event_created_at' => event.created_at,
         'versions' => merge_ticket_versions(last_ticket, feature_reviews),
         'approved_at' => merge_approved_at(last_ticket, event),
+        'version_timestamps' => merge_version_timestamps(last_ticket, feature_reviews, event),
       )
+    end
+
+    def merge_version_timestamps(ticket, feature_reviews, event)
+      old_version_timestamps = ticket.fetch('version_timestamps', {})
+      new_version_timestamps = feature_reviews.flat_map(&:versions).each_with_object({}) do |version, hash|
+                                 hash[version] = event.created_at
+                               end
+      new_version_timestamps.merge!(old_version_timestamps)
     end
 
     def merge_ticket_paths(ticket, feature_reviews)

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -31,10 +31,6 @@ module Repositories
         .map { |t| Ticket.new(t.attributes) }
     end
 
-    def find_last_by_key(key)
-      store.where(key: key).order('id ASC').last
-    end
-
     def apply(event)
       return unless event.is_a?(Events::JiraEvent) && event.issue?
 

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -77,17 +77,13 @@ module Repositories
 
     def merge_ticket_versions(ticket, feature_reviews)
       old_versions = ticket.fetch('versions', [])
-      new_versions = feature_review_versions(feature_reviews)
+      new_versions = feature_reviews.flat_map(&:versions)
       old_versions.concat(new_versions).uniq
     end
 
     def merge_approved_at(last_ticket, event)
       return nil unless Ticket.new(status: event.status).approved?
       last_ticket['approved_at'] || event.created_at
-    end
-
-    def feature_review_versions(feature_reviews)
-      feature_reviews.flat_map(&:versions)
     end
 
     def update_pull_requests_for(ticket_hash)

--- a/app/models/snapshots/ticket.rb
+++ b/app/models/snapshots/ticket.rb
@@ -2,5 +2,6 @@ require 'active_record'
 
 module Snapshots
   class Ticket < ActiveRecord::Base
+    store_accessor :version_timestamps
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -9,17 +9,24 @@ class Ticket
     attribute :status, String, default: 'To Do'
     attribute :paths, Array, default: []
     attribute :approved_at, DateTime
-    attribute :event_created_at, DateTime
     attribute :version_timestamps, Hash[String => DateTime]
     attribute :versions, Array, default: []
+  end
+
+  # TODO: test
+  def authorisation_status(versions_under_review)
+    return 'Requires reapproval' if approved? && !authorised?(versions_under_review)
+    status
   end
 
   def approved?
     Rails.application.config.approved_statuses.include?(status)
   end
 
-  def authorised?
+  def authorised?(versions_under_review)
     return false if approved_at.nil?
-    approved_at < event_created_at
+    linked_at = versions_under_review.map { |v| version_timestamps[v] }.compact.min
+    return false if linked_at.nil?
+    approved_at >= linked_at
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -10,6 +10,7 @@ class Ticket
     attribute :paths, Array, default: []
     attribute :approved_at, DateTime
     attribute :event_created_at, DateTime
+    attribute :version_timestamps, Hash[String => DateTime]
     attribute :versions, Array, default: []
   end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -16,4 +16,9 @@ class Ticket
   def approved?
     Rails.application.config.approved_statuses.include?(status)
   end
+
+  def authorised?
+    return false if approved_at.nil?
+    approved_at < event_created_at
+  end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -9,6 +9,7 @@ class Ticket
     attribute :status, String, default: 'To Do'
     attribute :paths, Array, default: []
     attribute :approved_at, DateTime
+    attribute :event_created_at, DateTime
     attribute :versions, Array, default: []
   end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -13,7 +13,6 @@ class Ticket
     attribute :versions, Array, default: []
   end
 
-  # TODO: test
   def authorisation_status(versions_under_review)
     return 'Requires reapproval' if approved? && !authorised?(versions_under_review)
     status

--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -9,7 +9,7 @@
 
 .row
   .col-lg-12
-    - panel(heading: feature_status(@feature_review_with_statuses), status: @feature_review_with_statuses.approval_status, klass: 'feature-status', help_url: wiki_links(:approve), align_right: true) do
+    - panel(heading: feature_status(@feature_review_with_statuses), status: @feature_review_with_statuses.authorisation_status, klass: 'feature-status', help_url: wiki_links(:approve), align_right: true) do
       - if @feature_review_with_statuses.tickets.empty?
         .panel-body
           No tickets found
@@ -21,8 +21,8 @@
               %td= jira_link(ticket.key)
               %td= ticket.summary
               %td
-                - icon(item_status_icon_class(ticket.approved?))
-                = ticket.status
+                - icon(item_status_icon_class(ticket.authorised?(@feature_review_with_statuses.versions)))
+                = ticket.authorisation_status(@feature_review_with_statuses.versions)
 
 .row
   .col-lg-6

--- a/app/views/releases/show.html.haml
+++ b/app/views/releases/show.html.haml
@@ -20,7 +20,7 @@
       %th{width: '35%'} feature reviews
   %tbody
   - @pending_releases.each do |release|
-    %tr.pending-release{class: ('danger' unless release.approved?)}
+    %tr.pending-release{class: ('danger' unless release.authorised?)}
       %td.monospace= commit_link(release.version, @github_repo_url)
       %td= pull_request_link(release.subject, @github_repo_url).html_safe
       %td
@@ -38,7 +38,7 @@
       %th{width: '20%'} last deployed at
   %tbody
   - @deployed_releases.each do |release|
-    %tr.deployed-release{class: ('danger' unless release.approved?)}
+    %tr.deployed-release{class: ('danger' unless release.authorised?)}
       %td.monospace= commit_link(release.version, @github_repo_url)
       %td= pull_request_link(release.subject, @github_repo_url).html_safe
       %td

--- a/db/migrate/20160212113505_add_version_timestamps_to_tickets.rb
+++ b/db/migrate/20160212113505_add_version_timestamps_to_tickets.rb
@@ -1,0 +1,6 @@
+class AddVersionTimestampsToTickets < ActiveRecord::Migration
+  def change
+    enable_extension 'hstore'
+    add_column :tickets, :version_timestamps, :hstore, default: '', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160209134817) do
+ActiveRecord::Schema.define(version: 20160212113505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "builds", force: :cascade do |t|
     t.string   "version"
@@ -90,10 +91,11 @@ ActiveRecord::Schema.define(version: 20160209134817) do
     t.string   "key"
     t.string   "summary"
     t.string   "status"
-    t.text     "paths",            array: true
+    t.text     "paths",                                        array: true
     t.datetime "event_created_at"
-    t.string   "versions",         array: true
+    t.string   "versions",                                     array: true
     t.datetime "approved_at"
+    t.hstore   "version_timestamps", default: {}, null: false
   end
 
   add_index "tickets", ["key"], name: "index_tickets_on_key", using: :btree

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -152,31 +152,31 @@ Scenario: Viewing a Feature Review as at a specified time
 
   And I should see the time "2014-10-04 14:00:00" for the Feature Review
 
-  @logged_in
-  Scenario: Viewing an approved Feature Review after regenerating snapshots
-    Given an application called "frontend"
+@logged_in
+Scenario: Viewing an approved Feature Review after regenerating snapshots
+  Given an application called "frontend"
 
-    And a ticket "JIRA-123" with summary "Urgent ticket" is started at "2014-10-04 13:00:00"
-    And a commit "#abc" by "Alice" is created at "2014-10-04 13:05:00" for app "frontend"
-    And developer prepares review known as "FR_123" for UAT "uat.fundingcircle.com" with apps
-      | app_name | version |
-      | frontend | #abc    |
-    And at time "2014-10-04 14:00:00.500" adds link for review "FR_123" to comment for ticket "JIRA-123"
-    And ticket "JIRA-123" is approved by "jim@fundingcircle.com" at "2014-10-05 17:30:10"
+  And a ticket "JIRA-123" with summary "Urgent ticket" is started at "2014-10-04 13:00:00"
+  And a commit "#abc" by "Alice" is created at "2014-10-04 13:05:00" for app "frontend"
+  And developer prepares review known as "FR_123" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version |
+    | frontend | #abc    |
+  And at time "2014-10-04 14:00:00.500" adds link for review "FR_123" to comment for ticket "JIRA-123"
+  And ticket "JIRA-123" is approved by "jim@fundingcircle.com" at "2014-10-05 17:30:10"
 
-    And snapshots are regenerated
+  And snapshots are regenerated
 
-    When I visit feature review "FR_123" as at "2014-10-04 15:00:00"
-    Then I should see that the Feature Review was not approved
-    Then I should only see the ticket
-      | Ticket                                        | Summary       | Status      |
-      | [JIRA-123](https://jira.test/browse/JIRA-123) | Urgent ticket | In Progress |
+  When I visit feature review "FR_123" as at "2014-10-04 15:00:00"
+  Then I should see that the Feature Review was not approved
+  Then I should only see the ticket
+    | Ticket                                        | Summary       | Status      |
+    | [JIRA-123](https://jira.test/browse/JIRA-123) | Urgent ticket | In Progress |
 
-    When I visit feature review "FR_123" as at "2014-10-06 10:00:00"
-    Then I should see that the Feature Review was approved at "2014-10-05 17:30:10"
-    And I should only see the ticket
-      | Ticket                                        | Summary       | Status               |
-      | [JIRA-123](https://jira.test/browse/JIRA-123) | Urgent ticket | Ready for Deployment |
+  When I visit feature review "FR_123" as at "2014-10-06 10:00:00"
+  Then I should see that the Feature Review was approved at "2014-10-05 17:30:10"
+  And I should only see the ticket
+    | Ticket                                        | Summary       | Status               |
+    | [JIRA-123](https://jira.test/browse/JIRA-123) | Urgent ticket | Ready for Deployment |
 
 
 Scenario: QA rejects feature

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -111,7 +111,7 @@ Scenario: Viewing a Feature Review
 
   Then I should see that the Feature Review was approved at "2014-10-05 17:30:10"
 
-  And I should only see the ticket
+  And I should see the tickets
     | Ticket                                        | Summary       | Status               |
     | [JIRA-123](https://jira.test/browse/JIRA-123) | Urgent ticket | Ready for Deployment |
 
@@ -134,6 +134,36 @@ Scenario: Viewing a Feature Review
     | backend  | #old    | no      |
 
 @logged_in
+Scenario: Viewing a Feature Review that requires re-approval
+  Given an application called "frontend"
+
+  And a ticket "JIRA-1" with summary "Some work" is started at "2014-10-11 13:01:17"
+  And a ticket "JIRA-2" with summary "More work" is started at "2014-10-11 15:10:27"
+
+  And a commit "#abc" by "Alice" is created at "2014-10-12 11:01:00" for app "frontend"
+  And a commit "#def" by "Alice" is created at "2014-10-13 12:02:00" for app "frontend"
+
+  And ticket "JIRA-1" is approved by "jim@fundingcircle.com" at "2014-10-13 17:30:10"
+
+  And developer prepares review known as "FR" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version |
+    | frontend | #abc    |
+
+  And at time "2014-10-14 16:00:01" adds link for review "FR" to comment for ticket "JIRA-1"
+  And at time "2014-10-14 17:00:01" adds link for review "FR" to comment for ticket "JIRA-2"
+
+  And ticket "JIRA-2" is approved by "jim@fundingcircle.com" at "2014-10-14 17:30:10"
+
+  When I visit the feature review known as "FR"
+
+  Then I should see that the Feature Review requires reapproval
+
+  And I should see the tickets
+    | Ticket                                    | Summary   | Status               |
+    | [JIRA-1](https://jira.test/browse/JIRA-1) | Some work | Requires reapproval  |
+    | [JIRA-2](https://jira.test/browse/JIRA-2) | More work | Ready for Deployment |
+
+@logged_in
 Scenario: Viewing a Feature Review as at a specified time
   Given an application called "frontend"
 
@@ -146,7 +176,7 @@ Scenario: Viewing a Feature Review as at a specified time
 
   When I visit feature review "FR_123" as at "2014-10-04 14:00:00"
 
-  Then I should only see the ticket
+  Then I should see the tickets
     | Ticket                                        | Summary       | Status      |
     | [JIRA-123](https://jira.test/browse/JIRA-123) | Urgent ticket | In Progress |
 
@@ -168,13 +198,13 @@ Scenario: Viewing an approved Feature Review after regenerating snapshots
 
   When I visit feature review "FR_123" as at "2014-10-04 15:00:00"
   Then I should see that the Feature Review was not approved
-  Then I should only see the ticket
+  Then I should see the tickets
     | Ticket                                        | Summary       | Status      |
     | [JIRA-123](https://jira.test/browse/JIRA-123) | Urgent ticket | In Progress |
 
   When I visit feature review "FR_123" as at "2014-10-06 10:00:00"
   Then I should see that the Feature Review was approved at "2014-10-05 17:30:10"
-  And I should only see the ticket
+  And I should see the tickets
     | Ticket                                        | Summary       | Status               |
     | [JIRA-123](https://jira.test/browse/JIRA-123) | Urgent ticket | Ready for Deployment |
 

--- a/features/releases.feature
+++ b/features/releases.feature
@@ -83,3 +83,20 @@ Scenario: Viewing releases for an app
     | [#merge1](https://github.com/...)  | Merge feature1 into master | FR_ONE          | Not approved          |                       | no       | 2014-10-01 17:34 |
     | [#master2](https://github.com/...) | historic commit            |                 |                       |                       | no       |                  |
     | [#master1](https://github.com/...) | initial commit             |                 |                       |                       | no       | 2014-09-28 11:37 |
+
+
+Scenario: Release requires re-approval
+  Given an application called "frontend"
+  And a commit "#master1" with message "merge commit" is created at "2016-01-17 10:20:45"
+  And a ticket "JIRA-ONE" with summary "Ticket ONE" is started at "2016-01-18 09:13:00"
+  And ticket "JIRA-ONE" is approved by "bob@fundingcircle.com" at "2016-01-19 15:20:34"
+  And developer prepares review known as "FR_ONE" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version  |
+    | frontend | #master1 |
+  And at time "2016-01-20 14:52:45" adds link for review "FR_ONE" to comment for ticket "JIRA-ONE"
+
+  When I view the releases for "frontend"
+
+  Then I should see the "pending" releases
+    | version                            | subject      | feature reviews | review statuses     | review times | approved |
+    | [#master1](https://github.com/...) | merge commit | FR_ONE          | Requires reapproval |              | no       |

--- a/features/step_definitions/feature_review_steps.rb
+++ b/features/step_definitions/feature_review_steps.rb
@@ -58,7 +58,7 @@ Then 'I should see the deploys to UAT with heading "$status" and content' do |st
   expect(feature_review_page.deploys).to match_array(expected_deploys)
 end
 
-Then 'I should only see the ticket' do |ticket_table|
+Then 'I should see the tickets' do |ticket_table|
   expected_tickets = ticket_table.hashes
   expect(feature_review_page.tickets).to match_array(expected_tickets)
 end
@@ -117,6 +117,10 @@ end
 
 Then 'I should see that the Feature Review was not approved' do
   expect(feature_review_page.feature_status).to eq('Feature Status: Not approved')
+end
+
+Then 'I should see that the Feature Review requires reapproval' do
+  expect(feature_review_page.feature_status).to eq('Feature Status: Requires reapproval')
 end
 
 When 'I reload the page after a while' do

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -97,11 +97,14 @@ module Support
 
     def approve_ticket(jira_key:, approver_email:, approve:, time: nil)
       ticket_details = @tickets.fetch(jira_key).except(:status, :comment_body)
+      ticket_details.merge!(user_email: approver_email, updated: time)
       event = build(
         :jira_event,
         approve ? :approved : :rejected,
-        ticket_details.merge!(user_email: approver_email, updated: time),
+        ticket_details,
       )
+      @tickets[jira_key] = ticket_details.merge(status: event.status)
+
       @stubbed_requests['success'] = stub_request(:post, %r{https://api.github.com/.*})
                                      .with(body: /"state":"success"/)
                                      .and_return(status: 201)

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -97,7 +97,8 @@ module Support
 
     def approve_ticket(jira_key:, approver_email:, approve:, time: nil)
       ticket_details = @tickets.fetch(jira_key).except(:status, :comment_body)
-      ticket_details.merge!(user_email: approver_email, updated: time)
+      ticket_details[:user_email] = approver_email
+      ticket_details[:updated] = time
       event = build(
         :jira_event,
         approve ? :approved : :rejected,

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -233,6 +233,47 @@ RSpec.describe FeatureReviewWithStatuses do
     end
   end
 
+  describe '#authorised?' do
+    subject { FeatureReviewWithStatuses.new(feature_review, tickets: tickets).authorised? }
+    let(:current_time) { Time.current }
+
+    context 'when there are no tickets' do
+      let(:tickets) { [] }
+      it { is_expected.to be false }
+    end
+
+    context 'when all tickets were approved after they were linked' do
+      let(:tickets) {
+        [
+          instance_double(Ticket, approved_at: current_time, event_created_at: current_time),
+          instance_double(Ticket, approved_at: current_time, event_created_at: 1.hour.ago),
+        ]
+      }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when at least one ticket was approved before it was linked' do
+      let(:tickets) {
+        [
+          instance_double(Ticket, approved_at: current_time, event_created_at: current_time),
+          instance_double(Ticket, approved_at: 1.hour.ago, event_created_at: current_time),
+        ]
+      }
+      it { is_expected.to be false }
+    end
+
+    context 'when at least one ticket is not yet approved' do
+      let(:tickets) {
+        [
+          instance_double(Ticket, approved_at: nil, event_created_at: 1.hour.ago),
+          instance_double(Ticket, approved_at: current_time, event_created_at: 1.hour.ago)
+        ]
+      }
+      it { is_expected.to be false}
+    end
+  end
+
   describe 'approval' do
     subject(:decorator) { FeatureReviewWithStatuses.new(feature_review, tickets: tickets) }
 

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -303,8 +303,8 @@ RSpec.describe FeatureReviewWithStatuses do
     end
   end
 
-  describe '#approved_at' do
-    subject { FeatureReviewWithStatuses.new(feature_review, tickets: tickets).approved_at }
+  describe '#tickets_approved_at' do
+    subject { FeatureReviewWithStatuses.new(feature_review, tickets: tickets).tickets_approved_at }
 
     let(:approval_time) { Time.current }
 

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe FeatureReviewWithStatuses do
   let(:apps) { { 'app1' => 'xxx', 'app2' => 'yyy' } }
 
   let(:uat_url) { 'http://uat.com' }
-  let(:feature_review) { instance_double(FeatureReview, uat_url: uat_url, app_versions: apps) }
+  let(:feature_review) {
+    instance_double(FeatureReview, uat_url: uat_url, app_versions: apps, versions: apps.values)
+  }
   let(:query_time) { Time.parse('2014-08-10 14:40:48 UTC') }
 
   subject(:decorator) {
@@ -363,24 +365,6 @@ RSpec.describe FeatureReviewWithStatuses do
       end
     end
 
-    describe '#approval_status' do
-      context 'when feature review is approved' do
-        let(:tickets) { [instance_double(Ticket, approved?: true)] }
-
-        it 'returns :approved' do
-          expect(decorator.approval_status).to be :approved
-        end
-      end
-
-      context 'when feature review is not approved' do
-        let(:tickets) { [instance_double(Ticket, approved?: false)] }
-
-        it 'returns :not_approved' do
-          expect(subject.approval_status).to be :not_approved
-        end
-      end
-    end
-
     describe '#approved_path' do
       let(:feature_review) {
         instance_double(
@@ -388,15 +372,16 @@ RSpec.describe FeatureReviewWithStatuses do
           base_path: '/something',
           query_hash: { 'apps' => apps, 'uat_url' => 'http://uat.com' },
           app_versions: apps,
+          versions: apps.values,
         )
       }
 
-      context 'feature review is approved' do
+      context 'when Feature Review is authorised' do
         let(:approval_time) { Time.parse('2013-09-05 14:56:52 UTC') }
         let(:tickets) {
           [
-            instance_double(Ticket, approved?: true, approved_at: approval_time),
-            instance_double(Ticket, approved?: true, approved_at: approval_time - 1.hour),
+            instance_double(Ticket, authorised?: true, approved?: true, approved_at: approval_time),
+            instance_double(Ticket, authorised?: true, approved?: true, approved_at: approval_time - 1.hour),
           ]
         }
 
@@ -410,7 +395,7 @@ RSpec.describe FeatureReviewWithStatuses do
       end
 
       context 'feature review is not approved' do
-        let(:tickets) { [instance_double(Ticket, approved?: false)] }
+        let(:tickets) { [instance_double(Ticket, authorised?: false)] }
 
         it 'returns nil' do
           expect(subject.approved_path).to be_nil

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -235,42 +235,31 @@ RSpec.describe FeatureReviewWithStatuses do
 
   describe '#authorised?' do
     subject { FeatureReviewWithStatuses.new(feature_review, tickets: tickets).authorised? }
-    let(:current_time) { Time.current }
 
     context 'when there are no tickets' do
       let(:tickets) { [] }
       it { is_expected.to be false }
     end
 
-    context 'when all tickets were approved after they were linked' do
+    context 'when all tickets are authorised' do
       let(:tickets) {
         [
-          instance_double(Ticket, approved_at: current_time, event_created_at: current_time),
-          instance_double(Ticket, approved_at: current_time, event_created_at: 1.hour.ago),
+          instance_double(Ticket, authorised?: true),
+          instance_double(Ticket, authorised?: true),
         ]
       }
 
       it { is_expected.to be true }
     end
 
-    context 'when at least one ticket was approved before it was linked' do
+    context 'when at least one ticket is unauthorised' do
       let(:tickets) {
         [
-          instance_double(Ticket, approved_at: current_time, event_created_at: current_time),
-          instance_double(Ticket, approved_at: 1.hour.ago, event_created_at: current_time),
+          instance_double(Ticket, authorised?: false),
+          instance_double(Ticket, authorised?: true),
         ]
       }
       it { is_expected.to be false }
-    end
-
-    context 'when at least one ticket is not yet approved' do
-      let(:tickets) {
-        [
-          instance_double(Ticket, approved_at: nil, event_created_at: 1.hour.ago),
-          instance_double(Ticket, approved_at: current_time, event_created_at: 1.hour.ago)
-        ]
-      }
-      it { is_expected.to be false}
     end
   end
 

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe FeatureReviewWithStatuses do
   context 'when initialized without builds, deploys, qa_submission, tickets, uatest and time' do
     let(:decorator) { described_class.new(feature_review) }
 
-    it 'returns default values for #builds, #deploy,s #qa_submission, #tickets, #uatest and #time' do
+    it 'returns default values for #builds, #deploys, #qa_submission, #tickets, #uatest and #time' do
       expect(decorator.builds).to eq({})
       expect(decorator.deploys).to eq([])
       expect(decorator.qa_submission).to eq(nil)
@@ -60,7 +60,7 @@ RSpec.describe FeatureReviewWithStatuses do
       allow(GitRepositoryLocation).to receive(:github_urls_for_apps).with(app_names).and_return(github_urls)
     end
 
-    it 'returs the repo URLs for the apps under review' do
+    it 'returns the repo URLs for the apps under review' do
       expect(decorator.github_repo_urls).to eq(github_urls)
     end
   end
@@ -236,7 +236,7 @@ RSpec.describe FeatureReviewWithStatuses do
   describe 'approval' do
     subject(:decorator) { FeatureReviewWithStatuses.new(feature_review, tickets: tickets) }
 
-    describe 'approved_at' do
+    describe '#approved_at' do
       let(:approval_time) { Time.current }
       let(:tickets) {
         [

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -248,7 +248,6 @@ RSpec.describe FeatureReviewWithStatuses do
           instance_double(Ticket, authorised?: true),
         ]
       }
-
       it { is_expected.to be true }
     end
 
@@ -260,6 +259,45 @@ RSpec.describe FeatureReviewWithStatuses do
         ]
       }
       it { is_expected.to be false }
+    end
+  end
+
+  describe '#authorisation_status' do
+    subject { FeatureReviewWithStatuses.new(feature_review, tickets: tickets).authorisation_status }
+
+    context 'when there are no associated tickets' do
+      let(:tickets) { [] }
+      it { is_expected.to be :not_approved }
+    end
+
+    context 'when any associated tickets are not approved' do
+      let(:tickets) {
+        [
+          instance_double(Ticket, approved?: false),
+          instance_double(Ticket, approved?: true),
+        ]
+      }
+      it { is_expected.to be :not_approved }
+    end
+
+    context 'when all associated tickets are approved after Feature Review offered' do
+      let(:tickets) {
+        [
+          instance_double(Ticket, approved?: true, authorised?: true),
+          instance_double(Ticket, approved?: true, authorised?: true),
+        ]
+      }
+      it { is_expected.to be :approved }
+    end
+
+    context 'when any associated tickets are approved before Feature Review offered' do
+      let(:tickets) {
+        [
+          instance_double(Ticket, approved?: true, authorised?: true),
+          instance_double(Ticket, approved?: true, authorised?: false),
+        ]
+      }
+      it { is_expected.to be :requires_reapproval }
     end
   end
 

--- a/spec/models/queries/releases_query_spec.rb
+++ b/spec/models/queries/releases_query_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Queries::ReleasesQuery do
       expect(deployed_releases.map(&:deployed_by)).to eq(['auser', nil])
       expect(deployed_releases.map(&:authorised?)).to eq([true, false])
       expect(deployed_releases.map(&:feature_reviews)).to eq([[authorised_feature_review], []])
-      expect(deployed_releases.map(&:feature_reviews).flatten.first.approved_at).to eq(approval_time)
+      expect(deployed_releases.map(&:feature_reviews).flatten.first.tickets_approved_at).to eq(approval_time)
     end
   end
 end

--- a/spec/models/queries/releases_query_spec.rb
+++ b/spec/models/queries/releases_query_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Queries::ReleasesQuery do
       paths: ['/feature_reviews?apps%5Bapp1%5D=xyz&apps%5Bapp2%5D=uvw'],
       status: 'Done',
       approved_at: approval_time,
+      version_timestamps: { 'xyz' => approval_time - 1.hour, 'uvw' => approval_time - 1.hour },
     )
   }
   let(:not_approved_ticket) {

--- a/spec/models/queries/releases_query_spec.rb
+++ b/spec/models/queries/releases_query_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Queries::ReleasesQuery do
   describe '#pending_releases' do
     subject(:pending_releases) { releases_query.pending_releases }
     it 'returns list of releases not yet deployed to production' do
-      not_approved_feature_review = FeatureReview.new(
+      not_authorised_feature_review = FeatureReview.new(
         versions: not_approved_ticket.versions,
         path: not_approved_ticket.paths.first,
       )
@@ -82,16 +82,16 @@ RSpec.describe Queries::ReleasesQuery do
       expect(pending_releases.map(&:subject)).to eq(['new commit on master'])
       expect(pending_releases.map(&:production_deploy_time)).to eq([nil])
       expect(pending_releases.map(&:deployed_by)).to eq([nil])
-      expect(pending_releases.map(&:approved?)).to eq([false])
-      expect(pending_releases.map(&:feature_reviews)).to eq([[not_approved_feature_review]])
-      expect(pending_releases.map(&:feature_reviews).flatten.first.approved?).to eq(false)
+      expect(pending_releases.map(&:authorised?)).to eq([false])
+      expect(pending_releases.map(&:feature_reviews)).to eq([[not_authorised_feature_review]])
+      expect(pending_releases.map(&:feature_reviews).flatten.first.authorised?).to eq(false)
     end
   end
 
   describe '#deployed_releases' do
     subject(:deployed_releases) { releases_query.deployed_releases }
     it 'returns list of releases deployed to production in region "gb"' do
-      approved_feature_review = FeatureReview.new(
+      authorised_feature_review = FeatureReview.new(
         versions: approved_ticket.versions,
         path: approved_ticket.paths.first,
       )
@@ -100,8 +100,8 @@ RSpec.describe Queries::ReleasesQuery do
       expect(deployed_releases.map(&:subject)).to eq(['merge commit', 'first commit on master branch'])
       expect(deployed_releases.map(&:production_deploy_time)).to eq([deploy_time, nil])
       expect(deployed_releases.map(&:deployed_by)).to eq(['auser', nil])
-      expect(deployed_releases.map(&:approved?)).to eq([true, false])
-      expect(deployed_releases.map(&:feature_reviews)).to eq([[approved_feature_review], []])
+      expect(deployed_releases.map(&:authorised?)).to eq([true, false])
+      expect(deployed_releases.map(&:feature_reviews)).to eq([[authorised_feature_review], []])
       expect(deployed_releases.map(&:feature_reviews).flatten.first.approved_at).to eq(approval_time)
     end
   end

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe Release do
     end
   end
 
-  describe '#approved?' do
+  describe '#authorised?' do
     subject(:release) { Release.new(feature_reviews: feature_reviews) }
 
-    it 'returns true if any of its feature reviews are approved' do
-      allow(feature_review1).to receive(:approved?).and_return(true)
-      allow(feature_review2).to receive(:approved?).and_return(false)
-      expect(release.approved?).to be true
+    it 'returns true if any of its feature reviews are authorised' do
+      allow(feature_review1).to receive(:authorised?).and_return(true)
+      allow(feature_review2).to receive(:authorised?).and_return(false)
+      expect(release.authorised?).to be true
     end
 
-    it 'returns false if none of its feature reviews are approved' do
-      allow(feature_review1).to receive(:approved?).and_return(false)
-      allow(feature_review2).to receive(:approved?).and_return(false)
-      expect(release.approved?).to be false
+    it 'returns false if none of its feature reviews are authorised' do
+      allow(feature_review1).to receive(:authorised?).and_return(false)
+      allow(feature_review2).to receive(:authorised?).and_return(false)
+      expect(release.authorised?).to be false
     end
   end
 end

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -399,21 +399,4 @@ RSpec.describe Repositories::TicketRepository do
       end
     end
   end
-
-  describe '#find_last_by_key' do
-    let!(:tickets) {
-      [
-        Snapshots::Ticket.create(key: '1', summary: 'first'),
-        Snapshots::Ticket.create(key: '2', summary: 'second'),
-        Snapshots::Ticket.create(key: '1', summary: 'fourth'),
-        Snapshots::Ticket.create(key: '3', summary: 'third'),
-      ]
-    }
-
-    context 'when key is specified' do
-      it 'returns the last snapshot with that key' do
-        expect(subject.find_last_by_key('1')).to eq(tickets[2])
-      end
-    end
-  end
 end

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -193,8 +193,9 @@ RSpec.describe Repositories::TicketRepository do
       ])
     end
 
-    it 'ignores non JIRA issue events' do
-      expect { repository.apply(build(:jira_event_user_created)) }.to_not raise_error
+    it 'ignores events that are not JIRA issues' do
+      store = repository.instance_variable_get(:@store)
+      expect { repository.apply(build(:jira_event_user_created)) }.to_not change { store.count }
     end
 
     context 'when multiple feature reviews are referenced in the same JIRA ticket' do

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Repositories::TicketRepository do
       expect(results).to eq([Ticket.new(ticket_1.merge(status: 'In Progress', approved_at: nil))])
     end
 
-    it 'projects the tickets referenced in JIRA comments' do
+    it 'snapshots tickets linked to a Feature Review' do
       jira_1 = { key: 'JIRA-1', summary: 'Ticket 1' }
       jira_4 = { key: 'JIRA-4', summary: 'Ticket 4' }
       ticket_1 = jira_1.merge(ticket_defaults)
@@ -173,19 +173,15 @@ RSpec.describe Repositories::TicketRepository do
       [
         build(:jira_event, :created, jira_1),
         build(:jira_event, :started, jira_1),
-        build(:jira_event, :development_completed, jira_1.merge(comment_body: "Review #{url}")),
+        build(:jira_event, :development_completed, jira_1.merge(comment_body: "Please review #{url}")),
 
         build(:jira_event, :created, key: 'JIRA-2'),
-        build(
-          :jira_event,
-          :created,
-          key: 'JIRA-3',
-          comment_body: 'Review http://example.com/feature_reviews/extra/stuff',
-        ),
+        build(:jira_event, :created, key: 'JIRA-3', comment_body: 'http://example.com/feature_reviews/fake'),
 
         build(:jira_event, :created, jira_4),
         build(:jira_event, :started, jira_4),
-        build(:jira_event, :development_completed, jira_4.merge(comment_body: "#{url} is ready!")),
+        build(:jira_event, :development_completed, jira_4.merge(comment_body: url)),
+
         build(:jira_event, :deployed, jira_1.merge(created_at: approval_time)),
       ].each do |event|
         repository.apply(event)

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -20,26 +20,41 @@ RSpec.describe Ticket do
   end
 
   describe '#authorised?' do
-    subject { ticket.authorised? }
+    let(:versions) { %w(abc def) }
+    let(:current_time) { Time.current }
+
+    subject { ticket.authorised?(versions) }
 
     context 'when the ticket was approved after it was linked' do
-      let(:ticket_attributes) { { approved_at: Time.current, event_created_at: 1.hour.ago } }
-      it { is_expected.to be false }
-    end
-
-    context 'when the ticket was approved before it was linked' do
-      let(:ticket_attributes) { { approved_at: 1.hour.ago, event_created_at: Time.current } }
+      let(:ticket_attributes) {
+        { approved_at: current_time, version_timestamps: { versions.first => 1.hour.ago } }
+      }
       it { is_expected.to be true }
     end
 
-    context 'when the ticket was approved and linked at the same time' do
-      let(:current_time) { Time.current }
-      let(:ticket_attributes) { { approved_at: current_time, event_created_at: current_time } }
+    context 'when the ticket was approved before it was linked' do
+      let(:ticket_attributes) {
+        { approved_at: 1.hour.ago, version_timestamps: { versions.first => current_time } }
+      }
       it { is_expected.to be false }
     end
 
+    context 'when the ticket was approved and linked at the same time' do
+      let(:ticket_attributes) {
+        { approved_at: current_time, version_timestamps: { versions.first => current_time } }
+      }
+      it { is_expected.to be true }
+    end
+
     context 'when the ticket has not been approved' do
-      let(:ticket_attributes) { { approved_at: nil, event_created_at: Time.current } }
+      let(:ticket_attributes) { { approved_at: nil } }
+      it { is_expected.to be false }
+    end
+
+    context 'when the ticket has not been linked to any of the passed in versions' do
+      let(:ticket_attributes) {
+        { approved_at: current_time, version_timestamps: { 'foo' => 1.hour.ago } }
+      }
       it { is_expected.to be false }
     end
   end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Ticket do
+  subject(:ticket) { Ticket.new(ticket_attributes) }
+
   describe '#approved?' do
     it 'returns true for approved statuses' do
       Rails.application.config.approved_statuses.each do |status|
@@ -14,6 +16,31 @@ RSpec.describe Ticket do
 
     it 'returns false if status not set' do
       expect(Ticket.new(status: nil).approved?).to be false
+    end
+  end
+
+  describe '#authorised?' do
+    subject { ticket.authorised? }
+
+    context 'when the ticket was approved after it was linked' do
+      let(:ticket_attributes) { { approved_at: Time.current, event_created_at: 1.hour.ago } }
+      it { is_expected.to be false }
+    end
+
+    context 'when the ticket was approved before it was linked' do
+      let(:ticket_attributes) { { approved_at: 1.hour.ago, event_created_at: Time.current } }
+      it { is_expected.to be true }
+    end
+
+    context 'when the ticket was approved and linked at the same time' do
+      let(:current_time) { Time.current }
+      let(:ticket_attributes) { { approved_at: current_time, event_created_at: current_time } }
+      it { is_expected.to be false }
+    end
+
+    context 'when the ticket has not been approved' do
+      let(:ticket_attributes) { { approved_at: nil, event_created_at: Time.current } }
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe Ticket do
   end
 
   describe '#authorised?' do
+    subject { ticket.authorised?(versions) }
+
     let(:versions) { %w(abc def) }
     let(:current_time) { Time.current }
-
-    subject { ticket.authorised?(versions) }
 
     context 'when the ticket was approved after it was linked' do
       let(:ticket_attributes) {
@@ -51,9 +51,15 @@ RSpec.describe Ticket do
       it { is_expected.to be false }
     end
 
-    context 'when the ticket has not been linked to any of the passed in versions' do
+    context 'when the ticket has not been linked to the versions under review' do
+      let(:ticket_attributes) { { approved_at: current_time, version_timestamps: { 'foo' => 1.hour.ago } } }
+      it { is_expected.to be false }
+    end
+
+    context 'when the ticket has been linked before approval but no versions are under review' do
+      let(:versions) { [] }
       let(:ticket_attributes) {
-        { approved_at: current_time, version_timestamps: { 'foo' => 1.hour.ago } }
+        { approved_at: current_time, version_timestamps: { versions.first => 1.hour.ago } }
       }
       it { is_expected.to be false }
     end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -64,4 +64,38 @@ RSpec.describe Ticket do
       it { is_expected.to be false }
     end
   end
+
+  describe '#authorisation_status' do
+    subject { ticket.authorisation_status(versions) }
+
+    let(:versions) { %w(abc def) }
+
+    context 'when ticket is not done' do
+      let(:ticket_attributes) { { status: 'Ready for Acceptance' } }
+
+      it 'returns its current status' do
+        expect(subject).to eq('Ready for Acceptance')
+      end
+    end
+
+    context 'when ticket is done' do
+      let(:ticket_attributes) { { status: 'Done' } }
+
+      context 'when ticket is authorised' do
+        before do
+          allow(ticket).to receive(:authorised?).and_return(true)
+        end
+
+        it { is_expected.to eq('Done') }
+      end
+
+      context 'when ticket is not authorised' do
+        before do
+          allow(ticket).to receive(:authorised?).and_return(false)
+        end
+
+        it { is_expected.to eq('Requires reapproval') }
+      end
+    end
+  end
 end


### PR DESCRIPTION
When a Feature Review is linked to a ticket *after* approval, it will now have a "Requires reapproval" status which is an "unauthorised" (red) status.

This new status can appear on the Releases and Feature Review pages.

On the Releases page, such a release will link to a Feature Review with events projected up until the current time, that is, projection will not be locked to the approval timestamp, since the approval is not legitimate. This also solves the problem where viewing a Feature Review that was linked to a Ticket *after* approval meant you would not see any associated tickets on the Feature Review page, because events would only be projected up until the approval time.