### PR TITLE
Add a new line between deployer info and reason.

### DIFF
--- a/app/models/deploy_alert.rb
+++ b/app/models/deploy_alert.rb
@@ -26,25 +26,25 @@ class DeployAlert
   end
 
   def self.alert_not_authorised(deploy)
-    "#{alert_header(deploy)} Release not authorised; Feature Review not approved."
+    "#{alert_header(deploy)}Release not authorised; Feature Review not approved."
   end
 
   def self.alert_not_on_master(deploy)
-    "#{alert_header(deploy)} Version does not exist on GitHub master branch."
+    "#{alert_header(deploy)}Version does not exist on GitHub master branch."
   end
 
   def self.alert_unknown_version(deploy)
-    "#{alert_header(deploy)} Deploy event sent to Shipment Tracker is missing the software version."
+    "#{alert_header(deploy)}Deploy event sent to Shipment Tracker is missing the software version."
   end
 
   def self.alert_rollback(deploy)
-    "#{alert_header(deploy)} Old release deployed. Was the rollback intentional?"
+    "#{alert_header(deploy)}Old release deployed. Was the rollback intentional?"
   end
 
   def self.alert_header(deploy)
     time = deploy.event_created_at.strftime('%F %H:%M%:z')
     "#{deploy.region.upcase} Deploy Alert for #{deploy.app_name} at #{time}.\n" \
-    "#{deploy.deployed_by} deployed #{deploy.version || 'unknown version'}."
+    "#{deploy.deployed_by} deployed #{deploy.version || 'unknown version'}.\n"
   end
   private_class_method :alert_header
 

--- a/features/step_definitions/deploy_alert_steps.rb
+++ b/features/step_definitions/deploy_alert_steps.rb
@@ -5,7 +5,7 @@ Then 'a deploy alert should be dispatched for' do |table|
 
     expect(SlackClient).to have_received(:send_deploy_alert).with(
       "GB Deploy Alert for #{app} at #{time}.\n"\
-      "#{deployer} deployed #{scenario_context.resolve_version(version)}. #{msg}",
+      "#{deployer} deployed #{scenario_context.resolve_version(version)}.\n#{msg}",
       'https://localhost/releases/frontend?region=gb',
       app,
       deployer,

--- a/spec/models/deploy_alert_spec.rb
+++ b/spec/models/deploy_alert_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe DeployAlert do
   def message(deploy, reason)
     "#{deploy.region.upcase} Deploy Alert for #{deploy.app_name} " \
     "at #{deploy.event_created_at.strftime('%F %H:%M%:z')}.\n"\
-    "#{deploy.deployed_by} deployed #{deploy.version || 'unknown version'}. #{reason}"
+    "#{deploy.deployed_by} deployed #{deploy.version || 'unknown version'}.\n#{reason}"
   end
 
   def version(pretend_version)


### PR DESCRIPTION
Makes the deploy alerts easier to read.