### PR TITLE
Rescue when repo not found

### DIFF
--- a/app/models/repositories/build_repository.rb
+++ b/app/models/repositories/build_repository.rb
@@ -9,6 +9,7 @@ module Repositories
       @store = store
     end
 
+    attr_reader :store
     delegate :table_name, to: :store
 
     def apply(event)
@@ -29,8 +30,6 @@ module Repositories
     end
 
     private
-
-    attr_reader :store
 
     def builds(versions, at)
       query = at ? store.arel_table['event_created_at'].lteq(at) : nil

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -9,6 +9,7 @@ module Repositories
       @store = store
     end
 
+    attr_reader :store
     delegate :table_name, to: :store
 
     def deploys_for(apps: nil, server:, at: nil)
@@ -49,8 +50,6 @@ module Repositories
     end
 
     private
-
-    attr_reader :store
 
     def create_deploy_snapshot!(event)
       store.create!(

--- a/app/models/repositories/manual_test_repository.rb
+++ b/app/models/repositories/manual_test_repository.rb
@@ -8,6 +8,7 @@ module Repositories
       @store = store
     end
 
+    attr_reader :store
     delegate :table_name, to: :store
 
     def qa_submission_for(versions:, at: nil)
@@ -27,8 +28,6 @@ module Repositories
     end
 
     private
-
-    attr_reader :store
 
     def qa_submission(versions, at)
       query = at ? table['created_at'].lteq(at) : nil

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -12,6 +12,7 @@ module Repositories
       @feature_review_factory = Factories::FeatureReviewFactory.new
     end
 
+    attr_reader :store
     delegate :table_name, to: :store
 
     def tickets_for_path(feature_review_path, at: nil)
@@ -46,7 +47,7 @@ module Repositories
 
     private
 
-    attr_reader :store, :git_repository_location, :feature_review_factory
+    attr_reader :git_repository_location, :feature_review_factory
 
     def previous_ticket_data(key)
       attrs = store.where(key: key).last.try(:attributes) || {}

--- a/app/models/repositories/uatest_repository.rb
+++ b/app/models/repositories/uatest_repository.rb
@@ -10,6 +10,7 @@ module Repositories
       @deploy_repository = deploy_repository
     end
 
+    attr_reader :store
     delegate :table_name, to: :store
 
     def uatest_for(versions:, server:, at: nil)
@@ -30,7 +31,7 @@ module Repositories
 
     private
 
-    attr_reader :store, :deploy_repository
+    attr_reader :deploy_repository
 
     def uatest(versions, server, at)
       query = at ? store.arel_table['event_created_at'].lteq(at) : nil

--- a/app/models/repositories/updater.rb
+++ b/app/models/repositories/updater.rb
@@ -33,7 +33,7 @@ module Repositories
     attr_reader :repositories
 
     def run_for(repository, ceiling_id)
-      ActiveRecord::Base.transaction do
+      repository.store.transaction do
         last_id = 0
         new_events_for(repository, ceiling_id).each do |event|
           last_id = event.id
@@ -52,9 +52,11 @@ module Repositories
     end
 
     def update_count_for(repository, id)
-      record = Snapshots::EventCount.find_or_create_by(snapshot_name: repository.table_name)
-      record.event_id = id
-      record.save!
+      Snapshots::EventCount.transaction do
+        record = Snapshots::EventCount.find_or_create_by(snapshot_name: repository.table_name)
+        record.event_id = id
+        record.save!
+      end
     end
 
     def all_tables

--- a/spec/models/repositories/updater_spec.rb
+++ b/spec/models/repositories/updater_spec.rb
@@ -15,9 +15,18 @@ RSpec.describe Repositories::Updater do
       expect(Repositories::Updater.from_rails_config).to eq(expected_updater)
     end
   end
-
-  let(:repository_1) { instance_double(Repositories::BuildRepository, 'repository_1', table_name: 'tbl_1') }
-  let(:repository_2) { instance_double(Repositories::DeployRepository, 'repository_2', table_name: 'tbl_2') }
+  let(:repository_1) {
+    instance_double(Repositories::BuildRepository,
+      'repository_1',
+      store: Snapshots::Build,
+      table_name: 'tbl_1')
+  }
+  let(:repository_2) {
+    instance_double(Repositories::DeployRepository,
+      'repository_2',
+      store: Snapshots::Deploy,
+      table_name: 'tbl_2')
+  }
   let(:repositories) { [repository_1, repository_2] }
 
   let(:events) { [build(:jira_event), build(:jira_event)] }


### PR DESCRIPTION
Also this improves the transaction on DB tables locking just the tables that are being used for the current snapshotting