### PR TITLE
Do not handle push events for annotated tags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,4 +62,7 @@ Style/SignalException:
 Style/FrozenStringLiteralComment:
   Enabled: false  # TODO: Enable in separate PR.
 
+Style/DoubleNegation:
+  Enabled: false
+
 inherit_from: .rubocop_todo.yml

--- a/app/models/payloads/github.rb
+++ b/app/models/payloads/github.rb
@@ -24,6 +24,10 @@ module Payloads
       @data.dig('repository', 'full_name')
     end
 
+    def push_annotated_tag?
+      !!(ref&.start_with?('refs/tags/') && base_ref.nil?)
+    end
+
     def push_to_master?
       @data['ref'] == 'refs/heads/master'
     end
@@ -34,6 +38,16 @@ module Payloads
 
     def branch_deleted?
       @data['deleted']
+    end
+
+    private
+
+    def ref
+      @data['ref']
+    end
+
+    def base_ref
+      @data['base_ref']
     end
   end
 end

--- a/app/use_cases/handle_push_event.rb
+++ b/app/use_cases/handle_push_event.rb
@@ -8,6 +8,7 @@ class HandlePushEvent
 
   def validate(payload)
     return fail :branch_deleted if payload.branch_deleted?
+    return fail :annotated_tag if payload.push_annotated_tag?
     return fail :repo_not_under_audit unless GitRepositoryLocation.repo_tracked?(payload.full_repo_name)
     continue(payload)
   end

--- a/spec/models/payloads/github_spec.rb
+++ b/spec/models/payloads/github_spec.rb
@@ -102,23 +102,56 @@ RSpec.describe Payloads::Github do
     end
   end
 
+  describe '#push_annotated_tag?' do
+    context 'when payload has insufficient data' do
+      it 'returns false' do
+        payload = Payloads::Github.new('some_key' => 'some_value')
+
+        expect(payload.push_annotated_tag?).to be false
+      end
+    end
+
+    context 'when payload is for a commit' do
+      it 'returns false' do
+        data = { 'ref' => 'refs/heads/some-branch', 'base_ref' => nil }
+        payload = Payloads::Github.new(data)
+
+        expect(payload.push_annotated_tag?).to be false
+      end
+    end
+
+    context 'when payload is for a lightweight tag' do
+      it 'returns false' do
+        data = { 'ref' => 'refs/tags/lightweight-tag', 'base_ref' => 'refs/heads/master' }
+        payload = Payloads::Github.new(data)
+
+        expect(payload.push_annotated_tag?).to be false
+      end
+    end
+
+    context 'when payload is for an annotated tag' do
+      it 'returns true' do
+        data = { 'ref' => 'refs/tags/annotated-tag', 'base_ref' => nil }
+        payload = Payloads::Github.new(data)
+
+        expect(payload.push_annotated_tag?).to be true
+      end
+    end
+  end
+
   describe '#push_to_master?' do
     context 'when payload references master branch' do
       it 'returns true' do
-        data = {
-          'ref' => 'refs/heads/master',
-        }
-        payload = Payloads::Github.new(data)
+        payload = Payloads::Github.new('ref' => 'refs/heads/master')
+
         expect(payload.push_to_master?).to be true
       end
     end
 
     context 'when payload does not reference master branch' do
-      it 'returns true' do
-        data = {
-          'ref' => 'refs/heads/changes',
-        }
-        payload = Payloads::Github.new(data)
+      it 'returns false' do
+        payload = Payloads::Github.new('ref' => 'refs/heads/topic-branch')
+
         expect(payload.push_to_master?).to be false
       end
     end

--- a/spec/use_cases/handle_push_event_spec.rb
+++ b/spec/use_cases/handle_push_event_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe HandlePushEvent do
       expect(result).to fail_with(:repo_not_under_audit)
     end
 
+    it 'fails if event is for pushing an annotated tag' do
+      github_payload = instance_double(Payloads::Github, push_annotated_tag?: true, branch_deleted?: false)
+
+      result = HandlePushEvent.run(github_payload)
+      expect(result).to fail_with(:annotated_tag)
+    end
+
     context 'when branch is deleted' do
       let(:payload_data) { default_payload_data.merge('deleted' => true) }
 


### PR DESCRIPTION
Avoids attempting to post commit statuses for annotated tags, which does not work.

Pushes for lightweight tags are still handled, because the SHA will refer to the head commit.
Whereas for annotated tags, the SHA refers to the annotated tag.