### PR TITLE
Allow usage of short SHA version

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -110,10 +110,7 @@ class GitRepository
     walker = get_walker(main_branch.target_id, parent_commit.oid, true)
 
     begin
-      # Current method fails if the commit_oid is the short version
-      # of the commit sha. The following should work better:
-      # walker.first.oid.start_with? commit_oid
-      walker.first.oid == commit_oid
+      walker.first.oid.start_with? commit_oid
     rescue NoMethodError => error
       Honeybadger.context(target_commit: commit_oid,
                           master_head: main_branch.target_id,

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -110,6 +110,9 @@ class GitRepository
     walker = get_walker(main_branch.target_id, parent_commit.oid, true)
 
     begin
+      # Current method fails if the commit_oid is the short version
+      # of the commit sha. The following should work better:
+      # walker.first.oid.start_with? commit_oid
       walker.first.oid == commit_oid
     rescue NoMethodError => error
       Honeybadger.context(target_commit: commit_oid,

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -418,10 +418,21 @@ RSpec.describe GitRepository do
 
     context 'the requested commit is on master' do
       let(:git_diagram) { '-o-A-o' }
-      let(:sha) { version('A') }
 
-      it 'returns true' do
-        expect(repo.commit_on_master?(sha)).to be true
+      context 'when using complete commit SHA' do
+        let(:sha) { version('A') }
+
+        it 'returns true' do
+          expect(repo.commit_on_master?(sha)).to be true
+        end
+      end
+
+      context 'when using short SHA version' do
+        let(:short_sha) { short_version('A') }
+
+        it 'returns true' do
+          expect(repo.commit_on_master?(short_sha)).to be true
+        end
       end
     end
   end
@@ -430,5 +441,9 @@ RSpec.describe GitRepository do
 
   def version(pretend_version)
     test_git_repo.commit_for_pretend_version(pretend_version)
+  end
+
+  def short_version(pretend_version)
+    test_git_repo.commit_for_pretend_version(pretend_version)[0..6]
   end
 end


### PR DESCRIPTION
So that it's still possible to query repositories using the short version, 7 characters.