### PR TITLE
Handle exception when failing to expand a deploy version

### DIFF
--- a/app/models/deploy_alert.rb
+++ b/app/models/deploy_alert.rb
@@ -34,7 +34,7 @@ class DeployAlert
   end
 
   def self.alert_unknown_version(deploy)
-    "#{alert_header(deploy)}Deploy event sent to Shipment Tracker is missing the software version."
+    "#{alert_header(deploy)}Deploy event sent to Shipment Tracker contains an unknown software version."
   end
 
   def self.alert_rollback(deploy)

--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -85,7 +85,9 @@ module Events
     end
 
     def full_sha(sha)
-      return sha if sha.nil? || sha.length == 40
+      return if sha.nil? || sha.length > 40
+      return sha if sha.length == 40
+
       git_repository_loader = GitRepositoryLoader.from_rails_config
       repo = git_repository_loader.load(app_name)
       repo.commit_for_version(sha).id

--- a/app/models/events/deploy_event.rb
+++ b/app/models/events/deploy_event.rb
@@ -26,7 +26,7 @@ module Events
       @version ||= if deployed_to_heroku?
                      details['head_long']
                    else
-                     expand_sha(details['version'])
+                     full_sha(details['version'])
                    end
     end
 
@@ -84,8 +84,8 @@ module Events
       heroku_app_name.split('-').first.downcase
     end
 
-    def expand_sha(sha)
-      return sha unless sha.present? && sha.size < 40
+    def full_sha(sha)
+      return sha if sha.nil? || sha.length == 40
       git_repository_loader = GitRepositoryLoader.from_rails_config
       repo = git_repository_loader.load(app_name)
       repo.commit_for_version(sha).id

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -185,7 +185,7 @@ class GitRepository
 
   def lookup(sha)
     rugged_repository.lookup(sha)
-  rescue Rugged::InvalidError, Rugged::ObjectError, Rugged::OdbError
+  rescue Rugged::InvalidError, Rugged::ObjectError, Rugged::OdbError, TypeError
     nil
   end
 end

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -48,6 +48,13 @@ module Repositories
         previous_deploy = second_last_production_deploy(current_deploy.app_name, current_deploy.region)
         audit_deploy(current_deploy: current_deploy.attributes, previous_deploy: previous_deploy&.attributes)
       end
+    rescue GitRepositoryLoader::NotFound => error
+      Honeybadger.context(event_id: event.id,
+                          app_name: event.app_name,
+                          deployer: event.deployed_by,
+                          deploy_time: event.created_at)
+      Honeybadger.notify(error)
+      Honeybadger.context.clear!
     end
 
     private

--- a/spec/models/deploy_alert_spec.rb
+++ b/spec/models/deploy_alert_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe DeployAlert do
         it 'returns an alert message for missing software version' do
           allow(git_repo).to receive(:exists?).and_return(false)
           actual = DeployAlert.audit_message(deploy)
-          expected = message(deploy, 'Deploy event sent to Shipment Tracker is missing the software version.')
+          expected = message(deploy,
+            'Deploy event sent to Shipment Tracker contains an unknown software version.')
 
           expect(actual).to eq(expected)
         end
@@ -136,7 +137,8 @@ RSpec.describe DeployAlert do
         it 'returns an alert message for missing software version' do
           allow(git_repo).to receive(:exists?).and_return(false)
           actual = DeployAlert.audit_message(deploy)
-          expected = message(deploy, 'Deploy event sent to Shipment Tracker is missing the software version.')
+          expected = message(deploy,
+            'Deploy event sent to Shipment Tracker contains an unknown software version.')
 
           expect(actual).to eq(expected)
         end

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -73,13 +73,19 @@ RSpec.describe Events::DeployEvent do
       end
     end
 
-    context 'when the payload contains an unknown version' do
+    context 'when the payload is missing the version' do
       before do
-        payload['version'] = 'something that is not a real version'
+        payload['version'] = nil
+      end
 
-        commit = double(GitCommit, id: nil)
-        git_repo = double(GitRepository, commit_for_version: commit)
-        allow_any_instance_of(GitRepositoryLoader).to receive(:load).and_return(git_repo)
+      it 'returns nil for the version' do
+        expect(subject.version).to be_nil
+      end
+    end
+
+    context 'when the payload contains a gibberish version longer than 40 chars' do
+      before do
+        payload['version'] = 'abc' * 20
       end
 
       it 'returns nil for the version' do

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -61,15 +61,29 @@ RSpec.describe Events::DeployEvent do
 
     context 'when the payload contains a short SHA' do
       before do
+        payload['version'] = '1abc'
+
         commit = double(GitCommit, id: '1abcabcabcabcabcabcabcabcabcabcabcabcabc')
         git_repo = double(GitRepository, commit_for_version: commit)
         allow_any_instance_of(GitRepositoryLoader).to receive(:load).and_return(git_repo)
-
-        payload['version'] = '1abc'
       end
 
       it 'expands to full SHA' do
         expect(subject.version).to eq('1abcabcabcabcabcabcabcabcabcabcabcabcabc')
+      end
+    end
+
+    context 'when the payload contains an unknown version' do
+      before do
+        payload['version'] = 'something that is not a real version'
+
+        commit = double(GitCommit, id: nil)
+        git_repo = double(GitRepository, commit_for_version: commit)
+        allow_any_instance_of(GitRepositoryLoader).to receive(:load).and_return(git_repo)
+      end
+
+      it 'returns nil for the version' do
+        expect(subject.version).to be_nil
       end
     end
 

--- a/spec/models/events/deploy_event_spec.rb
+++ b/spec/models/events/deploy_event_spec.rb
@@ -60,22 +60,12 @@ RSpec.describe Events::DeployEvent do
     end
 
     context 'when the payload contains a short SHA' do
-      let(:payload) {
-        {
-          'app_name' => 'some_app',
-          'servers' => ['prod1.example.com', 'prod2.example.com'],
-          'version' => 'abcabca',
-          'deployed_by' => 'bob',
-          'locale' => 'us',
-          'environment' => 'staging',
-        }
-      }
-      let(:repo) { double }
-      let(:commit) { double(GitCommit, id: '1abcabcabcabcabcabcabcabcabcabcabcabcabc') }
-
       before do
-        allow(repo).to receive(:commit_for_version).and_return(commit)
-        allow_any_instance_of(GitRepositoryLoader).to receive(:load).and_return(repo)
+        commit = double(GitCommit, id: '1abcabcabcabcabcabcabcabcabcabcabcabcabc')
+        git_repo = double(GitRepository, commit_for_version: commit)
+        allow_any_instance_of(GitRepositoryLoader).to receive(:load).and_return(git_repo)
+
+        payload['version'] = '1abc'
       end
 
       it 'expands to full SHA' do

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -199,10 +199,18 @@ RSpec.describe GitRepository do
       expect(commit.id).to eq version('A')
     end
 
-    it 'returns an empty GitCommit when the lookup fails' do
-      commit = subject.commit_for_version('invalid_sha')
-      expect(commit).to be_a(GitCommit)
-      expect(commit.associated_ids).to be_empty
+    context 'when the lookup fails' do
+      it 'returns an empty GitCommit for an invalid SHA' do
+        commit = subject.commit_for_version('invalid_sha')
+        expect(commit).to be_a(GitCommit)
+        expect(commit.associated_ids).to be_empty
+      end
+
+      it 'returns an empty GitCommit for an extra long SHA' do
+        commit = subject.commit_for_version('abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc')
+        expect(commit).to be_a(GitCommit)
+        expect(commit.id).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
An uncaught exception is raised when we have DeployEvents for an app but the git repository is missing, because it was never onboarded or it was removed. This rescues the exception (so the updater doesn't blow up) and notifies Honeybadger until we have a better solution.

This was happening whenever snapshotting DeployEvents, which happens in a couple of Repositories.

@FundingCircle/black-bat please review -- this issue is currently present on staging and development (if you use staging data), and is bound to happen on production.