### PR TITLE
show deploy regions on dashboard results

### DIFF
--- a/app/models/repositories/released_ticket_repository.rb
+++ b/app/models/repositories/released_ticket_repository.rb
@@ -45,32 +45,40 @@ module Repositories
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
     def snapshot_deploy_event(event)
       return unless event.version
       begin
-        git_repo = git_repository(event.app_name)
-        commit = git_repo.commit_for_version(event.version)
+        commit = git_repository(event.app_name).commit_for_version(event.version)
 
         tickets_for_versions(commit.associated_ids).each do |record|
-          next if record.deploys.map { |deploy| deploy['version'] }.include?(event.version)
+          next if new_deploy_to_region(record.deploys, event)
 
           record.deploys << build_deploy_hash(event)
           record.save!
         end
       rescue GitRepositoryLoader::NotFound => e
-        Rails.logger.warn "Could not find the repository '#{event.app_name}' locally"
-        Rails.logger.warn e.message
+        log_warning(e, event)
       end
     end
-    # rubocop:enable Metrics/AbcSize
+
+    def log_warning(error, event)
+      Rails.logger.warn "Could not find the repository '#{event.app_name}' locally"
+      Rails.logger.warn error.message
+    end
+
+    def new_deploy_to_region(deploys_for_record, event)
+      deploys_for_record.any? { |deploy_hash|
+        deploy_hash['version'] == event.version && deploy_hash['region'] == event.locale
+      }
+    end
 
     def build_deploy_hash(event)
       {
         app: event.app_name,
-        version: event.version,
         deployed_at: event.created_at.strftime('%F %H:%M %Z'),
         github_url: GitRepositoryLocation.github_url_for_app(event.app_name),
+        region: event.locale,
+        version: event.version,
       }
     end
 

--- a/app/models/repositories/released_ticket_repository.rb
+++ b/app/models/repositories/released_ticket_repository.rb
@@ -51,7 +51,7 @@ module Repositories
         commit = git_repository(event.app_name).commit_for_version(event.version)
 
         tickets_for_versions(commit.associated_ids).each do |record|
-          next if new_deploy_to_region(record.deploys, event)
+          next if duplicate_deploy?(record.deploys, event)
 
           record.deploys << build_deploy_hash(event)
           record.save!
@@ -66,7 +66,7 @@ module Repositories
       Rails.logger.warn error.message
     end
 
-    def new_deploy_to_region(deploys_for_record, event)
+    def duplicate_deploy?(deploys_for_record, event)
       deploys_for_record.any? { |deploy_hash|
         deploy_hash['version'] == event.version && deploy_hash['region'] == event.locale
       }

--- a/app/views/home/dashboard.html.haml
+++ b/app/views/home/dashboard.html.haml
@@ -26,5 +26,6 @@
                 = jira_link(ticket.key)
               - ticket.deploys.each do |deploy|
                 %p.deploy
+                  = flag_icon(deploy['region'].to_sym)
                   = "#{deploy['deployed_at']} #{deploy['app']}"
                   = "#{commit_link(deploy['version'], deploy['github_url'])}".html_safe

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -14,8 +14,8 @@ Scenario: User finds deployed tickets by description
   When I search tickets with keywords "another story"
   Then I should find the following tickets on the dashboard:
     | Jira Key | Summary       | Description                       | Deploys                         |
-    | ENG-3    | Another story | As a User implement another story | 2016-03-21 12:02 UTC app_1 #ghi |
-    | ENG-2    | Another task  | As a User implement another task  | 2016-03-21 12:02 UTC app_1 #def |
+    | ENG-3    | Another story | As a User implement another story | GB 2016-03-21 12:02 UTC app_1 #ghi |
+    | ENG-2    | Another task  | As a User implement another task  | GB 2016-03-21 12:02 UTC app_1 #def |
 
 @mock_slack_notifier
 Scenario: User finds tickets by deployed app name
@@ -27,4 +27,4 @@ Scenario: User finds tickets by deployed app name
   When I search tickets with keywords "app_1"
   Then I should find the following tickets on the dashboard:
     | Jira Key | Summary     | Description | Deploys                         |
-    | ENG-2    | Second task | Something   | 2016-03-21 12:02 UTC app_1 #abc |
+    | ENG-2    | Second task | Something   | GB 2016-03-21 12:02 UTC app_1 #abc |

--- a/features/support/sections/results_section.rb
+++ b/features/support/sections/results_section.rb
@@ -10,7 +10,9 @@ module Sections
           'Jira Key' => jira_element(panel_element, 'key')&.text,
           'Summary' =>  jira_element(panel_element, 'summary')&.text,
           'Description' => jira_element(panel_element, 'description')&.text,
-          'Deploys' => jira_elements(panel_element, 'deploy').map(&:text),
+          'Deploys' => jira_elements(panel_element, 'deploy').map {|e|
+                         "#{e.find('span.flag-icon')[:class].split('-').last.upcase} #{e.text}"
+                       },
         }
       }
     end


### PR DESCRIPTION
When deploying to multiple regions, 
I want to see deploy info for each region in the dashboard results,
so that I know when a ticket was released in a specific region. 