### PR TITLE
send deploy alert if deploy version unknown

### DIFF
--- a/app/models/deploy_alert.rb
+++ b/app/models/deploy_alert.rb
@@ -14,7 +14,7 @@ class DeployAlert
 
     github_repo = GitRepositoryLoader.from_rails_config.load(deploy.app_name)
 
-    alert_not_on_master(deploy) unless github_repo.commit_on_master?(deploy.version)
+    alert_not_on_master(deploy) if deploy.version.nil? || !github_repo.commit_on_master?(deploy.version)
 
     # @deploy_repo = Repositories::DeployRepository.new
     # deploy_region = deploy_vo.region
@@ -25,6 +25,6 @@ class DeployAlert
   def self.alert_not_on_master(deploy)
     time = deploy.event_created_at.strftime('%F %H:%M%:z')
     "Deploy Alert for #{deploy.app_name} at #{time}. #{deploy.deployed_by} " \
-    "deployed version #{deploy.version} not on master branch."
+    "deployed version #{deploy.version || 'unknown'} not on master branch."
   end
 end

--- a/spec/models/deploy_alert_spec.rb
+++ b/spec/models/deploy_alert_spec.rb
@@ -89,6 +89,24 @@ RSpec.describe DeployAlert do
         expect(DeployAlert.audit(deploy)).to eq(expected_message)
       end
     end
+
+    context 'deploy event does not have version' do
+      let(:deploy) {
+        Deploy.new(
+          version: nil, environment: 'production', app_name: app_name,
+          deployed_by: 'user1', event_created_at: DateTime.parse('2016-02-15T15:57:25+01:00'))
+      }
+      let(:git_diagram) { '-A' }
+
+      let(:expected_message) {
+        'Deploy Alert for frontend at 2016-02-15 15:57+01:00. ' \
+        'user1 deployed version unknown not on master branch.'
+      }
+
+      it 'returns a message' do
+        expect(DeployAlert.audit(deploy)).to eq(expected_message)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Given we receive production deploy events with version no given (i.e. NULL), we want to raise a deploy alert, so that we can establish what the deployer has deployed. 