### PR TITLE
Ensure *last* commit is shown in feature review show page even when it's not a merge commit

### DIFF
--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -105,12 +105,12 @@ class FeatureReviewWithStatuses < SimpleDelegator
 
   def fetch_commit_for(app_name, version)
     git_repository_loader = git_repository_loader_for(app_name)
-    dependent_commits(git_repository_loader, version)&.first ||
+    descendant_commits(git_repository_loader, version)&.first ||
       commit_for_version(git_repository_loader, version)
   end
 
-  def dependent_commits(loader, version)
-    loader.get_dependent_commits(version).presence
+  def descendant_commits(loader, version)
+    loader.get_descendant_commits_of_branch(version).presence
   end
 
   def commit_for_version(loader, version)

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -104,20 +104,20 @@ class FeatureReviewWithStatuses < SimpleDelegator
   private
 
   def fetch_commit_for(app_name, version)
-    git_repository_loader = git_repository_loader_for(app_name)
-    descendant_commits(git_repository_loader, version)&.first ||
-      commit_for_version(git_repository_loader, version)
+    git_repository = git_repository_for(app_name)
+    descendant_commits(git_repository, version)&.first ||
+      commit_for_version(git_repository, version)
   end
 
-  def descendant_commits(loader, version)
-    loader.get_descendant_commits_of_branch(version).presence
+  def descendant_commits(git_repository, version)
+    git_repository.get_descendant_commits_of_branch(version).presence
   end
 
-  def commit_for_version(loader, version)
-    loader.commit_for_version(version)
+  def commit_for_version(git_repository, version)
+    git_repository.commit_for_version(version)
   end
 
-  def git_repository_loader_for(app_name)
+  def git_repository_for(app_name)
     GitRepositoryLoader.from_rails_config.load(app_name)
   end
 end

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe FeatureReviewWithStatuses do
       allow(GitRepositoryLoader).to receive(:from_rails_config).and_return(repository_loader)
       allow(repository_loader).to receive(:load).and_return(repository)
 
-      allow(repository).to receive(:get_dependent_commits).with(versions.first)
+      allow(repository).to receive(:get_descendant_commits_of_branch).with(versions.first)
         .and_return(dependent_commits_1)
-      allow(repository).to receive(:get_dependent_commits).with(versions.second)
+      allow(repository).to receive(:get_descendant_commits_of_branch).with(versions.second)
         .and_return(dependent_commits_2)
     end
 


### PR DESCRIPTION
#184 and #186 introduced a live commit lookup for each feature review, the purpose was to show the merge commit author, and this is working as expected when the commit is an actual merge commit, while it doesn't when it's not - it shows the *first* commit of the branch the commit belongs to instead, not the *current* one (non-merge commit).

@0mega can you give it a look? Thanks