### PR TITLE
Reverting back to deploy alert fix

### DIFF
--- a/app/models/deploy_alert.rb
+++ b/app/models/deploy_alert.rb
@@ -89,7 +89,12 @@ class DeployAlert
 
     def auditable_commits
       @commits ||= if previous_deploy
-                     git_repo.commits_between(previous_deploy.version, current_deploy.version, simplify: true)
+                     git_repo.commits_between(
+                       previous_deploy.version,
+                       current_deploy.version,
+                       simplify: true,
+                       newest_first: true,
+                     )
                    else
                      [git_repo.commit_for_version(current_deploy.version)]
                    end

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -30,21 +30,18 @@ class GitRepository
     raise CommitNotFound
   end
 
-  def commits_between(from, to, simplify: false)
+  def commits_between(from, to, simplify: false, newest_first: false)
     instrument('commits_between') do
       validate_commit!(from) unless from.nil?
       validate_commit!(to)
 
-      walker = get_walker(to, from, simplify)
+      walker = get_walker(to, from, simplify: simplify, newest_first: newest_first)
       build_commits(walker)
     end
   end
 
   def recent_commits_on_main_branch(count = 50)
-    walker = Rugged::Walker.new(rugged_repository)
-    walker.sorting(Rugged::SORT_TOPO)
-    walker.push(main_branch.target_id)
-    walker.simplify_first_parent
+    walker = get_walker(main_branch.target_id, nil, simplify: true, newest_first: true)
 
     build_commits(walker.take(count))
   end
@@ -87,7 +84,7 @@ class GitRepository
 
     commits = []
 
-    walker = get_walker(main_branch.target_id, verified_commit_oid, false)
+    walker = get_walker(main_branch.target_id, verified_commit_oid, simplify: false)
     walker.each do |commit|
       commits << commit if rugged_repository.descendant_of?(commit.oid, verified_commit_oid)
       break if commit == merge_to_master_commit(verified_commit_oid)
@@ -117,7 +114,7 @@ class GitRepository
     parent_commit = rugged_repository.lookup(commit_oid).parents.first
     return true unless parent_commit
 
-    walker = get_walker(main_branch.target_id, parent_commit.oid, true)
+    walker = get_walker(main_branch.target_id, parent_commit.oid, simplify: true)
 
     begin
       walker.first.oid.start_with? commit_oid
@@ -135,9 +132,12 @@ class GitRepository
 
   attr_reader :rugged_repository
 
-  def get_walker(push_commit_oid, hide_commit_oid, simplify = false)
+  def get_walker(push_commit_oid, hide_commit_oid, simplify: false, newest_first: false)
+    sorting_strategy = Rugged::SORT_TOPO
+    sorting_strategy |= Rugged::SORT_REVERSE unless newest_first
+
     walker = Rugged::Walker.new(rugged_repository)
-    walker.sorting(Rugged::SORT_TOPO | Rugged::SORT_REVERSE)
+    walker.sorting(sorting_strategy)
     walker.simplify_first_parent if simplify
     walker.push(push_commit_oid)
     walker.hide(hide_commit_oid) if hide_commit_oid
@@ -145,7 +145,7 @@ class GitRepository
   end
 
   def merge_to_master_commit(commit_oid)
-    walker = get_walker(main_branch.target_id, commit_oid, true)
+    walker = get_walker(main_branch.target_id, commit_oid, simplify: true)
     walker.find { |commit| rugged_repository.descendant_of?(commit.oid, commit_oid) }
   end
 

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -4,6 +4,7 @@ Feature: Searching for releases on Dashboard
   I want to full text search for tickets
   So I can find tickets related to any topic
 
+@mock_slack_notifier
 Scenario: User finds deployed tickets by description
   Given the following tickets are created:
     | Jira Key | Summary       | Description                         | Deploys                     |

--- a/features/deploy_alert.feature
+++ b/features/deploy_alert.feature
@@ -33,6 +33,48 @@ Scenario: Release has no approved Feature Reviews
     | app_name | version | time                   | deployer | message                                              |
     | frontend | #merge1 | 2016-01-22 17:34+00:00 | Joe      | Release not authorised; Feature Review not approved. |
 
+Scenario: Dependent release has no approved Feature Reviews
+  Given an application called "frontend"
+
+  # An authorised deploy
+  And a commit "#master1" with message "initial commit" is created at "2016-01-18 09:10:57"
+  And a ticket "JIRA-ONE" with summary "Ticket ONE" is started at "2016-01-18 09:13:00"
+  And developer prepares review known as "FR_ONE" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version  |
+    | frontend | #master1 |
+  And at time "2016-01-20 14:52:45" adds link for review "FR_ONE" to comment for ticket "JIRA-ONE"
+  And ticket "JIRA-ONE" is approved by "bob@fundingcircle.com" at "2016-01-21 15:20:34"
+  When commit "#master1" of "frontend" is deployed by "Jeff" to production at "2016-01-21 16:34:20"
+  Then a deploy alert should not be dispatched
+
+  # An unauthorised release
+  And the branch "feature1" is checked out
+  And a ticket "JIRA-TWO" with summary "Ticket TWO" is started at "2016-01-21 09:13:00"
+  And a commit "#feat1_a" with message "feat1 first commit" is created at "2016-01-21 17:12:37"
+  And developer prepares review known as "FR_TWO" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version  |
+    | frontend | #feat1_a |
+  And at time "2016-01-21 18:52:45" adds link for review "FR_TWO" to comment for ticket "JIRA-TWO"
+  And the branch "master" is checked out
+  And the branch "feature1" is merged with merge commit "#merge1" at "2016-01-22 16:14:39"
+
+  # An authorised release, and deployed
+  And the branch "feature2" is checked out
+  And a ticket "JIRA-THREE" with summary "Ticket THREE" is started at "2016-01-23 09:13:00"
+  And a commit "#feat2_a" with message "feat2 first commit" is created at "2016-01-23 17:12:37"
+  And developer prepares review known as "FR_THREE" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version  |
+    | frontend | #feat2_a |
+  And at time "2016-01-23 18:52:45" adds link for review "FR_THREE" to comment for ticket "JIRA-THREE"
+  And the branch "master" is checked out
+  And the branch "feature2" is merged with merge commit "#merge2" at "2016-01-24 16:14:39"
+  And ticket "JIRA-THREE" is approved by "bob@fundingcircle.com" at "2016-01-24 16:20:34"
+
+  When commit "#merge2" of "frontend" is deployed by "Joe" to production at "2016-01-24 17:34:20"
+  Then a deploy alert should be dispatched for
+    | app_name | version | time                   | deployer | message                                              |
+    | frontend | #merge2 | 2016-01-24 17:34+00:00 | Joe      | Release not authorised; Feature Review not approved. |
+
 Scenario: Rollback to an older software version
   Given an application called "frontend"
 

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -120,6 +120,15 @@ RSpec.describe GitRepository do
         }.to raise_error(GitRepository::CommitNotFound, non_existent_commit)
       end
     end
+
+    context 'when called with newest_first flag set true' do
+      let(:options) { { newest_first: true } }
+
+      it 'returns all commits between two commits, including the end commit, in order of newest first' do
+        commits = repo.commits_between(version('A'), version('C'), options).map(&:id)
+        expect(commits).to eq([version('C'), version('B')])
+      end
+    end
   end
 
   describe '#recent_commits_on_main_branch' do


### PR DESCRIPTION
After deploying the revert of deploy alert fix, we had an increase in the number off errors in HB for not finding the repo.

This reverts commit 6c090e960e7936870ffaa8919ba4f10aa1bd553d.