### PR TITLE
Use actual approval time for tickets

### DIFF
--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -51,14 +51,15 @@ module Events
 
     def timestamp
       if details['timestamp']
-        seconds_since_epoch
+        epoch_time
       else
         created_at
       end
     end
 
-    def seconds_since_epoch
-      details['timestamp'] / 1000
+    def epoch_time
+      timestamp = details['timestamp']
+      timestamp.to_s.length == 13 ? timestamp / 1000 : timestamp
     end
 
     def status_item

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -3,6 +3,10 @@ require 'events/base_event'
 
 module Events
   class JiraEvent < Events::BaseEvent
+    def datetime
+      Time.zone.at(timestamp)
+    end
+
     def key
       details.fetch('issue').fetch('key')
     end
@@ -33,8 +37,8 @@ module Events
 
     def approval?
       status_item &&
-        approved_status?(status_item['toString']) &&
-        !approved_status?(status_item['fromString'])
+        !approved_status?(status_item['fromString']) &&
+        approved_status?(status_item['toString'])
     end
 
     def unapproval?
@@ -44,6 +48,12 @@ module Events
     end
 
     private
+
+    MILLISECONDS = 1000
+
+    def timestamp
+      details['timestamp'] && details['timestamp'] / MILLISECONDS
+    end
 
     def status_item
       @status_item ||= changelog_items.find { |item| item['field'] == 'status' }

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -49,10 +49,16 @@ module Events
 
     private
 
-    MILLISECONDS = 1000
-
     def timestamp
-      details['timestamp'] && details['timestamp'] / MILLISECONDS
+      if details['timestamp']
+        seconds_since_epoch
+      else
+        created_at
+      end
+    end
+
+    def seconds_since_epoch
+      details['timestamp'] / 1000
     end
 
     def status_item

--- a/spec/factories/jira_event.rb
+++ b/spec/factories/jira_event.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
       sequence(:issue_id)
       sequence(:key) { |n| "JIRA-#{n}" }
 
+      timestamp DateTime.current.strftime('%Q').to_i
       summary ''
       description ''
       display_name 'joe'
@@ -19,6 +20,7 @@ FactoryGirl.define do
 
       default_details do
         {
+          'timestamp' => timestamp,
           'webhookEvent' => 'jira:issue_updated',
           'user' => {
             'displayName' => display_name,

--- a/spec/models/events/jira_event_spec.rb
+++ b/spec/models/events/jira_event_spec.rb
@@ -2,6 +2,15 @@
 require 'rails_helper'
 
 RSpec.describe Events::JiraEvent do
+  describe '#datetime' do
+    it 'returns a UTC DateTime' do
+      event = build(:jira_event, timestamp: 1458842541458)
+      expected_time = Time.zone.parse('Thu, 24 Mar 2016 18:02:21 UTC')
+
+      expect(event.datetime).to eq(expected_time)
+    end
+  end
+
   describe '#approval?' do
     context 'when the status changes from unapproved to approved' do
       it 'returns true' do

--- a/spec/models/events/jira_event_spec.rb
+++ b/spec/models/events/jira_event_spec.rb
@@ -3,11 +3,18 @@ require 'rails_helper'
 
 RSpec.describe Events::JiraEvent do
   describe '#datetime' do
-    it 'returns a UTC DateTime' do
+    it 'returns a TimeWithZone in UTC' do
       event = build(:jira_event, timestamp: 1458842541458)
       expected_time = Time.zone.parse('Thu, 24 Mar 2016 18:02:21 UTC')
 
       expect(event.datetime).to eq(expected_time)
+    end
+
+    it 'falls back to created_at when timestamp missing' do
+      time = 1.hour.ago.change(usec: 0)
+      event = build(:jira_event, timestamp: nil, created_at: time)
+
+      expect(event.datetime).to eq(time)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ end
 require 'webmock/rspec'
 require 'solid_use_case'
 require 'solid_use_case/rspec_matchers'
+require 'active_support/testing/time_helpers'
 
 require 'clients/github'
 require 'support/feature_review_helpers'
@@ -31,6 +32,7 @@ require 'support/feature_review_helpers'
 RSpec.configure do |config|
   config.include Support::FeatureReviewHelpers
   config.include SolidUseCase::RSpecMatchers
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.before(:each, :disable_repo_verification) do
     allow_any_instance_of(GithubClient).to receive(:repo_accessible?).and_return(true)


### PR DESCRIPTION
For a lot of our events, we have a a hack where we use the time when the record is created in Shipment Tracker as the time when the event occurred, and we ignore the actual time that is sent in the payload.

This technical debt was good enough to start with because the time delta will be a few seconds at most due to network latency -- there is a risk that it is much higher if the service sending the events is experiencing issues and has events queued for a long time, but this is exceptional.

We should aim to be more realistic, especially for events such as JIRA ticket approvals as a lot of business logic is based on that. Most importantly, **the audit trail contains incorrect information**. The more accurate an audit trail is, the better it holds under scrutiny and protects the organization.

_These changes were originally introduced in #154 but extracted to reduce scope._