### PR TITLE
Set word-brake to 'break-word' for bootstrap panel-body

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,3 +96,7 @@ h1 a.glyphicon {
 .monospace {
   font-family: "Courier New", monospace;
 }
+
+.panel-body {
+    word-break: break-word;
+}


### PR DESCRIPTION
So that URLs can be broken into several lines when not fitting the panel