### PR TITLE
update database cleaner config to fix cukes

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -41,7 +41,7 @@ ActionController::Base.allow_rescue = false
 # Remove/comment out the lines below if your app doesn't have a database.
 # For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
 begin
-  DatabaseCleaner.strategy = :transaction
+  DatabaseCleaner.strategy = :deletion
 rescue NameError
   raise 'You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it.'
 end
@@ -64,7 +64,11 @@ end
 # Possible values are :truncation and :transaction
 # The :transaction strategy is faster, but might give you threading problems.
 # https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
-Cucumber::Rails::Database.javascript_strategy = :truncation
+Cucumber::Rails::Database.javascript_strategy = :deletion
+
+Around do |scenario, block|
+  DatabaseCleaner.cleaning(&block)
+end
 
 FactoryGirl.find_definitions
 World(FactoryGirl::Syntax::Methods)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -66,7 +66,7 @@ end
 # https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :deletion
 
-Around do |scenario, block|
+Around do |_scenario, block|
   DatabaseCleaner.cleaning(&block)
 end
 

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -29,10 +29,10 @@ namespace :jobs do
     manage_pid pid_path_for('jobs_recreate_snapshots')
 
     repos = Rails.configuration.repositories.dup
-    released_tickets_repo = repos.select {|repo| repo.table_name == 'released_tickets'}.first
+    released_tickets_repo = repos.find { |repo| repo.table_name == 'released_tickets' }
     repos.delete(released_tickets_repo)
 
-    t1=Thread.new{
+    t1 = Thread.new{
       puts "[#{Time.current}] Running recreate_snapshots for #{repos.map(&:table_name)}"
       updater = Repositories::Updater.new(repos)
 
@@ -41,10 +41,9 @@ namespace :jobs do
 
       updater.run(repo_event_id_hash)
       puts "[#{Time.current}] Completed recreate_snapshots for #{repos.map(&:table_name)}"
-
     }
 
-    t2=Thread.new{
+    t2 = Thread.new{
       puts "[#{Time.current}] Running recreate_snapshots for #{released_tickets_repo.table_name}"
       updater = Repositories::Updater.new([released_tickets_repo])
 


### PR DESCRIPTION
As described [here](https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature) threading causes issue if the DatabaseCleaner strategy is set to `transaction`. The author suggests to use `truncation` instead, but when running tests with `truncation` other scenarios fail in our test suite. 

The DatabaseCleaner [documentation](https://github.com/DatabaseCleaner/database_cleaner) suggests `deletion` as alternative strategy. This works, but I experienced some flaky test results - until I added an `Around` hook to explicitly clean the Database for each scenario - see [env.rb](https://github.com/FundingCircle/shipment_tracker/compare/fix-merge-database-cleaner?expand=1#diff-57013262a6cdf1f0f6cb2c64aa762c68R69)
