### PR TITLE
Ensure get_dependent_commits returns an empty array when commit is not found

### DIFF
--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -31,6 +31,8 @@ class FeatureReviewWithStatuses < SimpleDelegator
     app_versions.map do |app_name, version|
       latest_commit = fetch_commit_for(app_name, version)
 
+      latest_commit = GitCommit.new(id: version) unless latest_commit.id
+
       [app_name, latest_commit]
     end
   end

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -28,11 +28,11 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def apps_with_latest_commit
-    app_versions.map do |app_name, version|
+    app_versions.map { |app_name, version|
       latest_commit = fetch_commit_for(app_name, version)
 
-      [app_name, latest_commit]
-    end
+      latest_commit ? [app_name, latest_commit] : nil
+    }.compact
   end
 
   def build_status

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -28,11 +28,11 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def apps_with_latest_commit
-    app_versions.map { |app_name, version|
+    app_versions.map do |app_name, version|
       latest_commit = fetch_commit_for(app_name, version)
 
-      latest_commit ? [app_name, latest_commit] : nil
-    }.compact
+      [app_name, latest_commit]
+    end
   end
 
   def build_status

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -47,7 +47,9 @@ class GitRepository
   end
 
   def commit_for_version(sha)
-    build_commit(lookup(sha))
+    commit = build_commit(lookup(sha))
+    commit = GitCommit.new(id: sha) unless commit.id
+    commit
   end
 
   # Returns "dependent commits" given a commit sha from a topic branch.

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -47,9 +47,7 @@ class GitRepository
   end
 
   def commit_for_version(sha)
-    commit = build_commit(lookup(sha))
-    commit = GitCommit.new(id: sha) unless commit.id
-    commit
+    build_commit(lookup(sha))
   end
 
   # Returns "dependent commits" given a commit sha from a topic branch.

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -71,7 +71,7 @@ class GitRepository
     end
 
     dependent_commits + commits_between(common_ancestor_oid, commit_oid)[0...-1]
-  rescue CommitNotValid
+  rescue CommitNotValid, CommitNotFound
     []
   end
 

--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -53,8 +53,8 @@
           %tr
             %td= app_name
             %td= commit_link(latest_commit.id, @feature_review_with_statuses.github_repo_urls[app_name])
-            %td= latest_commit.author_name
-            %td= latest_commit.time
+            %td= latest_commit.author_name || 'unknown'
+            %td= latest_commit.time || 'unknown'
       %ul.list-group
         %li.list-group-item
           - if @feature_review_with_statuses.uat_url

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -73,6 +73,25 @@ RSpec.describe FeatureReviewWithStatuses do
         .and_return(dependent_commits_2)
     end
 
+    context 'when one of the app latest commit is not an existing commit' do
+      let(:dependent_commits_1) { [] }
+      let(:dependent_commits_2) { [] }
+      let(:expected_results) do
+        [
+          [app_names.first, commit_1],
+        ]
+      end
+
+      before do
+        allow(repository).to receive(:commit_for_version).with(versions.first).and_return(commit_1)
+        allow(repository).to receive(:commit_for_version).with(versions.second).and_return(nil)
+      end
+
+      it 'returns the expected results for the existing commit only' do
+        expect(decorator.apps_with_latest_commit).to eq(expected_results)
+      end
+    end
+
     context 'when the latest commit is not a merge commit' do
       let(:dependent_commits_1) { [] }
       let(:dependent_commits_2) { [] }

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -73,25 +73,6 @@ RSpec.describe FeatureReviewWithStatuses do
         .and_return(dependent_commits_2)
     end
 
-    context 'when one of the app latest commit is not an existing commit' do
-      let(:dependent_commits_1) { [] }
-      let(:dependent_commits_2) { [] }
-      let(:expected_results) do
-        [
-          [app_names.first, commit_1],
-        ]
-      end
-
-      before do
-        allow(repository).to receive(:commit_for_version).with(versions.first).and_return(commit_1)
-        allow(repository).to receive(:commit_for_version).with(versions.second).and_return(nil)
-      end
-
-      it 'returns the expected results for the existing commit only' do
-        expect(decorator.apps_with_latest_commit).to eq(expected_results)
-      end
-    end
-
     context 'when the latest commit is not a merge commit' do
       let(:dependent_commits_1) { [] }
       let(:dependent_commits_2) { [] }
@@ -103,8 +84,10 @@ RSpec.describe FeatureReviewWithStatuses do
       end
 
       before do
-        allow(repository).to receive(:commit_for_version).with(versions.first).and_return(commit_1)
-        allow(repository).to receive(:commit_for_version).with(versions.second).and_return(commit_2)
+        allow(repository).to receive(:commit_for_version).with(versions.first)
+          .and_return(commit_1)
+        allow(repository).to receive(:commit_for_version).with(versions.second)
+          .and_return(commit_2)
       end
 
       it 'returns the app_name and the very same commit' do

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -209,16 +209,25 @@ RSpec.describe GitRepository do
     end
 
     context 'when the lookup fails' do
-      it 'returns an empty GitCommit for an invalid SHA' do
-        commit = subject.commit_for_version('invalid_sha')
-        expect(commit).to be_a(GitCommit)
-        expect(commit.associated_ids).to be_empty
+      shared_examples :failed_lookup do |sha|
+        subject(:commit) { repo.commit_for_version(sha) }
+
+        it 'does not raise any exception' do
+          expect { commit }.not_to raise_error
+        end
+
+        it 'returns a GitCommit object for the given sha' do
+          expect(commit).to be_a(GitCommit)
+          expect(commit.id).to eq(sha)
+        end
       end
 
-      it 'returns an empty GitCommit for an extra long SHA' do
-        commit = subject.commit_for_version('abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc')
-        expect(commit).to be_a(GitCommit)
-        expect(commit.id).to be_nil
+      context 'invalid sha' do
+        include_examples :failed_lookup, 'invalid_sha'
+      end
+
+      context 'extra long sha' do
+        include_examples :failed_lookup, 'abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc'
       end
     end
   end

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -209,25 +209,16 @@ RSpec.describe GitRepository do
     end
 
     context 'when the lookup fails' do
-      shared_examples :failed_lookup do |sha|
-        subject(:commit) { repo.commit_for_version(sha) }
-
-        it 'does not raise any exception' do
-          expect { commit }.not_to raise_error
-        end
-
-        it 'returns a GitCommit object for the given sha' do
-          expect(commit).to be_a(GitCommit)
-          expect(commit.id).to eq(sha)
-        end
+      it 'returns an empty GitCommit for an invalid SHA' do
+        commit = subject.commit_for_version('invalid_sha')
+        expect(commit).to be_a(GitCommit)
+        expect(commit.associated_ids).to be_empty
       end
 
-      context 'invalid sha' do
-        include_examples :failed_lookup, 'invalid_sha'
-      end
-
-      context 'extra long sha' do
-        include_examples :failed_lookup, 'abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc'
+      it 'returns an empty GitCommit for an extra long SHA' do
+        commit = subject.commit_for_version('abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc')
+        expect(commit).to be_a(GitCommit)
+        expect(commit.id).to be_nil
       end
     end
   end

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -445,6 +445,20 @@ RSpec.describe GitRepository do
       end
     end
 
+    context 'when the commit is not found' do
+      let(:git_diagram) do
+        <<-'EOS'
+             o-A-o
+            /
+          -o-----o
+        EOS
+      end
+
+      it 'is empty' do
+        expect(repo.get_dependent_commits('5c6e280c6c4f5aff08a179526b6d73410552f453')).to be_empty
+      end
+    end
+
     context 'when the sha is invalid' do
       let(:git_diagram) do
         <<-'EOS'


### PR DESCRIPTION
Rescue `CommitNotFound` and return empty array when calling `get_dependent_commits`