### PR TITLE
Mention where releases are stored 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ All received events are stored in the DB and are never modified.
 [Event sourcing] is used to replay each event allowing us to reconstruct the state
 of the system at any point in time.
 
+## Releases
+
+Releases are tracked via the Releases page for [this project](https://shipment-tracker.fundingcircle.co.uk/releases/shipment_tracker)
+
 ## Getting Started
 
 Install the Ruby version specified in `.ruby-version`.


### PR DESCRIPTION
Shipment tracker releases aren't tracked on GitHub. Instead there's a releases page in shipment tracker.

Update the Readme to communicate this to users to avoid confusion, such as: https://github.com/FundingCircle/shipment_tracker/issues/19

issue https://github.com/FundingCircle/shipment_tracker/issues/19 will be closed once this has been approved.