### PR TITLE
Disable deploy alerts during maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,11 @@ You can also use Foreman to start the server and use settings from Heroku:
 bin/boot_with_heroku_settings
 ```
 
-### Running event snapshots
+### Snapshotting events
 
-In order to return results from recent events, Shipment Tracker needs to continuously record snapshots.
-There is a rake task `jobs:update_events_loop` which continuously updates the event cache.
-We suggest that you have this running in the background (e.g. using Supervisor or a Heroku worker).
-
-There is also a rake task `jobs:update_events` for running the snapshotting manually,
-for example, after you clear the event snapshots with the `db:clear_snapshots` rake task.
+Shipment Tracker needs to continuously record snapshots for incoming events that it processes.  
+The rake task `jobs:update_events_loop` should be used to do this.  
+We suggest running it as a background job (e.g. using Supervisor or a Heroku worker).
 
 *Warning:* This recurring task should only run on **one** server.
 
@@ -100,8 +97,9 @@ bundle exec rake jobs:update_git_loop
 
 *Warning:* This recurring task should run on **every** server that your application is running on.
 
-In addition to the `update_git_loop` task, you can set `ALLOW_GIT_FETCH_ON_REQUEST` to `true` if you also want
-the tracked repositories to be updated on web request (e.g. when preparing a Feature Review).
+In addition to the `update_git_loop` task, you can set the environment variable
+`ALLOW_GIT_FETCH_ON_REQUEST=true` if you also want the git repositories to be updated on web request
+(e.g. when preparing a Feature Review).
 
 ### Enable GitHub Webhooks
 
@@ -123,13 +121,17 @@ There are two environment variables for GitHub tokens.
 Recommended to use two different tokens, from two different users (one with READ access, one with WRITE),
 instead of one super token.
 
-### Maintenance Mode
+### Maintenance mode
 
-When recreating snapshots, you may want to put the application in maintenance mode.
-This is to disable GitHub status notifications and to tell the user that some data may appear out of date.
+There is a rake task `jobs:recreate_snapshots` for recreating snapshots.
+You'll want to recreate snapshots if you changed the schema of a snapshots database table for example.
 
-To enable maintenance mode, set an environment variable called `DATA_MAINTENANCE=true`.
-The application will require a reboot before taking effect.
+When recreating snapshots, you can put the application into maintenance mode.
+This temporarily disables GitHub status notifications, deploy alerts,
+and notifies users that some data may appear out of date.
+
+To enable maintenance mode, set the environment variable `DATA_MAINTENANCE=true` and reboot the application.  
+To disable maintenance mode, set the environment variable to `false` and reboot the application.
 
 ### Configure alerts
 

--- a/app/models/events/base_event.rb
+++ b/app/models/events/base_event.rb
@@ -21,8 +21,9 @@ module Events
       BatchedRelation.new(self)
     end
 
-    def self.between(id, up_to: nil)
+    def self.between(id, up_to: nil, to_id: nil)
       query = up_to ? where(arel_table['created_at'].lteq(up_to)) : self
+      query = query.where(arel_table['id'].lteq(to_id)) if to_id
       BatchedRelation.new(query, from_id: id + 1)
     end
   end

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -53,7 +53,7 @@ module Repositories
         event_created_at: event.created_at,
       )
 
-      audit_deploy(deploy.attributes)
+      audit_deploy(deploy.attributes) unless Rails.configuration.data_maintenance_mode
     end
 
     private

--- a/app/models/repositories/updater.rb
+++ b/app/models/repositories/updater.rb
@@ -13,9 +13,9 @@ module Repositories
       @repositories = repositories
     end
 
-    def run
+    def run(repo_event_id_hash = {})
       repositories.each do |repository|
-        run_for(repository)
+        run_for(repository, repo_event_id_hash[repository.table_name])
       end
     end
 
@@ -31,10 +31,10 @@ module Repositories
 
     attr_reader :repositories
 
-    def run_for(repository)
+    def run_for(repository, ceiling_id)
       ActiveRecord::Base.transaction do
         last_id = 0
-        new_events_for(repository).each do |event|
+        new_events_for(repository, ceiling_id).each do |event|
           last_id = event.id
           repository.apply(event)
         end
@@ -42,8 +42,8 @@ module Repositories
       end
     end
 
-    def new_events_for(repository)
-      Events::BaseEvent.between(last_id_for(repository))
+    def new_events_for(repository, ceiling_id)
+      Events::BaseEvent.between(last_id_for(repository), to_id: ceiling_id)
     end
 
     def last_id_for(repository)

--- a/app/models/snapshots/event_count.rb
+++ b/app/models/snapshots/event_count.rb
@@ -2,5 +2,8 @@ require 'active_record'
 
 module Snapshots
   class EventCount < ActiveRecord::Base
+    def self.repo_event_id_hash
+      pluck(:snapshot_name, :event_id).to_h
+    end
   end
 end

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -94,9 +94,7 @@ end
 
 When 'snapshots are regenerated' do
   Rails.application.load_tasks
-  Rake::Task['db:clear_snapshots'].reenable
-  Rake::Task['db:clear_snapshots'].invoke
 
-  Rake::Task['jobs:update_events'].reenable
-  Rake::Task['jobs:update_events'].invoke
+  Rake::Task['jobs:recreate_snapshots'].reenable
+  Rake::Task['jobs:recreate_snapshots'].invoke
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -10,8 +10,3 @@ task 'db:create_database_yml' do
     f.write ERB.new(file_contents).result
   end
 end
-
-desc 'clear snapshots'
-task 'db:clear_snapshots' => :environment do
-  Repositories::Updater.from_rails_config.reset
-end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -24,13 +24,18 @@ namespace :jobs do
     File.expand_path("#{name}.pid", Dir.tmpdir)
   end
 
-  desc 'Update event cache'
-  task update_events: :environment do
-    manage_pid pid_path_for('jobs_update_events')
+  desc 'Reset and recreate event snapshots (new events received during execution are not snapshotted)'
+  task recreate_snapshots: :environment do
+    manage_pid pid_path_for('jobs_recreate_snapshots')
 
-    puts "[#{Time.current}] Running update_events"
-    Repositories::Updater.from_rails_config.run
-    puts "[#{Time.current}] Completed update_events"
+    puts "[#{Time.current}] Running recreate_snapshots"
+    updater = Repositories::Updater.from_rails_config
+
+    repo_event_id_hash = Snapshots::EventCount.repo_event_id_hash # preserving the ceiling_ids before reset
+    updater.reset
+
+    updater.run(repo_event_id_hash)
+    puts "[#{Time.current}] Completed recreate_snapshots"
   end
 
   desc 'Continuously updates event cache'

--- a/spec/models/events/base_event_spec.rb
+++ b/spec/models/events/base_event_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Events::BaseEvent do
       events.each(&:save!)
     end
 
-    context 'when nil is specified' do
+    context 'when 0 is specified' do
       it 'returns all events' do
         expect(Events::BaseEvent.between(0).to_a).to eq(events)
       end
@@ -28,6 +28,12 @@ RSpec.describe Events::BaseEvent do
     context 'when an integer is specified' do
       it 'returns events greater than that id' do
         expect(Events::BaseEvent.between(events.second.id).to_a).to eq(events[2..-1])
+      end
+    end
+
+    context 'when to_id is also specified' do
+      it 'returns all events up to the id specified' do
+        expect(Events::BaseEvent.between(0, to_id: events.first.id).to_a).to eq(events[0, 1])
       end
     end
 

--- a/spec/models/repositories/updater_spec.rb
+++ b/spec/models/repositories/updater_spec.rb
@@ -41,6 +41,30 @@ RSpec.describe Repositories::Updater do
       expect(Snapshots::EventCount.find_by(snapshot_name: repository_2.table_name).event_id).to eq(last_id)
     end
 
+    context 'when given a hash with snapshot names and event ids' do
+      let(:events) {
+        [
+          build(:jira_event),
+          build(:jira_event),
+          build(:jira_event),
+        ]
+      }
+
+      it 'only snapshots up to the given event id for each repository' do
+        allow(repository_1).to receive(:apply)
+        allow(repository_2).to receive(:apply)
+
+        events.each(&:save!)
+
+        updater.run(repository_1.table_name => events[0].id, repository_2.table_name => events[1].id)
+
+        expect(Snapshots::EventCount.find_by(snapshot_name: repository_1.table_name).event_id)
+          .to eq(events[0].id)
+        expect(Snapshots::EventCount.find_by(snapshot_name: repository_2.table_name).event_id)
+          .to eq(events[1].id)
+      end
+    end
+
     context 'when the application is updated and we have different repositories specified' do
       let(:events) { [build(:jira_event), build(:jira_event)] }
       let(:new_events) { [build(:jira_event)] }

--- a/spec/models/snapshots/event_count_spec.rb
+++ b/spec/models/snapshots/event_count_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Snapshots::EventCount do
+  describe '.repo_event_id_hash' do
+    before do
+      Snapshots::EventCount.create([
+        { snapshot_name: 'foo', event_id: 1 },
+        { snapshot_name: 'bar', event_id: 2 },
+      ])
+    end
+
+    it 'returns a hash with all snapshot names and event ids' do
+      result = Snapshots::EventCount.repo_event_id_hash
+      expect(result).to eq('foo' => 1, 'bar' => 2)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Do not resend deploy alerts when in maintenance mode (i.e. recreating snapshots)
- [x] New rake task `recreate_snapshots` which does not process new events received during maintenance mode
- [x] Update docs