### PR TITLE
Improve validation when onboarding repositories

### DIFF
--- a/app/controllers/git_repository_locations_controller.rb
+++ b/app/controllers/git_repository_locations_controller.rb
@@ -29,6 +29,7 @@ class GitRepositoryLocationsController < ApplicationController
 
   def git_repo_location_params
     permitted = params.require(:repository_locations_form).permit(:uri)
+    permitted[:uri] = permitted[:uri].strip
     permitted[:token_types] = params[:token_types] if params[:token_types].present?
     permitted
   end

--- a/app/controllers/git_repository_locations_controller.rb
+++ b/app/controllers/git_repository_locations_controller.rb
@@ -10,7 +10,6 @@ class GitRepositoryLocationsController < ApplicationController
     AddRepositoryLocation.run(git_repo_location_params).match do
       success do |repo_name|
         flash[:success] = success_msg(repo_name)
-
         redirect_to :git_repository_locations
       end
 

--- a/app/models/forms/repository_locations_form.rb
+++ b/app/models/forms/repository_locations_form.rb
@@ -14,7 +14,8 @@ module Forms
     end
 
     WHITELIST_DOMAINS = %w(github.com).freeze
-    REPO_URI_REGEX = %r{((file|git|ssh|http(s)?)|(git@[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?}
+    REPO_GIT_URI_REGEX = %r{(git)@([\w\.]+):([\w\.\/\-]+)(\.git)$}
+    REPO_VCS_URI_REGEX = %r{(file|git|ssh|http(s)?)(://)([\w\.@/\-~]+)(\:[0-9]{1,5})?/([\w\.\-]+)(\.git)?(/)?}
     DEFAULT_SELECTED_TOKENS = %w(circleci deploy).freeze
 
     attr_reader :uri, :token_types
@@ -48,7 +49,7 @@ module Forms
         return false
       end
 
-      unless uri =~ REPO_URI_REGEX
+      unless valid_uri_format?
         errors.add(:git_uri, 'must be valid Git URI, e.g. git@github.com:owner/repo.git')
         return false
       end
@@ -68,6 +69,14 @@ module Forms
       end
 
       true
+    end
+
+    def valid_uri_format?
+      if uri.start_with?('git@')
+        (REPO_GIT_URI_REGEX =~ uri) == 0
+      else
+        (REPO_VCS_URI_REGEX =~ uri) == 0
+      end
     end
 
     def valid_hostname?

--- a/app/models/forms/repository_locations_form.rb
+++ b/app/models/forms/repository_locations_form.rb
@@ -45,17 +45,17 @@ module Forms
 
     def valid_uri?
       if uri.blank?
-        errors.add(:git_uri, 'cannot be empty')
+        errors.add(:base, 'Git URI cannot be empty')
         return false
       end
 
       unless valid_uri_format?
-        errors.add(:git_uri, 'must be valid Git URI, e.g. git@github.com:owner/repo.git')
+        errors.add(:base, "Not a valid Git URI '#{uri}'")
         return false
       end
 
       unless valid_hostname?
-        errors.add(:git_uri, "domain should be one of #{WHITELIST_DOMAINS.join(', ')}")
+        errors.add(:base, "Git URI did not contain a whitelisted domain: #{WHITELIST_DOMAINS.join(', ')}")
         return false
       end
 

--- a/app/models/forms/repository_locations_form.rb
+++ b/app/models/forms/repository_locations_form.rb
@@ -19,9 +19,8 @@ module Forms
 
     attr_reader :uri, :token_types
 
-    def initialize(uri, token_types)
+    def initialize(uri)
       @uri = uri
-      @token_types = token_types
     end
 
     def valid?
@@ -30,7 +29,7 @@ module Forms
 
     def self.default_token_types
       @default_token_types ||= Token.sources.map { |token_src|
-        value = DEFAULT_SELECTED_TOKENS.include? token_src.endpoint
+        value = DEFAULT_SELECTED_TOKENS.include?(token_src.endpoint)
         { id: token_src.endpoint, name: token_src.name, value: value }
       }
     end

--- a/app/models/git_repository_location.rb
+++ b/app/models/git_repository_location.rb
@@ -2,6 +2,7 @@ require 'git_clone_url'
 
 class GitRepositoryLocation < ActiveRecord::Base
   before_validation on: :create do
+    self.uri = uri&.strip
     self.name = extract_name(uri)
   end
 

--- a/app/use_cases/add_repository_location.rb
+++ b/app/use_cases/add_repository_location.rb
@@ -6,10 +6,7 @@ class AddRepositoryLocation
   steps :validate, :add_repo, :generate_tokens
 
   def validate(args)
-    validation_form = Forms::RepositoryLocationsForm.new(
-      args[:uri],
-      args[:token_types],
-    )
+    validation_form = Forms::RepositoryLocationsForm.new(args[:uri])
 
     return fail :invalid_uri, message: errors_for(validation_form) unless validation_form.valid?
     continue(args)

--- a/app/views/git_repository_locations/index.html.haml
+++ b/app/views/git_repository_locations/index.html.haml
@@ -4,7 +4,7 @@
   .form-group.row
     = form.label(:uri, 'Git URI', class: 'col-md-1 control-label')
     .col-md-4
-      = form.text_field(:uri, placeholder: 'git@github.com:user/repo.git', class: 'form-control')
+      = form.text_field(:uri, placeholder: 'git@github.com:owner/repo.git', class: 'form-control')
   .form-group.row
     %label.col-md-1.control-label Tokens
     .col-md-2

--- a/lib/clients/github.rb
+++ b/lib/clients/github.rb
@@ -24,6 +24,9 @@ class GithubClient
     path = parsed_uri.path
     repo_path = path.start_with?('/') ? path[1..-1] : path
     client.repository?(repo_path.chomp('.git'))
+  rescue ArgumentError => error
+    Rails.logger.warn(error)
+    false
   end
 
   private

--- a/spec/controllers/git_repository_locations_controller_spec.rb
+++ b/spec/controllers/git_repository_locations_controller_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe GitRepositoryLocationsController do
       it { is_expected.to set_flash.now[:error] }
     end
 
+    context 'when the GitRepositoryLocation is valid but contains whitespace' do
+      let(:params) { { repository_locations_form: { uri: ' ssh://git@github.com/some/repo.git ' } } }
+
+      it { is_expected.to set_flash[:success] }
+      it { is_expected.to redirect_to(git_repository_locations_path) }
+    end
+
     context 'when the GitRepositoryLocation is valid' do
       let(:params) { { repository_locations_form: { uri: 'ssh://git@github.com/some/repo.git' } } }
 

--- a/spec/lib/clients/github_spec.rb
+++ b/spec/lib/clients/github_spec.rb
@@ -44,5 +44,11 @@ RSpec.describe GithubClient do
         expect(github.repo_accessible?('git@bitbucket.com:owner/repo.git')).to be_nil
       end
     end
+
+    context 'when the format is not owner/repo' do
+      it 'returns false' do
+        expect(github.repo_accessible?('https://github.com/foo')).to be false
+      end
+    end
   end
 end

--- a/spec/models/forms/repository_locations_form_spec.rb
+++ b/spec/models/forms/repository_locations_form_spec.rb
@@ -25,11 +25,12 @@ RSpec.describe Forms::RepositoryLocationsForm do
           aggregate_failures do
             expect(repo_form('git@github.com:owner/repo.git')).to be_valid
             expect(repo_form('ssh://git@github.com/owner/repo.git')).to be_valid
+            expect(repo_form('ssh://git@github.com:8080/owner/repo.git')).to be_valid
             expect(repo_form('git://git@github.com/owner/repo.git')).to be_valid
             expect(repo_form('http://github.com/owner/repo.git')).to be_valid
             expect(repo_form('https://github.com/owner/repo.git')).to be_valid
             expect(repo_form('https://github.com/owner/repo')).to be_valid
-            expect(repo_form('file:///path/to/repo')).to be_valid
+            expect(repo_form('file:///path/to/repo/')).to be_valid
           end
         end
       end
@@ -37,6 +38,9 @@ RSpec.describe Forms::RepositoryLocationsForm do
       context 'when the input is not a valid Git URI' do
         it 'is not valid' do
           aggregate_failures do
+            expect(repo_form('git@github.com:owner/repo~name.git')).to_not be_valid
+            expect(repo_form('foo git@github.com:owner/repo.git')).to_not be_valid
+            expect(repo_form('ssh://git@github.com:no/port.git')).to_not be_valid
             expect(repo_form('github.com\user\repo.git')).to_not be_valid
             expect(repo_form('repo')).to_not be_valid
             expect(repo_form('')).to_not be_valid

--- a/spec/models/forms/repository_locations_form_spec.rb
+++ b/spec/models/forms/repository_locations_form_spec.rb
@@ -2,31 +2,19 @@ require 'rails_helper'
 require 'forms/repository_locations_form'
 
 RSpec.describe Forms::RepositoryLocationsForm do
-  let(:expected_tokens) {
-    [
-      { id: 'circleci', name: 'CircleCI (webhook)', value: true },
-      { id: 'circleci-manual', name: 'CircleCI (post test)', value: false },
-      { id: 'deploy', name: 'Deployment', value: true },
-      { id: 'jenkins', name: 'Jenkins', value: false },
-      { id: 'jira', name: 'JIRA', value: false },
-      { id: 'uat', name: 'UAT', value: false },
-      { id: 'github_notifications', name: 'Github Notifications', value: false },
-    ]
-  }
-
   before { stub_const('ShipmentTracker::GITHUB_REPO_READ_TOKEN', 'token') }
 
   describe '#valid?' do
     describe 'URI validation', :disable_repo_verification do
       context 'when the domain is whitelisted' do
         it 'is valid' do
-          expect(repo_form('https://github.com/owner/repo.git', expected_tokens)).to be_valid
+          expect(repo_form('https://github.com/owner/repo.git')).to be_valid
         end
       end
 
       context 'when the domain is not whitelisted' do
         it 'is not valid' do
-          expect(repo_form('https://example.com/owner/repo.git', expected_tokens)).to_not be_valid
+          expect(repo_form('https://example.com/owner/repo.git')).to_not be_valid
         end
       end
 
@@ -35,13 +23,13 @@ RSpec.describe Forms::RepositoryLocationsForm do
           allow_any_instance_of(URI::Generic).to receive(:host).and_return('github.com')
 
           aggregate_failures do
-            expect(repo_form('git@github.com:owner/repo.git', expected_tokens)).to be_valid
-            expect(repo_form('ssh://git@github.com/owner/repo.git', expected_tokens)).to be_valid
-            expect(repo_form('git://git@github.com/owner/repo.git', expected_tokens)).to be_valid
-            expect(repo_form('http://github.com/owner/repo.git', expected_tokens)).to be_valid
-            expect(repo_form('https://github.com/owner/repo.git', expected_tokens)).to be_valid
-            expect(repo_form('https://github.com/owner/repo', expected_tokens)).to be_valid
-            expect(repo_form('file:///path/to/repo', expected_tokens)).to be_valid
+            expect(repo_form('git@github.com:owner/repo.git')).to be_valid
+            expect(repo_form('ssh://git@github.com/owner/repo.git')).to be_valid
+            expect(repo_form('git://git@github.com/owner/repo.git')).to be_valid
+            expect(repo_form('http://github.com/owner/repo.git')).to be_valid
+            expect(repo_form('https://github.com/owner/repo.git')).to be_valid
+            expect(repo_form('https://github.com/owner/repo')).to be_valid
+            expect(repo_form('file:///path/to/repo')).to be_valid
           end
         end
       end
@@ -49,9 +37,9 @@ RSpec.describe Forms::RepositoryLocationsForm do
       context 'when the input is not a valid Git URI' do
         it 'is not valid' do
           aggregate_failures do
-            expect(repo_form('github.com\user\repo.git', expected_tokens)).to_not be_valid
-            expect(repo_form('repo', expected_tokens)).to_not be_valid
-            expect(repo_form('', expected_tokens)).to_not be_valid
+            expect(repo_form('github.com\user\repo.git')).to_not be_valid
+            expect(repo_form('repo')).to_not be_valid
+            expect(repo_form('')).to_not be_valid
           end
         end
       end
@@ -61,13 +49,13 @@ RSpec.describe Forms::RepositoryLocationsForm do
       context 'when the repo does not exist or we lack read permissions' do
         it 'is not valid' do
           allow_any_instance_of(GithubClient).to receive(:repo_accessible?).and_return(false)
-          expect(repo_form('ssh://git@github.com/owner/repo.git', expected_tokens)).to_not be_valid
+          expect(repo_form('ssh://git@github.com/owner/repo.git')).to_not be_valid
         end
       end
 
       context 'when the check is skipped because the repo is not on GitHub' do
         it 'is not valid' do
-          expect(repo_form('ssh://git@bitbucket.com/owner/repo.git', expected_tokens)).to_not be_valid
+          expect(repo_form('ssh://git@bitbucket.com/owner/repo.git')).to_not be_valid
         end
       end
     end
@@ -75,11 +63,21 @@ RSpec.describe Forms::RepositoryLocationsForm do
 
   describe '.default_token_types' do
     it 'returns complete list of token types and default values' do
+      expected_tokens = [
+        { id: 'circleci', name: 'CircleCI (webhook)', value: true },
+        { id: 'circleci-manual', name: 'CircleCI (post test)', value: false },
+        { id: 'deploy', name: 'Deployment', value: true },
+        { id: 'jenkins', name: 'Jenkins', value: false },
+        { id: 'jira', name: 'JIRA', value: false },
+        { id: 'uat', name: 'UAT', value: false },
+        { id: 'github_notifications', name: 'Github Notifications', value: false },
+      ]
+
       expect(Forms::RepositoryLocationsForm.default_token_types).to eq(expected_tokens)
     end
   end
 
-  def repo_form(uri, token_types)
-    Forms::RepositoryLocationsForm.new(uri, token_types)
+  def repo_form(uri)
+    Forms::RepositoryLocationsForm.new(uri)
   end
 end

--- a/spec/models/git_repository_location_spec.rb
+++ b/spec/models/git_repository_location_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe GitRepositoryLocation, :disable_repo_verification do
       location = GitRepositoryLocation.create(uri: 'git@github.com/owner/repo.git')
       expect(location.name).to eq('repo')
     end
+
+    it 'strips whitespace from the URI' do
+      location = GitRepositoryLocation.create(uri: '  git@github.com/owner/repo.git  ')
+      expect(location.uri).to eq('git@github.com/owner/repo.git')
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
Git URI validation improvements.

- [x] Strip whitespace from URI
  - Allows valid repos that are padded with whitespace to still be added
- [x] Checks that the regex match occurs at the beginning of the string
  - Avoids URIs like `foo<uri>` from passing regex validation
- [x] Consider repo not accessible if Octokit does not receive correct format for a repository name
  - Prevents app from blowing up if a valid Git URI is not a valid GitHub URI  
     (GitHub has its own restrictions)
- [x] Handle ports in URIs
  - Prevents URIs like `ssh://git@github.com:not_a_port/repo.git` from passing validation
- [x] Improve user feedback