### PR TITLE
Link multiple Jira ticket via form

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,8 @@ Style/MultilineBlockChain:
 
 Style/SignalException:
   EnforcedStyle: semantic
+  Exclude:
+    - 'app/use_cases/link_ticket.rb'
 
 Style/FrozenStringLiteralComment:
   Enabled: false  # TODO: Enable in separate PR.

--- a/app/use_cases/link_ticket.rb
+++ b/app/use_cases/link_ticket.rb
@@ -21,15 +21,13 @@ class LinkTicket
   end
 
   def post_comment(args)
-    begin
-      JiraClient.post_comment(args[:jira_key], jira_comment(args))
-    rescue JiraClient::InvalidKeyError
-      return fail :invalid_key, message: invalid_key_message(args)
-    rescue StandardError => error
-      Honeybadger.notify(error)
-      return fail :post_failed, message: generic_error_message(args)
-    end
+    JiraClient.post_comment(args[:jira_key], jira_comment(args))
     continue(success_message(args))
+  rescue JiraClient::InvalidKeyError
+    fail :invalid_key, message: invalid_key_message(args)
+  rescue StandardError => error
+    Honeybadger.notify(error)
+    fail :post_failed, message: generic_error_message(args)
   end
 
   private

--- a/app/use_cases/link_ticket.rb
+++ b/app/use_cases/link_ticket.rb
@@ -1,0 +1,59 @@
+require 'repositories/ticket_repository'
+require 'clients/jira'
+
+class LinkTicket
+  include SolidUseCase
+
+  steps :validate_id_format, :assert_not_linked, :post_comment
+
+  def validate_id_format(args)
+    return fail :invalid_key, message: invalid_key_message(args) unless /[A-Z][A-Z]+-\d*/ =~ args[:jira_key]
+    continue(args)
+  end
+
+  def assert_not_linked(args)
+    tickets = Repositories::TicketRepository.new.tickets_for_path(args[:feature_review_path])
+
+    return fail :duplicate_key, message: duplicate_key_message(args) if tickets.any? { |ticket|
+      ticket.key == args[:jira_key]
+    }
+    continue(args)
+  end
+
+  def post_comment(args)
+    begin
+      JiraClient.post_comment(args[:jira_key], jira_comment(args))
+    rescue JiraClient::InvalidKeyError
+      return fail :invalid_key, message: invalid_key_message(args)
+    rescue StandardError => error
+      Honeybadger.notify(error)
+      return fail :post_failed, message: generic_error_message(args)
+    end
+    continue(success_message(args))
+  end
+
+  private
+
+  def invalid_key_message(args)
+    "Failed to link #{args[:jira_key]}. Please check that the ticket ID is correct."
+  end
+
+  def duplicate_key_message(args)
+    "Failed to link #{args[:jira_key]}. Duplicate tickets should not be added."
+  end
+
+  def generic_error_message(args)
+    "Failed to link #{args[:jira_key]}. Something went wrong."
+  end
+
+  def success_message(args)
+    "Feature Review was linked to #{args[:jira_key]}."\
+    ' Refresh this page in a moment and the ticket will appear.'
+  end
+
+  def jira_comment(args)
+    feature_review_url = "#{args[:root_url].chomp('/')}#{args[:feature_review_path]}"
+
+    "[Feature ready for review|#{feature_review_url}]"
+  end
+end

--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -10,14 +10,7 @@
 .row
   .col-lg-12
     - panel(heading: feature_status(@feature_review_with_statuses), status: @feature_review_with_statuses.authorisation_status, klass: 'feature-status', help_url: wiki_links(:approve), align_right: true) do
-      - if @feature_review_with_statuses.tickets.empty?
-        .panel-body
-          = form_tag(link_ticket_feature_reviews_path(return_to: @return_to), method: 'post', class: 'form-inline') do
-            .form-group
-              = label_tag('jira_key', 'Link Jira Ticket:', class: 'control-label')
-              = text_field_tag('jira_key', '', placeholder: 'e.g: ENG-123', class: 'form-control input-sm', required: true)
-            = submit_tag('Link', class: 'btn btn-primary btn-sm')
-      - else
+      - if @feature_review_with_statuses.tickets.any?
         - table(headers: %w(Ticket Summary Status)) do
           - @feature_review_with_statuses.tickets.each do |ticket|
             %tr.ticket
@@ -26,7 +19,12 @@
               %td
                 - icon(item_status_icon_class(ticket.authorised?(@feature_review_with_statuses.versions)))
                 = ticket.authorisation_status(@feature_review_with_statuses.versions)
-
+      .panel-body
+        = form_tag(link_ticket_feature_reviews_path(return_to: @return_to), method: 'post', class: 'form-inline') do
+          .form-group
+            = label_tag('jira_key', 'Link Jira Ticket:', class: 'control-label')
+            = text_field_tag('jira_key', '', placeholder: 'e.g: ENG-123', class: 'form-control input-sm', required: true)
+          = submit_tag('Link', class: 'btn btn-primary btn-sm')
 .row
   .col-lg-6
     - panel(heading: 'Summary', status: @feature_review_with_statuses.summary_status, klass: 'summary') do

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -64,6 +64,9 @@ Scenario: Linking a Feature Review
     | Ticket   | Summary       | Status      |
     | JIRA-123 | Urgent ticket | In Progress |
 
+  When I link the feature review "FR_view" to the Jira ticket "JIRA-123"
+  Then I should see an alert: "Failed to link JIRA-123. Duplicate tickets should not be added."
+
 @logged_in
 Scenario: Viewing User Acceptance Tests results on a Feature review
   Given an application called "frontend"

--- a/spec/controllers/feature_reviews_controller_spec.rb
+++ b/spec/controllers/feature_reviews_controller_spec.rb
@@ -180,10 +180,14 @@ RSpec.describe FeatureReviewsController do
 
   describe 'POST #link_ticket', :logged_in do
     let(:ticket_id) { 'JIRA-123' }
-    subject(:link_ticket) { post :link_ticket, return_to: feature_review_path, jira_key: ticket_id }
+    let(:apps_with_versions) { { 'frontend' => 'abc', 'backend' => 'def' } }
+    subject(:link_ticket) {
+      post :link_ticket, return_to: feature_review_path(apps_with_versions), jira_key: ticket_id
+    }
+    let(:expected_comment) {
+      "[Feature ready for review|http://test.host#{feature_review_path(apps_with_versions)}]"
+    }
 
-    let(:expected_comment) { "[Feature ready for review|http://test.host#{feature_review_path}]" }
-    let(:feature_review_path) { '/feature_reviews?some=app' }
     before do
       allow(JiraClient).to receive(:post_comment)
     end
@@ -195,7 +199,7 @@ RSpec.describe FeatureReviewsController do
 
     it 'redirects to the return path' do
       link_ticket
-      expect(response).to redirect_to(feature_review_path)
+      expect(response).to redirect_to(feature_review_path(apps_with_versions))
     end
 
     context 'when the key is invalid' do
@@ -205,7 +209,7 @@ RSpec.describe FeatureReviewsController do
       it 'shows flash error asking to check ticker ID' do
         link_ticket
         expect(flash[:error]).to eq(expected_flash_error)
-        expect(response).to redirect_to(feature_review_path)
+        expect(response).to redirect_to(feature_review_path(apps_with_versions))
       end
     end
 
@@ -226,7 +230,7 @@ RSpec.describe FeatureReviewsController do
           link_ticket
 
           expect(flash[:error]).to eq(expected_flash_error)
-          expect(response).to redirect_to(feature_review_path)
+          expect(response).to redirect_to(feature_review_path(apps_with_versions))
         end
       end
 
@@ -238,7 +242,7 @@ RSpec.describe FeatureReviewsController do
         it 'shows a basic flash error' do
           link_ticket
           expect(flash[:error]).to eq(expected_flash_error)
-          expect(response).to redirect_to(feature_review_path)
+          expect(response).to redirect_to(feature_review_path(apps_with_versions))
         end
       end
     end

--- a/spec/use_cases/link_ticket_spec.rb
+++ b/spec/use_cases/link_ticket_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+require 'link_ticket'
+
+RSpec.describe LinkTicket do
+  let(:ticket_repository) { double }
+
+  let(:apps_with_versions) { { 'frontend' => 'abc', 'backend' => 'def' } }
+  let(:args) {
+    {
+      jira_key: jira_key,
+      feature_review_path: feature_review_path(apps_with_versions),
+      root_url: 'http://test.com/',
+    }
+  }
+
+  before do
+    allow(Repositories::TicketRepository).to receive(:new).and_return(ticket_repository)
+    allow(ticket_repository).to receive(:tickets_for_path).and_return([])
+    allow(JiraClient).to receive(:post_comment)
+  end
+
+  context 'when valid ticket ID format' do
+    let(:jira_key) { 'JIRA-123' }
+
+    context 'when not linked yet' do
+      let(:expected_message) {
+        "Feature Review was linked to #{jira_key}. Refresh this page in a moment and the ticket will appear."
+      }
+      let(:expected_comment) {
+        "[Feature ready for review|http://test.com#{feature_review_path(apps_with_versions)}]"
+      }
+
+      it 'posts a comment' do
+        expect(JiraClient).to receive(:post_comment).with(jira_key, expected_comment)
+        LinkTicket.run(args)
+      end
+
+      it 'returns a success message' do
+        result = LinkTicket.run(args)
+        expect(result).to be_a_success
+        expect(result.value).to eq(expected_message)
+      end
+    end
+
+    context 'when ticket ID can not be found' do
+      let(:expected_message) {
+        "Failed to link #{jira_key}. Please check that the ticket ID is correct."
+      }
+      before do
+        allow(JiraClient).to receive(:post_comment).and_raise(JiraClient::InvalidKeyError)
+      end
+      it 'fails with message' do
+        result = LinkTicket.run(args)
+        expect(result).to fail_with(:invalid_key)
+        expect(result.value.message).to eq(expected_message)
+      end
+    end
+
+    context 'when ticket is already linked' do
+      let(:expected_message) {
+        "Failed to link #{jira_key}. Duplicate tickets should not be added."
+      }
+      let(:ticket) { Ticket.new(paths: [feature_review_path(apps_with_versions)], key: jira_key) }
+
+      before do
+        expect(ticket_repository).to receive(:tickets_for_path).and_return([ticket])
+      end
+
+      it 'fails with message' do
+        result = LinkTicket.run(args)
+        expect(result).to fail_with(:duplicate_key)
+        expect(result.value.message).to eq(expected_message)
+      end
+    end
+
+    context 'when posting returns an error' do
+      let(:expected_message) { "Failed to link #{jira_key}. Something went wrong." }
+
+      before do
+        allow(JiraClient).to receive(:post_comment).and_raise(StandardError)
+      end
+
+      it 'fails with message' do
+        result = LinkTicket.run(args)
+        expect(result).to fail_with(:post_failed)
+        expect(result.value.message).to eq(expected_message)
+      end
+    end
+  end
+
+  context 'when invalid ticket ID format' do
+    let(:jira_key) { 'INVALID' }
+    let(:expected_message) {
+      "Failed to link #{jira_key}. Please check that the ticket ID is correct."
+    }
+
+    it 'fails validation' do
+      result = LinkTicket.run(args)
+      expect(result).to fail_with(:invalid_key)
+      expect(result.value.message).to eq(expected_message)
+    end
+  end
+end


### PR DESCRIPTION
Allows linking of multiple tickets to a feature review. Assets the feature review is not already linked. 