### PR TITLE
Fix Releases show requests where app name contains a request format

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,4 +1,6 @@
 class ReleasesController < ApplicationController
+  before_action :force_html_format, only: :show
+
   def index
     @app_names = GitRepositoryLocation.app_names
   end
@@ -26,7 +28,11 @@ class ReleasesController < ApplicationController
   end
 
   def app_name
-    params[:id]
+    if request.path_parameters[:format]
+      "#{params[:id]}.#{request.path_parameters[:format]}"
+    else
+      params[:id]
+    end
   end
 
   def region
@@ -40,5 +46,9 @@ class ReleasesController < ApplicationController
 
   def git_repository
     git_repository_loader.load(app_name)
+  end
+
+  def force_html_format
+    request.format = 'html'
   end
 end

--- a/spec/controllers/releases_controller_spec.rb
+++ b/spec/controllers/releases_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ReleasesController do
 
     before do
       allow(GitRepositoryLoader).to receive(:from_rails_config).and_return(repository_loader)
-      allow(repository_loader).to receive(:load).with('frontend').and_return(repository)
+      allow(repository_loader).to receive(:load).with(app_name).and_return(repository)
       allow(GitRepositoryLocation).to receive(:github_url_for_app).with(app_name).and_return(github_url)
       allow(Queries::ReleasesQuery).to receive(:new).with(
         per_page: 50,

--- a/spec/requests/releases_controller_formats_spec.rb
+++ b/spec/requests/releases_controller_formats_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'ReleasesControllerFormats', type: :request do
+  describe 'GET /releases/<app_name>', :logged_in do
+    before do
+      allow(Queries::ReleasesQuery).to receive(:new).and_return(double.as_null_object)
+      allow_any_instance_of(GitRepositoryLoader).to receive(:load)
+      allow(GitRepositoryLocation).to receive(:github_url_for_app)
+    end
+
+    context 'when app name contains a valid non-html format' do
+      it 'assigns the app name correctly' do
+        get '/releases/example.js?region=gb'
+
+        expect(response).to have_http_status(:success)
+        expect(assigns(:app_name)).to eq('example.js')
+      end
+    end
+
+    context 'when app name does not contain a format' do
+      it 'assigns the app name correctly' do
+        get '/releases/example?region=gb'
+
+        expect(response).to have_http_status(:success)
+        expect(assigns(:app_name)).to eq('example')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rails magic was causing requests where the repository name included a valid format (e.g. 'reponame.js') to error.