### PR TITLE
fix deploy alerts for dependent releases

### DIFF
--- a/app/models/deploy_alert.rb
+++ b/app/models/deploy_alert.rb
@@ -92,8 +92,11 @@ class DeployAlert
     def auditable_commits_newest_first
       @commits ||= if previous_deploy
                      git_repo
-                       .commits_between(previous_deploy.version, current_deploy.version, simplify: true)
-                       .reverse
+                       .commits_between(previous_deploy.version,
+                         current_deploy.version,
+                         simplify: true,
+                         newest_first: true,
+                                       )
                    else
                      [git_repo.commit_for_version(current_deploy.version)]
                    end

--- a/app/models/deploy_alert.rb
+++ b/app/models/deploy_alert.rb
@@ -69,7 +69,9 @@ class DeployAlert
     end
 
     def recent_releases_authorised?
-      release_query = release_query_for(auditable_commits, current_deploy.region, current_deploy.app_name)
+      release_query = release_query_for(auditable_commits_newest_first,
+        current_deploy.region,
+        current_deploy.app_name)
       release_query.deployed_releases.all?(&:authorised?)
     end
 
@@ -87,9 +89,11 @@ class DeployAlert
       )
     end
 
-    def auditable_commits
+    def auditable_commits_newest_first
       @commits ||= if previous_deploy
-                     git_repo.commits_between(previous_deploy.version, current_deploy.version, simplify: true)
+                     git_repo
+                       .commits_between(previous_deploy.version, current_deploy.version, simplify: true)
+                       .reverse
                    else
                      [git_repo.commit_for_version(current_deploy.version)]
                    end

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -4,6 +4,7 @@ Feature: Searching for releases on Dashboard
   I want to full text search for tickets
   So I can find tickets related to any topic
 
+@mock_slack_notifier
 Scenario: User finds deployed tickets by description
   Given the following tickets are created:
     | Jira Key | Summary       | Description                         | Deploys                     |

--- a/features/deploy_alert.feature
+++ b/features/deploy_alert.feature
@@ -33,6 +33,48 @@ Scenario: Release has no approved Feature Reviews
     | app_name | version | time                   | deployer | message                                              |
     | frontend | #merge1 | 2016-01-22 17:34+00:00 | Joe      | Release not authorised; Feature Review not approved. |
 
+Scenario: Dependent release has no approved Feature Reviews
+  Given an application called "frontend"
+
+  # An authorised deploy
+  And a commit "#master1" with message "initial commit" is created at "2016-01-18 09:10:57"
+  And a ticket "JIRA-ONE" with summary "Ticket ONE" is started at "2016-01-18 09:13:00"
+  And developer prepares review known as "FR_ONE" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version  |
+    | frontend | #master1 |
+  And at time "2016-01-20 14:52:45" adds link for review "FR_ONE" to comment for ticket "JIRA-ONE"
+  And ticket "JIRA-ONE" is approved by "bob@fundingcircle.com" at "2016-01-21 15:20:34"
+  When commit "#master1" of "frontend" is deployed by "Jeff" to production at "2016-01-21 16:34:20"
+  Then a deploy alert should not be dispatched
+
+  # An unauthorised release
+  And the branch "feature1" is checked out
+  And a ticket "JIRA-TWO" with summary "Ticket TWO" is started at "2016-01-21 09:13:00"
+  And a commit "#feat1_a" with message "feat1 first commit" is created at "2016-01-21 17:12:37"
+  And developer prepares review known as "FR_TWO" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version  |
+    | frontend | #feat1_a |
+  And at time "2016-01-21 18:52:45" adds link for review "FR_TWO" to comment for ticket "JIRA-TWO"
+  And the branch "master" is checked out
+  And the branch "feature1" is merged with merge commit "#merge1" at "2016-01-22 16:14:39"
+
+  # An authorised release, and deployed
+  And the branch "feature2" is checked out
+  And a ticket "JIRA-THREE" with summary "Ticket THREE" is started at "2016-01-23 09:13:00"
+  And a commit "#feat2_a" with message "feat2 first commit" is created at "2016-01-23 17:12:37"
+  And developer prepares review known as "FR_THREE" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version  |
+    | frontend | #feat2_a |
+  And at time "2016-01-23 18:52:45" adds link for review "FR_THREE" to comment for ticket "JIRA-THREE"
+  And the branch "master" is checked out
+  And the branch "feature2" is merged with merge commit "#merge2" at "2016-01-24 16:14:39"
+  And ticket "JIRA-THREE" is approved by "bob@fundingcircle.com" at "2016-01-24 16:20:34"
+
+  When commit "#merge2" of "frontend" is deployed by "Joe" to production at "2016-01-24 17:34:20"
+  Then a deploy alert should be dispatched for
+    | app_name | version | time                   | deployer | message                                              |
+    | frontend | #merge2 | 2016-01-24 17:34+00:00 | Joe      | Release not authorised; Feature Review not approved. |
+
 Scenario: Rollback to an older software version
   Given an application called "frontend"
 

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -120,6 +120,15 @@ RSpec.describe GitRepository do
         }.to raise_error(GitRepository::CommitNotFound, non_existent_commit)
       end
     end
+
+    context 'when called with new_first flag set true' do
+      let(:options) { { newest_first: true } }
+
+      it 'returns all commits between two commits, including the end commit' do
+        commits = repo.commits_between(version('A'), version('C'), options).map(&:id)
+        expect(commits).to eq([version('C'), version('B')])
+      end
+    end
   end
 
   describe '#recent_commits_on_main_branch' do


### PR DESCRIPTION
Change to initialize `Queries::ReleasesQuery` with commits correct order: 'newest-first'. This is the order that the query uses if no commits are passed in - see: http://github.com/FundingCircle/shipment_tracker/blob/3e5a343af249a143c770b261c16a274c163ccc1c/app/models/queries/releases_query.rb#L39-L40

This fixes a bug where the deploy auditor does not detect unauthorised releases that are deployed as bundled of a newer release. 

paired with @0mega 