### PR TITLE
Remove environment from Heroku DeployEvent app name

### DIFF
--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -5,7 +5,7 @@ require 'events/deploy_event'
 RSpec.describe Events::DeployEvent do
   subject { Events::DeployEvent.new(details: payload) }
 
-  context 'given an expected payload' do
+  context 'given a custom payload' do
     let(:payload) {
       {
         'app_name' => 'some_app',
@@ -84,7 +84,7 @@ RSpec.describe Events::DeployEvent do
     }
 
     it 'returns the correct values' do
-      expect(subject.app_name).to eq('us-nameless-forest-uat')
+      expect(subject.app_name).to eq('us-nameless-forest')
       expect(subject.deployed_by).to eq('user@example.com')
       expect(subject.environment).to eq('uat')
       expect(subject.locale).to eq('us')

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Events::DeployEvent do
   context 'given an expected payload' do
     let(:payload) {
       {
-        'app_name' => 'soMeApp',
+        'app_name' => 'some_app',
         'servers' => ['prod1.example.com', 'prod2.example.com'],
-        'version' => '123abc',
+        'version' => 'abc123',
         'deployed_by' => 'bob',
         'locale' => 'us',
         'environment' => 'staging',
@@ -18,9 +18,9 @@ RSpec.describe Events::DeployEvent do
     }
 
     it 'returns the correct values' do
-      expect(subject.app_name).to eq('someapp')
+      expect(subject.app_name).to eq('some_app')
       expect(subject.server).to eq('prod1.example.com')
-      expect(subject.version).to eq('123abc')
+      expect(subject.version).to eq('abc123')
       expect(subject.deployed_by).to eq('bob')
       expect(subject.environment).to eq('staging')
       expect(subject.locale).to eq('us')
@@ -36,23 +36,34 @@ RSpec.describe Events::DeployEvent do
       end
     end
 
-    context 'when the payload structure is deprecated' do
+    context 'when the payload contains uppercased values' do
       let(:payload) {
         {
-          'app_name' => 'soMeApp',
-          'server' => 'uat.example.com',
-          'version' => '123abc',
-          'deployed_by' => 'bob',
+          'app_name' => 'AwesomeApp',
+          'servers' => ['PROD.example.com'],
+          'version' => 'ABC123',
+          'deployed_by' => 'Johnny Five',
+          'locale' => 'GB',
           'environment' => 'UAT',
         }
       }
 
-      it 'returns the correct downcased values' do
-        expect(subject.app_name).to eq('someapp')
-        expect(subject.server).to eq('uat.example.com')
-        expect(subject.version).to eq('123abc')
-        expect(subject.deployed_by).to eq('bob')
+      it 'downcases the app_name, environment, and locale' do
+        expect(subject.app_name).to eq('awesomeapp')
         expect(subject.environment).to eq('uat')
+        expect(subject.locale).to eq('gb')
+
+        expect(subject.server).to eq('PROD.example.com')
+        expect(subject.version).to eq('ABC123')
+        expect(subject.deployed_by).to eq('Johnny Five')
+      end
+    end
+
+    context 'when the payload contains deprecated params' do
+      let(:payload) { { 'server' => 'uat.example.com' } }
+
+      it 'returns the correct values' do
+        expect(subject.server).to eq('uat.example.com')
       end
     end
   end

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -5,18 +5,18 @@ require 'events/deploy_event'
 RSpec.describe Events::DeployEvent do
   subject { Events::DeployEvent.new(details: payload) }
 
-  let(:payload) {
-    {
-      'app_name' => 'soMeApp',
-      'servers' => ['prod1.example.com', 'prod2.example.com'],
-      'version' => '123abc',
-      'deployed_by' => 'bob',
-      'locale' => 'us',
-      'environment' => 'staging',
+  context 'given an expected payload' do
+    let(:payload) {
+      {
+        'app_name' => 'soMeApp',
+        'servers' => ['prod1.example.com', 'prod2.example.com'],
+        'version' => '123abc',
+        'deployed_by' => 'bob',
+        'locale' => 'us',
+        'environment' => 'staging',
+      }
     }
-  }
 
-  context 'when given a valid payload' do
     it 'returns the correct values' do
       expect(subject.app_name).to eq('someapp')
       expect(subject.server).to eq('prod1.example.com')
@@ -33,71 +33,6 @@ RSpec.describe Events::DeployEvent do
 
       it 'uses default locale "gb"' do
         expect(subject.locale).to eq('gb')
-      end
-    end
-
-    context 'when the payload comes from Heroku' do
-      let(:payload) {
-        {
-          'app' => 'us-nameless-forest-uat',
-          'app_uuid' => '8d1e4aff-eac8-4ced-90c8-bf97f8334a4c',
-          'git_log' => '',
-          'head' => '2beae04',
-          'head_long' => '2beae049a22c053883661771551f914d2d3de6e5',
-          'prev_head' => '7650eb713bcaae1e4c03637eae2e333fc4fb5a74',
-          'release' => 'v189',
-          'url' => 'http://us-nameless-forest-uat.herokuapp.com',
-          'user' => 'user@example.com',
-        }
-      }
-
-      it 'returns the correct values' do
-        expect(subject.app_name).to eq('us-nameless-forest-uat')
-        expect(subject.deployed_by).to eq('user@example.com')
-        expect(subject.environment).to eq('uat')
-        expect(subject.locale).to eq('us')
-        expect(subject.server).to eq('http://us-nameless-forest-uat.herokuapp.com')
-        expect(subject.version).to eq('2beae049a22c053883661771551f914d2d3de6e5')
-      end
-
-      context 'when the app name does not have the environment in lowercase' do
-        before do
-          payload['app'] = 'nameless-forest-UAT'
-        end
-
-        it 'downcases the environment' do
-          expect(subject.environment).to eq('uat')
-        end
-      end
-
-      context 'when the app name does not have the locale prefix in lowercase' do
-        before do
-          payload['app'] = 'GB-nameless-forest'
-        end
-
-        it 'downcases the environment' do
-          expect(subject.locale).to eq('gb')
-        end
-      end
-
-      context 'when the app name does not include the environment at the end' do
-        before do
-          payload['app'] = 'nameless-forest'
-        end
-
-        it 'sets the environment to nil' do
-          expect(subject.environment).to be nil
-        end
-      end
-
-      context 'when the app name does not include the locale prefix' do
-        before do
-          payload['app'] = 'nameless-forest'
-        end
-
-        it 'sets the environment to nil' do
-          expect(subject.locale).to eq('us')
-        end
       end
     end
 
@@ -122,12 +57,73 @@ RSpec.describe Events::DeployEvent do
     end
   end
 
-  context 'when given an invalid payload' do
+  context 'given a Heroku payload' do
     let(:payload) {
       {
-        'bad' => 'news',
+        'app' => 'us-nameless-forest-uat',
+        'app_uuid' => '8d1e4aff-eac8-4ced-90c8-bf97f8334a4c',
+        'git_log' => '',
+        'head' => '2beae04',
+        'head_long' => '2beae049a22c053883661771551f914d2d3de6e5',
+        'prev_head' => '7650eb713bcaae1e4c03637eae2e333fc4fb5a74',
+        'release' => 'v189',
+        'url' => 'http://us-nameless-forest-uat.herokuapp.com',
+        'user' => 'user@example.com',
       }
     }
+
+    it 'returns the correct values' do
+      expect(subject.app_name).to eq('us-nameless-forest-uat')
+      expect(subject.deployed_by).to eq('user@example.com')
+      expect(subject.environment).to eq('uat')
+      expect(subject.locale).to eq('us')
+      expect(subject.server).to eq('http://us-nameless-forest-uat.herokuapp.com')
+      expect(subject.version).to eq('2beae049a22c053883661771551f914d2d3de6e5')
+    end
+
+    context 'when the app name does not have the environment in lowercase' do
+      before do
+        payload['app'] = 'nameless-forest-UAT'
+      end
+
+      it 'downcases the environment' do
+        expect(subject.environment).to eq('uat')
+      end
+    end
+
+    context 'when the app name does not have the locale prefix in lowercase' do
+      before do
+        payload['app'] = 'GB-nameless-forest'
+      end
+
+      it 'downcases the environment' do
+        expect(subject.locale).to eq('gb')
+      end
+    end
+
+    context 'when the app name does not include the environment at the end' do
+      before do
+        payload['app'] = 'nameless-forest'
+      end
+
+      it 'sets the environment to nil' do
+        expect(subject.environment).to be nil
+      end
+    end
+
+    context 'when the app name does not include the locale prefix' do
+      before do
+        payload['app'] = 'nameless-forest'
+      end
+
+      it 'sets the environment to nil' do
+        expect(subject.locale).to eq('us')
+      end
+    end
+  end
+
+  context 'given an unexpected payload' do
+    let(:payload) { { 'some' => 'value' } }
 
     it 'returns the correct values' do
       expect(subject.app_name).to be nil
@@ -135,6 +131,7 @@ RSpec.describe Events::DeployEvent do
       expect(subject.version).to be nil
       expect(subject.deployed_by).to be nil
       expect(subject.environment).to be nil
+      expect(subject.locale).to eq 'gb'
     end
   end
 end


### PR DESCRIPTION
In our latest snapshot repository, `ReleasedTicketRepository`, we load Git repositories via the app name that we get from DeployEvents. This would fail for Heroku DeployEvents, because most Heroku apps follow a naming convention of `APPNAME-ENVIRONMENT`, e.g. "awesomeapp-staging", but the repository name would be "awesomeapp".

Also includes refactoring of `DeployEvent` model. Previously we handled Heroku payloads via fallbacks  but that behaviour was difficult to follow. It's now more explicit how we handle the payload depending on if it's a Heroku deploy. The plan was to then extract it to its own class using STI but it's a difficult change because it would require a new `EventType` and endpoint, and changing the webhook endpoint for all onboarded Heroku apps is not trivial. So that's deferred.