### PR TITLE
Use jira Fully Qualified Domain Name instead of just domain name

### DIFF
--- a/app/helpers/feature_reviews_helper.rb
+++ b/app/helpers/feature_reviews_helper.rb
@@ -52,7 +52,7 @@ module FeatureReviewsHelper
   def jira_link(jira_key)
     link_to(
       jira_key,
-      "https://#{ShipmentTracker::JIRA_HOST_NAME}/browse/#{jira_key}",
+      "#{ShipmentTracker::JIRA_FQDN}/browse/#{jira_key}",
       target: '_blank',
     )
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ Dotenv.load
 module ShipmentTracker
   JIRA_USER ||= ENV.fetch('JIRA_USER', nil)
   JIRA_PASSWD ||= ENV.fetch('JIRA_PASSWD', nil)
-  JIRA_HOST_NAME ||= ENV.fetch('JIRA_HOST_NAME', nil)
+  JIRA_FQDN ||= ENV.fetch('JIRA_FQDN', nil)
   JIRA_PATH ||= ENV.fetch('JIRA_PATH', nil)
   GITHUB_REPO_READ_TOKEN ||= ENV.fetch('GITHUB_REPO_READ_TOKEN', nil)
   GITHUB_REPO_STATUS_WRITE_TOKEN ||= ENV.fetch('GITHUB_REPO_STATUS_WRITE_TOKEN', nil)

--- a/lib/clients/jira.rb
+++ b/lib/clients/jira.rb
@@ -16,7 +16,7 @@ class JiraClient
     @options ||= {
       username: ShipmentTracker::JIRA_USER,
       password: ShipmentTracker::JIRA_PASSWD,
-      site: ShipmentTracker::JIRA_HOST_NAME,
+      site: ShipmentTracker::JIRA_FQDN,
       context_path: ShipmentTracker::JIRA_PATH,
       auth_type: :basic,
       read_timeout: 120,

--- a/spec/helpers/feature_review_helper_spec.rb
+++ b/spec/helpers/feature_review_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FeatureReviewsHelper do
     let(:jira_key) { 'JIRA-123' }
     let(:expected_link) { link_to(jira_key, 'https://jira.test/browse/JIRA-123', target: '_blank') }
     it 'returns a link to the relevant jira ticket' do
-      stub_const('ShipmentTracker::JIRA_HOST_NAME', 'jira.test')
+      stub_const('ShipmentTracker::JIRA_FQDN', 'https://jira.test')
       expect(helper.jira_link(jira_key)).to eq(expected_link)
     end
   end


### PR DESCRIPTION
So that protocol is explicit for communication between Jira and ST