### PR TITLE
Add integration test to prove search by title

### DIFF
--- a/app/controllers/heart_beat_controller.rb
+++ b/app/controllers/heart_beat_controller.rb
@@ -1,0 +1,7 @@
+class HeartBeatController < ApplicationController
+  skip_before_action :require_authentication
+
+  def index
+    head :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root 'home#index'
 
+  get '/heartbeat', to: 'heart_beat#index'
+
   get '/auth/auth0/callback', to: 'sessions#auth0_success_callback'
   post '/auth/developer/callback', to: 'sessions#auth0_success_callback'
 

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -28,3 +28,16 @@ Scenario: User finds tickets by deployed app name
   Then I should find the following tickets on the dashboard:
     | Jira Key | Summary     | Description | Deploys                         |
     | ENG-2    | Second task | Something   | GB 2016-03-21 12:02 UTC app_1 #abc |
+
+@mock_slack_notifier
+Scenario: User finds ticket by title
+  Given the following tickets are created:
+    | Jira Key | Summary                 | Description                    | Deploys                     |
+    | ENG-1    | Make this task          | As a User\n make the task      | 2016-03-21 12:02 app_1 #abc |
+    | ENG-2    | Implement this critical | As a User\n do another task    | 2016-03-22 15:13 app_2 #def |
+    | ENG-3    | Perform that issue      | As a User\n perform some story | 2016-03-22 16:13 app_3 #ghj |
+  When I search tickets with keywords "implement issue"
+  Then I should find the following tickets on the dashboard:
+    | Jira Key | Summary                 | Description                  | Deploys                            |
+    | ENG-2    | Implement this critical | As a User do another task    | GB 2016-03-22 15:13 UTC app_2 #def |
+    | ENG-3    | Perform that issue      | As a User perform some story | GB 2016-03-22 16:13 UTC app_3 #ghj |

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -26,13 +26,13 @@ Given 'the following tickets are created:' do |tickets_table|
 
       And a commit "#master_1" by "Alice" is created at "#{(datetime - 5.hours)}" for app "#{app_name}"
       And the branch "feature" is checked out
-      And a commit "#feat_1" with message "some commit" is created at "#{(datetime - 4.hours)}"
+      And a commit "#feat_1_#{app_name}" with message "some commit" is created at "#{(datetime - 4.hours)}"
       And the branch "master" is checked out
       And the branch "feature" is merged with merge commit "#{deploy_sha}" at "#{(datetime - 3.hours)}"
 
       And developer prepares review known as "#{fr}" for UAT "uat.fundingcircle.com" with apps
-        | app_name    | version |
-        | #{app_name} | #feat_1 |
+        | app_name    | version             |
+        | #{app_name} | #feat_1_#{app_name} |
 
       And at time "#{(datetime - 2.hours)}" adds link for review "#{fr}" to comment for ticket "#{ticket}"
 

--- a/spec/controllers/heart_beat_controller_spec.rb
+++ b/spec/controllers/heart_beat_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe HeartBeatController, type: :controller do
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an integration test which shows that searching tickets by title works.

Original heartbeat was done on home controller. That had to be removed, since home controller now hosts the dashboard and has to be authenticates.
This PR adds heart beat on `/heartbeat` route so that we can continue monitoring our app.