### PR TITLE
Fix perfomance/projections_spec.rb feature_review url

### DIFF
--- a/spec/performance/projections_spec.rb
+++ b/spec/performance/projections_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Projection performance', type: :request do
   describe 'Feature Review' do
     let(:apps) { { 'frontend' => 'abc', 'backend' => 'def' } }
     let(:server) { 'uat.fc.com' }
-    let(:url) { feature_review_path(apps, server) }
+    let(:url) { feature_review_url(apps, server) }
     let(:path) { URI.parse(url).request_uri }
 
     it 'measures the request time' do
@@ -40,7 +40,7 @@ RSpec.describe 'Projection performance', type: :request do
   describe 'Feature Review Search' do
     let(:apps) { { 'frontend' => version, 'backend' => 'def' } }
     let(:server) { 'uat.fc.com' }
-    let(:url) { feature_review_path(apps, server) }
+    let(:url) { feature_review_url(apps, server) }
 
     let(:repo_name) { 'frontend' }
     let(:test_git_repo) { Support::GitTestRepository.new }
@@ -72,7 +72,7 @@ RSpec.describe 'Projection performance', type: :request do
   describe 'Releases' do
     let(:apps) { { 'frontend' => version, 'backend' => 'def' } }
     let(:server) { 'uat.fc.com' }
-    let(:url) { feature_review_path(apps, server) }
+    let(:url) { feature_review_url(apps, server) }
 
     let(:repo_name) { 'frontend' }
     let(:test_git_repo) { Support::GitTestRepository.new }


### PR DESCRIPTION
In this block: 

```ruby
..
  let(:url) { feature_review_path(apps, server) }
  let(:path) { URI.parse(url).request_uri }
..
```

`request_uri` cannot be called on a URI parsed object without a real URL -- `feature_review_path` is stripping it down so you have to use `feature_review_url` first, or `path` on the URI parsed object

Note: this was always passing because CircleCI is configured to skip this test, it would fail otherwise