### PR TITLE
fix deploy alert errors

### DIFF
--- a/app/models/deploy_alert.rb
+++ b/app/models/deploy_alert.rb
@@ -51,8 +51,8 @@ class DeployAlert
   class DeployAuditor
     def initialize(current_deploy, previous_deploy = nil)
       @current_deploy = current_deploy
-      @previous_deploy = previous_deploy
       @git_repo = GitRepositoryLoader.from_rails_config.load(current_deploy.app_name)
+      @previous_deploy = previous_deploy if git_repo.exists?(previous_deploy&.version, allow_short_sha: true)
     end
 
     def not_on_master?
@@ -60,7 +60,7 @@ class DeployAlert
     end
 
     def unknown_version?
-      current_deploy.version.nil?
+      !git_repo.exists?(current_deploy.version, allow_short_sha: true)
     end
 
     def rollback?

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -16,8 +16,10 @@ class GitRepository
     @rugged_repository = rugged_repository
   end
 
-  def exists?(full_sha)
-    full_sha.length == 40 && rugged_repository.exists?(full_sha)
+  def exists?(sha, allow_short_sha: false)
+    return false if sha.nil?
+    return false if !allow_short_sha && sha.length != 40
+    sha.length.between?(7, 40) && rugged_repository.exists?(sha)
   rescue Rugged::InvalidError
     false
   end

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -28,9 +28,23 @@ RSpec.describe GitRepository do
       it { is_expected.to be(false) }
     end
 
-    context 'when commit id is too short (even if it exists)' do
-      let(:sha) { version('A').slice(1..3) }
+    context 'when commit id is nil' do
+      let(:sha) { nil }
       it { is_expected.to be(false) }
+    end
+
+    context 'when commit id is too short (even if it exists)' do
+      let(:sha) { version('A').slice(0..6) }
+      it { is_expected.to be(false) }
+    end
+
+    context 'when allowing short shas' do
+      subject { repo.exists?(sha, allow_short_sha: true) }
+
+      context 'when commit id is too short (even if it exists)' do
+        let(:sha) { version('A').slice(0..6) }
+        it { is_expected.to be(true) }
+      end
     end
 
     context 'when commit id is invalid' do


### PR DESCRIPTION
ensure that deploy alerts are raised even if the deploy events contain SHAs that can not be parsed or looked up.