### PR TITLE
remove events key from payload

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,7 @@ class EventsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
-    event_factory.create(params[:type], request.request_parameters, current_user.email)
+    event_factory.create(params[:type], request.request_parameters.except('event'), current_user.email)
 
     if redirect_path
       flash[:success] = 'Thank you for your submission. It will appear in a moment.'

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -86,6 +86,17 @@ RSpec.describe 'EventsController' do
         expect(response).to be_ok
       end
 
+      it 'discards duplicated data' do
+        expect(event_factory).to receive(:create).with(
+          'circleci', { 'foo' => 'bar', 'token' => 'the payloads token' }, nil
+        )
+
+        post "/events/circleci?token=#{token}", foo: 'bar', token: 'the payloads token',
+                                                event: { foo: 'bar', token: 'the payloads token' }
+
+        expect(response).to be_ok
+      end
+
       it 'does not create authorised session' do
         expect(event_factory).to receive(:create).once
 


### PR DESCRIPTION
this seems added as a duplication by the rails controller

and we do not use it