### PR TITLE
Fix search by deployed app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :data_maintenance_warning
 
   def git_repository_loader
-    @git_repository_loader ||= GitRepositoryLoader.from_rails_config
+    GitRepositoryLoader.from_rails_config
   end
 
   def event_factory

--- a/app/models/git_commit.rb
+++ b/app/models/git_commit.rb
@@ -16,6 +16,12 @@ class GitCommit
   end
 
   def associated_ids
-    [id, parent_ids.second].compact
+    [id, merged_branch_head_commit].compact
+  end
+
+  private
+
+  def merged_branch_head_commit
+    parent_ids[1]
   end
 end

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -151,6 +151,8 @@ class GitRepository
   end
 
   def build_commit(commit)
+    return GitCommit.new unless commit
+
     GitCommit.new(
       id: commit.oid,
       author_name: commit.author[:name],

--- a/app/models/git_repository_loader.rb
+++ b/app/models/git_repository_loader.rb
@@ -9,12 +9,11 @@ class GitRepositoryLoader
   class BadLocation < RuntimeError; end
 
   def self.from_rails_config
-    config = Rails.configuration
-    new(
-      ssh_private_key: config.ssh_private_key,
-      ssh_public_key: config.ssh_public_key,
-      ssh_user: config.ssh_user,
-      cache_dir: config.git_repository_cache_dir,
+    @repo_loader ||= new(
+      ssh_private_key: Rails.configuration.ssh_private_key,
+      ssh_public_key: Rails.configuration.ssh_public_key,
+      ssh_user: Rails.configuration.ssh_user,
+      cache_dir: Rails.configuration.git_repository_cache_dir,
     )
   end
 

--- a/app/models/released_ticket.rb
+++ b/app/models/released_ticket.rb
@@ -1,0 +1,13 @@
+require 'virtus'
+
+class ReleasedTicket
+  include Virtus.value_object
+
+  values do
+    attribute :key, String
+    attribute :summary, String, default: ''
+    attribute :description, String, default: ''
+    attribute :versions, Array, default: []
+    attribute :deploys, Array, default: []
+  end
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -12,7 +12,6 @@ class Ticket
     attribute :approved_at, DateTime
     attribute :version_timestamps, Hash[String => DateTime]
     attribute :versions, Array, default: []
-    attribute :deploys, Array, default: []
   end
 
   def authorisation_status(versions_under_review)

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -17,6 +17,7 @@ Scenario: User finds deployed tickets by description
     | ENG-3    | Another story | As a User implement another story | 2016-03-21 12:02 UTC app_1 #ghi |
     | ENG-2    | Another task  | As a User implement another task  | 2016-03-21 12:02 UTC app_1 #def |
 
+@mock_slack_notifier
 Scenario: User finds tickets by deployed app name
   Given the following tickets are created:
     | Jira Key | Summary     | Description | Deploys                     |

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -16,7 +16,7 @@ Given 'the following tickets are created:' do |tickets_table|
 
     deploys = ticket_row['Deploys']
     next if deploys.empty?
-    date, time, app_name, sha = deploys.split
+    date, time, app_name, deploy_sha = deploys.split
     datetime = Time.zone.parse("#{date} #{time}")
     fr = "FR_#{app_name}"
     ticket = ticket_row['Jira Key']
@@ -24,17 +24,21 @@ Given 'the following tickets are created:' do |tickets_table|
     steps %(
       Given an application called "#{app_name}"
 
-      And a commit "#{sha}" by "Alice" is created at "#{(datetime - 3.hours)}" for app "#{app_name}"
+      And a commit "#master_1" by "Alice" is created at "#{(datetime - 5.hours)}" for app "#{app_name}"
+      And the branch "feature" is checked out
+      And a commit "#feat_1" with message "some commit" is created at "#{(datetime - 4.hours)}"
+      And the branch "master" is checked out
+      And the branch "feature" is merged with merge commit "#{deploy_sha}" at "#{(datetime - 3.hours)}"
 
       And developer prepares review known as "#{fr}" for UAT "uat.fundingcircle.com" with apps
         | app_name    | version |
-        | #{app_name} | #{sha}  |
+        | #{app_name} | #feat_1 |
 
       And at time "#{(datetime - 2.hours)}" adds link for review "#{fr}" to comment for ticket "#{ticket}"
 
       And ticket "#{ticket}" is approved by "bob@fundingcircle.com" at "#{(datetime - 1.hour)}"
 
-      And commit "#{sha}" of "#{app_name}" is deployed by "Jeff" to production at "#{datetime}"
+      And commit "#{deploy_sha}" of "#{app_name}" is deployed by "Jeff" to production at "#{datetime}"
     )
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -11,26 +11,4 @@ namespace :db do
       f.write ERB.new(file_contents).result
     end
   end
-
-  desc 'reindex released tickets if indexing trigger exists'
-  task reindex_tickets: :environment do
-    check_trigger_exists_and_reindex
-  end
-
-  def check_trigger_exists_and_reindex
-    @connection = ActiveRecord::Base.connection
-    result = @connection.exec_query(
-      "SELECT tgname FROM pg_trigger WHERE not tgisinternal AND tgrelid = 'released_tickets'::regclass",
-    )
-
-    if result.first[:tgname] == 'released_tickets_tsv_update'
-      puts 'ERROR: Trigger does not exist for released_tickets relation, aborting!'
-      puts 'Tickets were not indexed'
-      return
-    end
-
-    now = Time.current.to_s(:db)
-    @connection.exec_query("UPDATE released_tickets SET updated_at = '#{now}'")
-    puts 'Tickets indexed successfully =)'
-  end
 end

--- a/spec/controllers/feature_reviews_controller_spec.rb
+++ b/spec/controllers/feature_reviews_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe FeatureReviewsController do
         uat_url: 'http://uat.example.com',
         git_repository_loader: git_repository_loader,
       ).and_return(feature_review_form)
-      allow(GitRepositoryLoader).to receive(:new).and_return(git_repository_loader)
+      allow(GitRepositoryLoader).to receive(:from_rails_config).and_return(git_repository_loader)
     end
 
     context 'when the params are invalid' do
@@ -161,7 +161,7 @@ RSpec.describe FeatureReviewsController do
       allow(VersionResolver).to receive(:new).with(repo).and_return(version_resolver)
       allow(version_resolver).to receive(:related_versions).with(version).and_return(related_versions)
       allow(GitRepositoryLocation).to receive(:app_names).and_return(applications)
-      allow(GitRepositoryLoader).to receive(:new).and_return(git_repository_loader)
+      allow(GitRepositoryLoader).to receive(:from_rails_config).and_return(git_repository_loader)
       allow(Repositories::TicketRepository).to receive(:new).and_return(repository)
       allow(repository).to receive(:tickets_for_versions)
         .with(related_versions)

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -180,8 +180,14 @@ RSpec.describe GitRepository do
 
     it 'returns a GitCommit object for a given sha' do
       commit = subject.commit_for_version(version('A'))
-      expect(commit).to be_kind_of(GitCommit)
+      expect(commit).to be_a(GitCommit)
       expect(commit.id).to eq version('A')
+    end
+
+    it 'returns an empty GitCommit when the lookup fails' do
+      commit = subject.commit_for_version('invalid_sha')
+      expect(commit).to be_a(GitCommit)
+      expect(commit.associated_ids).to be_empty
     end
   end
 


### PR DESCRIPTION
Frequently Feature Review is created for head of topic branch, but the deploy to production happens for the commit merged to master. This prevented us to index all deploys which behave in such way. 

This PR looks at both commits, the head of topic branch and the merged commit to master to decide if there was a deploy for a given ticket.