### PR TITLE
Remove legacy Heroku multiple buildpack config

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/ddollar/heroku-buildpack-apt
-https://github.com/heroku/heroku-buildpack-ruby


### PR DESCRIPTION
💁  Heroku now supports multiple buildpacks for applications and support for https://github.com/ddollar/heroku-buildpack-multi has been deprecated. This change removes the configuration file.

https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app