### PR TITLE
Optimize ticket snapshotting

### DIFF
--- a/app/jobs/relink_ticket_job.rb
+++ b/app/jobs/relink_ticket_job.rb
@@ -12,11 +12,11 @@ class RelinkTicketJob < ActiveJob::Base
     full_repo_name = args.delete(:full_repo_name)
     branch_created = args.delete(:branch_created)
 
-    linked_tickets = relink_tickets(before_sha, after_sha) unless branch_created
-
-    post_not_found_status(full_repo_name: full_repo_name, sha: after_sha) \
-      if branch_created || linked_tickets&.empty?
-    post_error_status(full_repo_name: full_repo_name, sha: after_sha) if @send_error_status
+    if branch_created || relink_tickets(before_sha, after_sha).empty?
+      post_not_found_status(full_repo_name: full_repo_name, sha: after_sha)
+    elsif @send_error_status
+      post_error_status(full_repo_name: full_repo_name, sha: after_sha)
+    end
   end
 
   private
@@ -31,7 +31,6 @@ class RelinkTicketJob < ActiveJob::Base
         link_feature_review_to_ticket(ticket.key, feature_review_path, before_sha, after_sha)
       end
     end
-    linked_tickets
   end
 
   def link_feature_review_to_ticket(ticket_key, old_feature_review_path, before_sha, after_sha)

--- a/app/models/events/circle_ci_event.rb
+++ b/app/models/events/circle_ci_event.rb
@@ -8,15 +8,11 @@ module Events
     end
 
     def success
-      status = details
-               .fetch('payload', {})
-               .fetch('outcome', nil)
-
-      status == 'success'
+      details.dig('payload', 'outcome') == 'success'
     end
 
     def version
-      details.fetch('payload', {}).fetch('vcs_revision', 'unknown')
+      details.dig('payload', 'vcs_revision') || 'unknown'
     end
   end
 end

--- a/app/models/events/jenkins_event.rb
+++ b/app/models/events/jenkins_event.rb
@@ -8,18 +8,11 @@ module Events
     end
 
     def success
-      status = details
-               .fetch('build', {})
-               .fetch('status', nil)
-
-      status == 'SUCCESS'
+      details.dig('build', 'status') == 'SUCCESS'
     end
 
     def version
-      details
-        .fetch('build', {})
-        .fetch('scm', {})
-        .fetch('commit', 'unknown')
+      details.dig('build', 'scm', 'commit') || 'unknown'
     end
   end
 end

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -4,7 +4,7 @@ require 'events/base_event'
 module Events
   class JiraEvent < Events::BaseEvent
     def key
-      details.fetch('issue').fetch('key')
+      details.dig('issue', 'key')
     end
 
     def issue?
@@ -12,29 +12,29 @@ module Events
     end
 
     def issue_id
-      details.fetch('issue').fetch('id')
+      details.dig('issue', 'id')
     end
 
     def summary
-      details.fetch('issue').fetch('fields').fetch('summary')
+      details.dig('issue', 'fields', 'summary')
     end
 
     def description
-      details.fetch('issue').fetch('fields').fetch('description')
+      details.dig('issue', 'fields', 'description')
     end
 
     def status
-      details.fetch('issue').fetch('fields').fetch('status').fetch('name')
+      details.dig('issue', 'fields', 'status', 'name')
     end
 
     def comment
-      details.fetch('comment', {}).fetch('body', '')
+      details.dig('comment', 'body') || ''
     end
 
     def approval?
       status_item &&
-        approved_status?(status_item['toString']) &&
-        !approved_status?(status_item['fromString'])
+        !approved_status?(status_item['fromString']) &&
+        approved_status?(status_item['toString'])
     end
 
     def unapproval?
@@ -50,7 +50,7 @@ module Events
     end
 
     def changelog_items
-      details.fetch('changelog', 'items' => []).fetch('items')
+      details.dig('changelog', 'items') || []
     end
 
     def approved_status?(status)

--- a/app/models/repositories/released_ticket_repository.rb
+++ b/app/models/repositories/released_ticket_repository.rb
@@ -139,7 +139,7 @@ module Repositories
     end
 
     def tickets_for_versions(versions)
-      store.where('versions && ARRAY[?]::varchar[]', versions)
+      store.where('versions && ARRAY[?]', versions)
     end
 
     def released_commits(app_name, current_version, previous_version = nil)

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -39,9 +39,10 @@ module Repositories
       return unless event.is_a?(Events::JiraEvent) && event.issue?
 
       feature_reviews = feature_review_factory.create_from_text(event.comment)
-      return if feature_reviews.empty?
-
       last_ticket = previous_ticket_data(event.key)
+
+      return if last_ticket.empty? && feature_reviews.empty?
+
       new_ticket = build_ticket(last_ticket, event, feature_reviews)
       store.create!(new_ticket)
 

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -97,8 +97,11 @@ module Repositories
     end
 
     def merge_approved_at(last_ticket, event)
-      return nil unless event.approval?
-      last_ticket['approved_at'] || event.created_at
+      if event.approval?
+        event.created_at
+      elsif last_ticket.present? && Ticket.new(status: event.status).approved?
+        last_ticket['approved_at']
+      end
     end
 
     def update_github_status_for(ticket_hash)

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -39,6 +39,7 @@ module Repositories
       return unless event.is_a?(Events::JiraEvent) && event.issue?
 
       feature_reviews = feature_review_factory.create_from_text(event.comment)
+      return if feature_reviews.empty?
 
       last_ticket = previous_ticket_data(event.key)
       new_ticket = build_ticket(last_ticket, event, feature_reviews)

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -30,7 +30,7 @@ module Repositories
     def tickets_for_versions(versions)
       store
         .select('DISTINCT ON (key) *')
-        .where('versions && ARRAY[?]::varchar[]', versions)
+        .where('versions && ARRAY[?]', versions)
         .order('key, id DESC')
         .map { |t| Ticket.new(t.attributes) }
     end

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -7,14 +7,15 @@ require 'ticket'
 
 module Repositories
   class TicketRepository
+    attr_reader :store
+
+    delegate :table_name, to: :store
+
     def initialize(store = Snapshots::Ticket, git_repository_location: GitRepositoryLocation)
       @store = store
       @git_repository_location = git_repository_location
       @feature_review_factory = Factories::FeatureReviewFactory.new
     end
-
-    attr_reader :store
-    delegate :table_name, to: :store
 
     def tickets_for_path(feature_review_path, at: nil)
       query = at ? store.arel_table['event_created_at'].lteq(at) : nil

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -97,7 +97,7 @@ module Repositories
     end
 
     def merge_approved_at(last_ticket, event)
-      return nil unless Ticket.new(status: event.status).approved?
+      return nil unless event.approval?
       last_ticket['approved_at'] || event.created_at
     end
 

--- a/db/migrate/20160324142505_add_defaults_to_array_columns.rb
+++ b/db/migrate/20160324142505_add_defaults_to_array_columns.rb
@@ -1,0 +1,9 @@
+class AddDefaultsToArrayColumns < ActiveRecord::Migration
+  def change
+    change_column :tickets, :paths, :text, array: true, default: []
+    change_column :tickets, :versions, :text, array: true, default: []
+    change_column :uatests, :versions, :text, array: true, default: []
+    change_column :manual_tests, :versions, :text, array: true, default: []
+    change_column :released_tickets, :versions, :text, array: true, default: []
+  end
+end

--- a/db/migrate/20160324142505_add_defaults_to_array_columns.rb
+++ b/db/migrate/20160324142505_add_defaults_to_array_columns.rb
@@ -1,9 +1,17 @@
 class AddDefaultsToArrayColumns < ActiveRecord::Migration
-  def change
+  def up
     change_column :tickets, :paths, :text, array: true, default: []
     change_column :tickets, :versions, :text, array: true, default: []
     change_column :uatests, :versions, :text, array: true, default: []
     change_column :manual_tests, :versions, :text, array: true, default: []
     change_column :released_tickets, :versions, :text, array: true, default: []
+  end
+
+  def down
+    change_column :tickets, :paths, :text, array: true
+    change_column :tickets, :versions, :string, array: true
+    change_column :uatests, :versions, :text, array: true
+    change_column :manual_tests, :versions, :string, array: true
+    change_column :released_tickets, :versions, :string, array: true
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -282,7 +282,7 @@ ALTER SEQUENCE git_repository_locations_id_seq OWNED BY git_repository_locations
 CREATE TABLE manual_tests (
     id integer NOT NULL,
     email character varying,
-    versions character varying[],
+    versions text[] DEFAULT '{}'::text[],
     accepted boolean,
     comment text,
     created_at timestamp without time zone
@@ -321,7 +321,7 @@ CREATE TABLE released_tickets (
     updated_at timestamp without time zone NOT NULL,
     tsv tsvector,
     deploys json DEFAULT '[]'::json,
-    versions character varying[]
+    versions text[] DEFAULT '{}'::text[]
 );
 
 
@@ -362,9 +362,9 @@ CREATE TABLE tickets (
     key character varying,
     summary character varying,
     status character varying,
-    paths text[],
+    paths text[] DEFAULT '{}'::text[],
     event_created_at timestamp without time zone,
-    versions character varying[],
+    versions text[] DEFAULT '{}'::text[],
     approved_at timestamp without time zone,
     version_timestamps hstore DEFAULT ''::hstore NOT NULL
 );
@@ -432,7 +432,7 @@ CREATE TABLE uatests (
     success boolean,
     test_suite_version character varying,
     event_created_at timestamp without time zone,
-    versions text[]
+    versions text[] DEFAULT '{}'::text[]
 );
 
 
@@ -816,4 +816,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160315165607');
 INSERT INTO schema_migrations (version) VALUES ('20160316154428');
 
 INSERT INTO schema_migrations (version) VALUES ('20160318164129');
+
+INSERT INTO schema_migrations (version) VALUES ('20160324142505');
 

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -156,32 +156,20 @@ Scenario: Viewing a Feature Review
 @logged_in
 Scenario: Viewing a Feature Review that requires re-approval
   Given an application called "frontend"
-
   And a ticket "JIRA-1" with summary "Some work" is started at "2014-10-11 13:01:17"
-  And a ticket "JIRA-2" with summary "More work" is started at "2014-10-11 15:10:27"
-
   And a commit "#abc" by "Alice" is created at "2014-10-12 11:01:00" for app "frontend"
-  And a commit "#def" by "Alice" is created at "2014-10-13 12:02:00" for app "frontend"
-
   And ticket "JIRA-1" is approved by "jim@fundingcircle.com" at "2014-10-13 17:30:10"
-
   And developer prepares review known as "FR" for UAT "uat.fundingcircle.com" with apps
     | app_name | version |
     | frontend | #abc    |
-
   And at time "2014-10-14 16:00:01" adds link for review "FR" to comment for ticket "JIRA-1"
-  And at time "2014-10-14 17:00:01" adds link for review "FR" to comment for ticket "JIRA-2"
-
-  And ticket "JIRA-2" is approved by "jim@fundingcircle.com" at "2014-10-14 17:30:10"
 
   When I visit the feature review known as "FR"
 
   Then I should see that the Feature Review requires reapproval
-
   And I should see the tickets
-    | Ticket | Summary   | Status               |
-    | JIRA-1 | Some work | Requires reapproval  |
-    | JIRA-2 | More work | Ready for Deployment |
+    | Ticket | Summary   | Status              |
+    | JIRA-1 | Some work | Requires reapproval |
 
 @logged_in
 Scenario: Viewing a Feature Review as at a specified time

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -102,7 +102,7 @@ module Support
       ticket_details[:updated] = time
       event = build(
         :jira_event,
-        approve ? :approved : :rejected,
+        approve ? :approved : :unapproved,
         ticket_details,
       )
       @tickets[jira_key] = ticket_details.merge(status: event.status)

--- a/spec/factories/jira_event.rb
+++ b/spec/factories/jira_event.rb
@@ -46,8 +46,28 @@ FactoryGirl.define do
 
     initialize_with { new(attributes) }
 
-    trait :created do
+    trait :todo do
       status 'To Do'
+    end
+
+    trait :in_progress do
+      status 'In Progress'
+    end
+
+    trait :ready_for_review do
+      status 'Ready For Review'
+    end
+
+    trait :ready_for_deploy do
+      status 'Ready for Deployment'
+    end
+
+    trait :done do
+      status 'Done'
+    end
+
+    trait :created do
+      todo
     end
 
     trait :started do
@@ -62,7 +82,7 @@ FactoryGirl.define do
           ],
         },
       )
-      status 'In Progress'
+      in_progress
     end
 
     trait :development_completed do
@@ -77,7 +97,22 @@ FactoryGirl.define do
           ],
         },
       )
-      status 'Ready For Review'
+      ready_for_review
+    end
+
+    trait :rejected do
+      changelog_details(
+        'changelog' => {
+          'items' => [
+            {
+              'field' => 'status',
+              'fromString' => 'Ready for Review',
+              'toString' => 'In Progress',
+            },
+          ],
+        },
+      )
+      in_progress
     end
 
     trait :approved do
@@ -92,7 +127,7 @@ FactoryGirl.define do
           ],
         },
       )
-      status 'Ready for Deployment'
+      ready_for_deploy
     end
 
     trait :deployed do
@@ -107,10 +142,10 @@ FactoryGirl.define do
           ],
         },
       )
-      status 'Done'
+      done
     end
 
-    trait :rejected do
+    trait :unapproved do
       changelog_details(
         'changelog' => {
           'items' => [
@@ -122,7 +157,7 @@ FactoryGirl.define do
           ],
         },
       )
-      status 'In Progress'
+      in_progress
     end
   end
 

--- a/spec/models/events/jira_event_spec.rb
+++ b/spec/models/events/jira_event_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Events::JiraEvent do
 
     context 'when the status changes from approved to unapproved' do
       it 'returns false' do
-        expect(build(:jira_event, :rejected).approval?).to be false
+        expect(build(:jira_event, :unapproved).approval?).to be false
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe Events::JiraEvent do
 
     context 'when the status changes from approved to unapproved' do
       it 'returns true' do
-        expect(build(:jira_event, :rejected).unapproval?).to be true
+        expect(build(:jira_event, :unapproved).unapproval?).to be true
       end
     end
   end

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Repositories::TicketRepository do
         Ticket.new(ticket_1.merge(status: 'In Progress')),
       ])
 
-      repository.apply(build(:jira_event, :approved, key: 'JIRA-1', created_at: time)) # TODO: timestamp: time.to_i
+      repository.apply(build(:jira_event, :approved, key: 'JIRA-1', created_at: time))
       results = repository.tickets_for_path(path)
       expect(results).to eq([
         Ticket.new(
@@ -221,14 +221,14 @@ RSpec.describe Repositories::TicketRepository do
         ),
       ])
 
-      repository.apply(build(:jira_event, :deployed, key: 'JIRA-1', created_at: time + 1.hour)) # TODO
+      repository.apply(build(:jira_event, :deployed, key: 'JIRA-1', created_at: time + 1.hour))
       results = repository.tickets_for_path(path)
       expect(results).to eq([
         Ticket.new(
           ticket_1.merge(status: 'Done', approved_at: time, event_created_at: time + 1.hour)),
       ])
 
-      repository.apply(build(:jira_event, :rejected, key: 'JIRA-1', created_at: time + 2.hours)) # TODO
+      repository.apply(build(:jira_event, :unapproved, key: 'JIRA-1', created_at: time + 2.hours))
       results = repository.tickets_for_path(path)
       expect(results).to eq([
         Ticket.new(
@@ -267,13 +267,13 @@ RSpec.describe Repositories::TicketRepository do
     end
 
 
-    context 'when multiple feature reviews are referenced in the same JIRA ticket' do
+    context 'when multiple Feature Reviews are referenced in the same JIRA ticket' do
       let(:url1) { feature_review_url(app1: 'one') }
       let(:url2) { feature_review_url(app2: 'two') }
       let(:path1) { feature_review_path(app1: 'one') }
       let(:path2) { feature_review_path(app2: 'two') }
 
-      subject(:repository1) { Repositories::TicketRepository.new }
+      subject(:repository) { Repositories::TicketRepository.new }
 
       it 'projects the ticket referenced in the JIRA comments for each repository' do
         [
@@ -281,10 +281,10 @@ RSpec.describe Repositories::TicketRepository do
           build(:jira_event, key: 'JIRA-1', comment_body: "Review [FR link|#{url2}]", created_at: times[1]),
           build(:jira_event, key: 'JIRA-1', comment_body: "Review #{url1}", created_at: times[2]),
         ].each do |event|
-          repository1.apply(event)
+          repository.apply(event)
         end
 
-        expect(repository1.tickets_for_path(path1)).to eq([
+        expect(repository.tickets_for_path(path1)).to eq([
           Ticket.new(
             key: 'JIRA-1',
             paths: [path1, path2],
@@ -415,7 +415,7 @@ RSpec.describe Repositories::TicketRepository do
       end
 
       context 'when ticket event is for an unapproval' do
-        let(:unapproval_event) { build(:jira_event, :rejected, key: 'JIRA-XYZ', created_at: time) }
+        let(:unapproval_event) { build(:jira_event, :unapproved, key: 'JIRA-XYZ', created_at: time) }
 
         before do
           event = build(

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -199,43 +199,40 @@ RSpec.describe Repositories::TicketRepository do
     end
 
     it 'projects latest associated tickets' do
-      jira_1 = { key: 'JIRA-1', summary: 'Ticket 1' }
-      ticket_1 = jira_1.merge(ticket_defaults)
+      ticket_1 = ticket_defaults.merge(key: 'JIRA-1')
 
-      repository.apply(build(:jira_event, :created, jira_1.merge(comment_body: url)))
+      repository.apply(build(:jira_event, :created, key: 'JIRA-1', comment_body: url))
       results = repository.tickets_for_path(path)
       expect(results).to eq([
         Ticket.new(ticket_1.merge(status: 'To Do')),
       ])
 
-      repository.apply(build(:jira_event, :started, jira_1))
+      repository.apply(build(:jira_event, :started, key: 'JIRA-1'))
       results = repository.tickets_for_path(path)
-      expect(results).to eq([Ticket.new(ticket_1.merge(status: 'In Progress'))])
+      expect(results).to eq([
+        Ticket.new(ticket_1.merge(status: 'In Progress')),
+      ])
 
-      repository.apply(build(:jira_event, :approved, jira_1.merge(created_at: time)))
+      repository.apply(build(:jira_event, :approved, key: 'JIRA-1', created_at: time)) # TODO: timestamp: time.to_i
       results = repository.tickets_for_path(path)
       expect(results).to eq([
         Ticket.new(
-          ticket_1.merge(
-            status: 'Ready for Deployment', approved_at: time, event_created_at: time,
-          ),
+          ticket_1.merge(status: 'Ready for Deployment', approved_at: time, event_created_at: time),
         ),
       ])
 
-      repository.apply(build(:jira_event, :deployed, jira_1.merge(created_at: time + 1.hour)))
+      repository.apply(build(:jira_event, :deployed, key: 'JIRA-1', created_at: time + 1.hour)) # TODO
       results = repository.tickets_for_path(path)
       expect(results).to eq([
-        Ticket.new(ticket_1.merge(
-                     status: 'Done', approved_at: time, event_created_at: time + 1.hour,
-        )),
+        Ticket.new(
+          ticket_1.merge(status: 'Done', approved_at: time, event_created_at: time + 1.hour)),
       ])
 
-      repository.apply(build(:jira_event, :rejected, jira_1.merge(created_at: time + 2.hours)))
+      repository.apply(build(:jira_event, :rejected, key: 'JIRA-1', created_at: time + 2.hours)) # TODO
       results = repository.tickets_for_path(path)
       expect(results).to eq([
-        Ticket.new(ticket_1.merge(
-                     status: 'In Progress', approved_at: nil, event_created_at: time + 2.hours,
-        )),
+        Ticket.new(
+          ticket_1.merge(status: 'In Progress', approved_at: nil, event_created_at: time + 2.hours)),
       ])
     end
 

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -223,8 +223,9 @@ RSpec.describe Repositories::TicketRepository do
     end
 
     it 'ignores events that are not JIRA issues' do
-      store = repository.instance_variable_get(:@store)
-      expect { repository.apply(build(:jira_event_user_created)) }.to_not change { store.count }
+      event = build(:jira_event_user_created)
+
+      expect { repository.apply(event) }.to_not change { repository.store.count }
     end
 
     context 'when multiple feature reviews are referenced in the same JIRA ticket' do

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe Repositories::TicketRepository do
       allow(CommitStatusUpdateJob).to receive(:perform_later)
     end
 
+    it 'only snapshots tickets that contain a Feature Review' do
+      event = build(:jira_event)
+      expect { repository.apply(event) }.to_not change { repository.store.count }
+
+      event = build(:jira_event, comment_body: "Feature Review #{url}")
+      expect { repository.apply(event) }.to change { repository.store.count }
+    end
+
     it 'projects latest associated tickets' do
       jira_1 = { key: 'JIRA-1', summary: 'Ticket 1' }
       ticket_1 = jira_1.merge(ticket_defaults)


### PR DESCRIPTION
Only snapshot tickets if they contain a Feature Review.

##### Context
JIRA can be configured to send webhook events for all Issue activity, which results in a massive amount of ticket snapshots -- one for every ticket.

There is no need to prematurely snapshot tickets without a Feature Review because many of them will never contain a Feature Review and hence do not go through the Shipment Tracker process.

This will not cause any issues when we *do* have to snapshot tickets because the payload of comment events (which is what ST receives when a FR is linked) contain the all the other information we need to create the snapshots, such as ticket key, title (summary), description, etc.

---

- [x] Only snapshot tickets if they contain a FR or a previous snapshot exists for the ticket
- [x] Only record `approved_at` time on ticket snapshots for approval events or if time can be carried over
  - Needed for "requires re-approval" scenario to continue working with snapshotting optimization
- [ ] ~~Use JIRA timestamp instead of record creation time for `approved_at`~~  
  Excluded from this PR and moved to #168 