### PR TITLE
Ensure Tempfile object is closed after written to.

### DIFF
--- a/app/models/git_repository_loader.rb
+++ b/app/models/git_repository_loader.rb
@@ -92,9 +92,13 @@ class GitRepositoryLoader
   end
 
   def create_temporary_file(key)
-    file = Tempfile.new('key', cache_dir)
-    file.write(key.strip + "\n")
-    file.close
+    file = Tempfile.open('key', cache_dir)
+    begin
+      file.write(key.strip + "\n")
+    ensure
+      file.close
+    end
+
     file
   end
 
@@ -108,8 +112,8 @@ class GitRepositoryLoader
 
     yield credentials: Rugged::Credentials::SshKey.new(
       username: ssh_user,
-      privatekey: ssh_private_key_file.path,
       publickey: ssh_public_key_file.path,
+      privatekey: ssh_private_key_file.path,
     )
   ensure
     ssh_public_key_file.unlink if ssh_public_key_file


### PR DESCRIPTION
I suspect that's why https://app.honeybadger.io/projects/44071/faults/27840709#notice-summary happened.

I had to use `begin; ensure` because passing in a block doesn't return the file object, which means we can't find out the `#path` that's needed by the `Rugged::Credentials::SsKey` class.