### PR TITLE
NS-1506: Add ability to unlink Jira ticket from a feature review

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,10 @@ Rails/TimeZone:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 110
+  Max: 120
+
+Style/SingleLineBlockParams:
+  Enabled: false
 
 Metrics/MethodLength:
   Max: 15
@@ -58,6 +61,7 @@ Style/SignalException:
   EnforcedStyle: semantic
   Exclude:
     - 'app/use_cases/link_ticket.rb'
+    - 'app/use_cases/unlink_ticket.rb'
 
 Style/FrozenStringLiteralComment:
   Enabled: enable

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ gem 'unicorn'
 gem 'virtus'
 
 group :development do
-  gem 'better_errors', require: false
-  gem 'binding_of_caller', require: false
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'foreman', require: false
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,4 +408,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.5
+   1.14.3

--- a/app/controllers/feature_reviews_controller.rb
+++ b/app/controllers/feature_reviews_controller.rb
@@ -37,6 +37,20 @@ class FeatureReviewsController < ApplicationController
     redirect_to redirect_path
   end
 
+  def unlink_ticket
+    args = ticket_linking_options.merge(apps: params.fetch(:apps))
+    UnlinkTicket.run(args).match do
+      success do |success_message|
+        flash[:success] = success_message
+      end
+
+      failure do |error|
+        flash[:error] = error.message
+      end
+    end
+    redirect_to feature_reviews_path(apps: params[:apps])
+  end
+
   private
 
   def ticket_linking_options

--- a/app/helpers/ticket_validation_helper.rb
+++ b/app/helpers/ticket_validation_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# This helper relies on gem SolidUseCase
+module TicketValidationHelper
+  def validate_id_format(args)
+    return fail :invalid_key, message: invalid_key_message(args) unless /[A-Z]{2,}-\d+/ =~ args[:jira_key]
+    continue(args)
+  end
+end

--- a/app/jobs/relink_ticket_job.rb
+++ b/app/jobs/relink_ticket_job.rb
@@ -36,8 +36,7 @@ class RelinkTicketJob < ActiveJob::Base
 
   def link_feature_review_to_ticket(ticket_key, old_feature_review_path, before_sha, after_sha)
     new_feature_review_path = old_feature_review_path.sub(before_sha, after_sha)
-    message = "[Feature ready for review|#{feature_review_url(new_feature_review_path)}]"
-    JiraClient.post_comment(ticket_key, message)
+    JiraClient.post_comment(ticket_key, LinkTicket.build_comment(feature_review_url(new_feature_review_path)))
   rescue JiraClient::InvalidKeyError
     @send_error_status = true
     Rails.logger.warn "Failed to post comment to JIRA ticket #{ticket_key}. Ticket might have been deleted."

--- a/app/models/events/handlers/link_ticket_handler.rb
+++ b/app/models/events/handlers/link_ticket_handler.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Events
+  module Handlers
+    class LinkTicketHandler < TicketHandler
+      def apply
+        super.merge(
+          'paths' => paths,
+          'versions' => versions,
+          'version_timestamps' => version_timestamps,
+        )
+      end
+
+      private
+
+      def paths
+        old_paths = ticket.fetch('paths', [])
+        new_paths = feature_reviews_from_event.map(&:path)
+        old_paths.concat(new_paths).uniq
+      end
+
+      def versions
+        old_versions = ticket.fetch('versions', [])
+        new_versions = feature_reviews_from_event.flat_map(&:versions)
+        old_versions.concat(new_versions).uniq
+      end
+
+      def version_timestamps
+        old_version_timestamps = ticket.fetch('version_timestamps', {})
+        versions = feature_reviews_from_event.flat_map(&:versions)
+        new_version_timestamps = versions.each_with_object({}) { |version, hash|
+          hash[version] = event.created_at
+        }
+        new_version_timestamps.merge(old_version_timestamps)
+      end
+    end
+  end
+end

--- a/app/models/events/handlers/ticket_handler.rb
+++ b/app/models/events/handlers/ticket_handler.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Events
+  module Handlers
+    class TicketHandler
+      def initialize(ticket, event)
+        @ticket = ticket
+        @event = event
+      end
+
+      def apply
+        ticket.merge(
+          'key' => event.key,
+          'summary' => event.summary,
+          'status' => event.status,
+          'event_created_at' => event.created_at,
+          'approved_at' => merge_approved_at(ticket, event),
+        )
+      end
+
+      protected
+
+      attr_reader :ticket, :event
+
+      def feature_reviews_from_event
+        Factories::FeatureReviewFactory.new.create_from_text(event.comment)
+      end
+
+      private
+
+      def merge_approved_at(last_ticket, event)
+        if event.approval?
+          event.created_at
+        elsif last_ticket.present? && Ticket.new(status: event.status).approved?
+          last_ticket['approved_at']
+        end
+      end
+    end
+  end
+end

--- a/app/models/events/handlers/unlink_ticket_handler.rb
+++ b/app/models/events/handlers/unlink_ticket_handler.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Events
+  module Handlers
+    class UnlinkTicketHandler < TicketHandler
+      def apply
+        old_versions = ticket.fetch('versions', [])
+        new_versions = feature_reviews_from_event.flat_map(&:versions)
+        versions_to_remove = old_versions - new_versions
+        super.merge(
+          'paths' => paths,
+          'versions' => versions_to_remove,
+          'version_timestamps' => ticket.fetch('version_timestamps', {}).slice(*versions_to_remove),
+        )
+      end
+
+      private
+
+      def paths
+        old_paths = ticket.fetch('paths', [])
+        old_paths - feature_reviews_from_event.map(&:path)
+      end
+    end
+  end
+end

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -43,7 +43,29 @@ module Events
         !approved_status?(status_item['toString'])
     end
 
+    def apply(ticket)
+      handler.new(ticket, self).apply
+    end
+
     private
+
+    def handler
+      if link_action?
+        Handlers::LinkTicketHandler
+      elsif unlink_action?
+        Handlers::UnlinkTicketHandler
+      else
+        Handlers::TicketHandler
+      end
+    end
+
+    def link_action?
+      comment.include?(LinkTicket::COMMENT_LABEL)
+    end
+
+    def unlink_action?
+      comment.include?(UnlinkTicket::COMMENT_LABEL)
+    end
 
     def status_item
       @status_item ||= changelog_items.find { |item| item['field'] == 'status' }

--- a/app/use_cases/link_ticket.rb
+++ b/app/use_cases/link_ticket.rb
@@ -4,25 +4,30 @@ require 'clients/jira'
 
 class LinkTicket
   include SolidUseCase
+  include TicketValidationHelper
+
+  COMMENT_LABEL = 'Feature ready for review'
 
   steps :validate_id_format, :assert_not_linked, :post_comment
 
-  def validate_id_format(args)
-    return fail :invalid_key, message: invalid_key_message(args) unless /[A-Z][A-Z]+-\d*/ =~ args[:jira_key]
-    continue(args)
+  class << self
+    def build_comment(url)
+      "[#{COMMENT_LABEL}|#{url}]"
+    end
   end
 
   def assert_not_linked(args)
     tickets = Repositories::TicketRepository.new.tickets_for_path(args[:feature_review_path])
 
-    return fail :duplicate_key, message: duplicate_key_message(args) if tickets.any? { |ticket|
-      ticket.key == args[:jira_key]
-    }
+    has_links = tickets.any? { |ticket| ticket.key == args[:jira_key] }
+    return fail :duplicate_key, message: duplicate_key_message(args) if has_links
     continue(args)
   end
 
   def post_comment(args)
-    JiraClient.post_comment(args[:jira_key], jira_comment(args))
+    feature_review_url = "#{args[:root_url].chomp('/')}#{args[:feature_review_path]}"
+
+    JiraClient.post_comment(args[:jira_key], self.class.build_comment(feature_review_url))
     continue(success_message(args))
   rescue JiraClient::InvalidKeyError
     fail :invalid_key, message: invalid_key_message(args)
@@ -46,13 +51,6 @@ class LinkTicket
   end
 
   def success_message(args)
-    "Feature Review was linked to #{args[:jira_key]}."\
-    ' Refresh this page in a moment and the ticket will appear.'
-  end
-
-  def jira_comment(args)
-    feature_review_url = "#{args[:root_url].chomp('/')}#{args[:feature_review_path]}"
-
-    "[Feature ready for review|#{feature_review_url}]"
+    "Feature Review was linked to #{args[:jira_key]}. Refresh this page in a moment and the ticket will appear."
   end
 end

--- a/app/use_cases/unlink_ticket.rb
+++ b/app/use_cases/unlink_ticket.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'clients/jira'
+
+class UnlinkTicket
+  COMMENT_LABEL = 'Feature review was unlinked'
+
+  include SolidUseCase
+  include TicketValidationHelper
+
+  steps :validate_id_format,
+    :assert_linked,
+    :post_unlink_comment
+
+  class << self
+    def build_comment(feature_review_url)
+      "[#{COMMENT_LABEL}|#{feature_review_url}]"
+    end
+  end
+
+  def assert_linked(args)
+    tickets = Repositories::TicketRepository.new.tickets_for_path(args[:feature_review_path])
+
+    has_links = tickets.any? { |ticket| ticket.key == args[:jira_key] }
+    return fail :missing_key, message: missing_key_message(args) unless has_links
+    continue(args)
+  end
+
+  def post_unlink_comment(args)
+    comment = self.class.build_comment("#{args[:root_url].chomp('/')}#{args[:feature_review_path]}")
+    JiraClient.post_comment(args[:jira_key], comment)
+    continue(success_message(args))
+  rescue JiraClient::InvalidKeyError
+    fail :invalid_key, message: invalid_key_message(args)
+  rescue StandardError => error
+    Honeybadger.notify(error)
+    fail :post_failed, message: generic_error_message(args)
+  end
+
+  private
+
+  def invalid_key_message(args)
+    "Failed to unlink #{args[:jira_key]}. Please check that the ticket ID is correct."
+  end
+
+  def missing_key_message(args)
+    "Failed to unlink #{args[:jira_key]}. Existing link couldn't be found."
+  end
+
+  def generic_error_message(args)
+    "Failed to unlink #{args[:jira_key]}. Something went wrong."
+  end
+
+  def success_message(args)
+    "Feature Review was unlinked from #{args[:jira_key]}. Refresh this page in a moment and the ticket will disappear."
+  end
+end

--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -11,7 +11,7 @@
   .col-lg-12
     - panel(heading: feature_status(@feature_review_with_statuses), status: @feature_review_with_statuses.authorisation_status, klass: 'feature-status', help_url: wiki_links(:approval), align_right: true) do
       - if @feature_review_with_statuses.tickets.any?
-        - table(headers: %w(Ticket Summary Status)) do
+        - table(headers: %w(Ticket Summary Status Actions)) do
           - @feature_review_with_statuses.tickets.each do |ticket|
             %tr.ticket
               %td= jira_link(ticket.key)
@@ -19,6 +19,9 @@
               %td
                 - icon(item_status_icon_class(ticket.authorised?(@feature_review_with_statuses.versions)))
                 = ticket.authorisation_status(@feature_review_with_statuses.versions)
+              %td
+                = link_to 'unlink', {controller: :feature_reviews, action: :unlink_ticket, apps: @feature_review_with_statuses.app_versions, jira_key: ticket.key, return_to: @return_to}, {class: 'btn btn-danger btn-xs', role: 'button'}
+
       .panel-body
         = form_tag(link_ticket_feature_reviews_path(return_to: @return_to), method: 'post', class: 'form-inline') do
           .form-group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
   post 'events/:type', to: 'events#create', as: 'events'
 
   resource :feature_reviews, only: [:new, :show, :create] do
+    member do
+      get 'unlink', to: 'feature_reviews#unlink_ticket'
+    end
     post 'link_ticket'
   end
 

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -67,6 +67,33 @@ Scenario: Linking a Feature Review
   When I link the feature review "FR_view" to the Jira ticket "JIRA-123"
   Then I should see an alert: "Failed to link JIRA-123. Duplicate tickets should not be added."
 
+@logged_in @disable_jira_client
+Scenario: Unlinking a ticket from a Feature Review
+  Given an application called "frontend"
+  And a commit "#abc" by "Alice" is created at "2014-10-04 11:00:00" for app "frontend"
+  And a ticket "JIRA-123" with summary "Urgent ticket" is started at "2014-10-04 13:01:17"
+  And a ticket "JIRA-789" with summary "Urgent ticket" is started at "2014-10-04 13:01:17"
+  And developer prepares review known as "FR_view" for UAT "uat.fundingcircle.com" with apps
+    | app_name | version |
+    | frontend | #abc    |
+
+  When I visit the feature review known as "FR_view"
+  When I link the feature review "FR_view" to the Jira ticket "JIRA-123"
+  And I link the feature review "FR_view" to the Jira ticket "JIRA-789"
+
+  When I reload the page after a while
+  Then I should see the tickets
+    | Ticket   | Summary       | Status      |
+    | JIRA-123 | Urgent ticket | In Progress |
+    | JIRA-789 | Urgent ticket | In Progress |
+
+  When I unlink the feature review "FR_view" from the Jira ticket "JIRA-123"
+
+  When I reload the page after a while
+  Then I should see the tickets
+    | Ticket   | Summary       | Status      |
+    | JIRA-789 | Urgent ticket | In Progress |
+
 @logged_in
 Scenario: Viewing User Acceptance Tests results on a Feature review
   Given an application called "frontend"
@@ -216,7 +243,6 @@ Scenario: Viewing an approved Feature Review after regenerating snapshots
   And I should see the tickets
     | Ticket   | Summary       | Status               |
     | JIRA-123 | Urgent ticket | Ready for Deployment |
-
 
 Scenario: QA rejects feature
   Given an application called "frontend"

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -45,10 +45,11 @@ Given 'the following tickets are created:' do |tickets_table|
 end
 
 Given 'at time "$a" adds link for review "$b" to comment for ticket "$c"' do |time, nickname, jira_key|
-  scenario_context.link_ticket_and_feature_review(
+  scenario_context.post_jira_comment(
     jira_key: jira_key,
     feature_review_nickname: nickname,
     time: time,
+    comment_type: LinkTicket,
   )
 end
 

--- a/features/step_definitions/feature_review_steps.rb
+++ b/features/step_definitions/feature_review_steps.rb
@@ -146,5 +146,10 @@ end
 
 When 'I link the feature review "$nickname" to the Jira ticket "$jira_key"' do |nickname, jira_key|
   feature_review_page.link_a_jira_ticket(jira_key: jira_key)
-  scenario_context.link_ticket_and_feature_review(jira_key: jira_key, feature_review_nickname: nickname)
+  scenario_context.post_jira_comment(jira_key: jira_key, feature_review_nickname: nickname, comment_type: LinkTicket)
+end
+
+When 'I unlink the feature review "$nickname" from the Jira ticket "$jira_key"' do |nickname, jira_key|
+  feature_review_page.unlink_a_jira_ticket(jira_key: jira_key)
+  scenario_context.post_jira_comment(jira_key: jira_key, feature_review_nickname: nickname, comment_type: UnlinkTicket)
 end

--- a/features/support/pages/feature_review_page.rb
+++ b/features/support/pages/feature_review_page.rb
@@ -67,6 +67,11 @@ module Pages
       page.click_link_or_button('Link')
     end
 
+    def unlink_a_jira_ticket(jira_key:)
+      verify!
+      page.find('tr', text: jira_key) { click_link_or_button('unlink') }
+    end
+
     def qa_submission_panel
       verify!
       Sections::PanelListSection.new(

--- a/features/support/pages/feature_review_page.rb
+++ b/features/support/pages/feature_review_page.rb
@@ -91,7 +91,7 @@ module Pages
 
     def tickets
       verify!
-      Sections::TableSection.new(page.find('.feature-status table')).items
+      Sections::TableSection.new(page.find('.feature-status table')).items.map { |row| row.except('Actions') }
     end
 
     def uatest_panel

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -100,7 +100,7 @@ module Support
     def link_ticket_and_feature_review(jira_key:, feature_review_nickname:, time: Time.current.to_s)
       url = review_url(feature_review_nickname: feature_review_nickname)
       ticket_details = @tickets.fetch(jira_key).merge!(
-        comment_body: "Here you go: #{url}",
+        comment_body: LinkTicket.build_comment(url),
         updated: time,
       )
       @stubbed_requests['pending'] = stub_request(:post, %r{https://api.github.com/.*})

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -97,10 +97,10 @@ module Support
       }
     end
 
-    def link_ticket_and_feature_review(jira_key:, feature_review_nickname:, time: Time.current.to_s)
+    def post_jira_comment(jira_key:, feature_review_nickname:, time: Time.current.to_s, comment_type:)
       url = review_url(feature_review_nickname: feature_review_nickname)
       ticket_details = @tickets.fetch(jira_key).merge!(
-        comment_body: LinkTicket.build_comment(url),
+        comment_body: comment_type.build_comment(url),
         updated: time,
       )
       @stubbed_requests['pending'] = stub_request(:post, %r{https://api.github.com/.*})

--- a/spec/helpers/ticket_validation_helper_spec.rb
+++ b/spec/helpers/ticket_validation_helper_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe TicketValidationHelper do
+  class ClassWithTicketValidator
+    include SolidUseCase
+    include TicketValidationHelper
+
+    def invalid_key_message(_args)
+      'Not valid at all'
+    end
+  end
+
+  let(:object) { ClassWithTicketValidator.new }
+
+  describe '#validate_id_format' do
+    context 'when jira key is valid' do
+      let(:args) { { jira_key: 'NS-123' } }
+
+      it 'continues' do
+        expect(object).to receive(:continue).with(args)
+        object.validate_id_format(args)
+      end
+    end
+
+    context 'when jira key is invalid' do
+      let(:args) { { jira_key: 'nope' } }
+
+      specify {
+        expect(object).to receive(:fail).with(:invalid_key, message: 'Not valid at all')
+        object.validate_id_format(args)
+      }
+    end
+  end
+end

--- a/spec/models/events/handlers/link_ticket_handler_spec.rb
+++ b/spec/models/events/handlers/link_ticket_handler_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Events::Handlers::LinkTicketHandler do
+  let(:time) { Time.current.change(usec: 0) }
+
+  let(:url1) { feature_review_url(app1: 'one') }
+  let(:path1) { feature_review_path(app1: 'one') }
+  let(:time1) { time - 3.hours }
+
+  let(:path2) { feature_review_path(app2: 'two') }
+  let(:url2) { feature_review_url(app2: 'two') }
+  let(:time2) { time - 2.hours }
+
+  describe '#apply' do
+    it 'adds link references' do
+      events = [
+        build(:jira_event, key: 'JIRA-1', comment_body: LinkTicket.build_comment(url1), created_at: time1),
+        build(:jira_event, key: 'JIRA-1', comment_body: LinkTicket.build_comment(url2), created_at: time2),
+        build(:jira_event, key: 'JIRA-1', comment_body: LinkTicket.build_comment(url1), created_at: time - 1.hour),
+      ]
+
+      final_ticket = events.reduce({}) { |ticket, event| described_class.new(ticket, event).apply }
+      expect(final_ticket).to match(
+        hash_including(
+          'key' => 'JIRA-1',
+          'paths' => [path1, path2],
+          'versions' => %w(one two),
+          'version_timestamps' => { 'one' => time1, 'two' => time2 },
+        ),
+      )
+    end
+  end
+end

--- a/spec/models/events/handlers/ticket_handler_spec.rb
+++ b/spec/models/events/handlers/ticket_handler_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Events::Handlers::TicketHandler do
+  describe '#apply' do
+    let(:time) { Time.current.change(usec: 0) }
+    let(:ticket_defaults) { { paths: [path], versions: %w(foo), version_timestamps: { 'foo' => nil } } }
+    let(:url) { feature_review_url(app: 'foo') }
+    let(:path) { feature_review_path(app: 'foo') }
+
+    it 'updates key information' do
+      ticket = {}
+      created_ticket_event = build(:jira_event, :created, key: 'JIRA-1', summary: 'work 1', created_at: time + 1.hour)
+
+      new_ticket = described_class.new(ticket, created_ticket_event).apply
+
+      expect(new_ticket).to include(
+        'key' => 'JIRA-1',
+        'summary' => 'work 1',
+        'status' => 'To Do',
+        'event_created_at' => time + 1.hour,
+        'approved_at' => nil,
+      )
+    end
+
+    context 'when the event is approval' do
+      it 'updates approved_at with events created_at' do
+        ticket = {}
+        created_ticket_event = build(:jira_event, :approved, created_at: time + 1.hour)
+
+        new_ticket = described_class.new(ticket, created_ticket_event).apply
+
+        expect(new_ticket).to include('approved_at' => time + 1.hour)
+      end
+    end
+
+    context 'when ticket is present and event is PAST approval' do
+      it 'uses approved_at from previous event' do
+        ticket = { 'approved_at' => 123 }
+        created_ticket_event = build(:jira_event, :deployed, created_at: time + 1.hour)
+
+        new_ticket = described_class.new(ticket, created_ticket_event).apply
+
+        expect(new_ticket).to include('approved_at' => 123)
+      end
+    end
+  end
+end

--- a/spec/models/events/handlers/unlink_ticket_handler_spec.rb
+++ b/spec/models/events/handlers/unlink_ticket_handler_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Events::Handlers::UnlinkTicketHandler do
+  let(:time) { Time.current.change(usec: 0) }
+
+  let(:path1) { feature_review_path(app1: 'one') }
+
+  let(:url2) { feature_review_url(app2: 'two') }
+  let(:path2) { feature_review_path(app2: 'two') }
+
+  describe '#apply' do
+    it 'removes the link' do
+      time1 = time - 3.hours
+      ticket = {
+        'key' => 'JIRA-1',
+        'paths' => [path1, path2],
+        'versions' => %w(one two),
+        'version_timestamps' => { 'one' => time1, 'two' => time - 2.hours },
+      }
+      unlink_2_event = build(
+        :jira_event,
+        key: 'JIRA-1',
+        comment_body: UnlinkTicket.build_comment(url2),
+        created_at: time - 1.hour,
+      )
+
+      new_ticket = described_class.new(ticket, unlink_2_event).apply
+      expect(new_ticket).to include(
+        'key' => 'JIRA-1',
+        'paths' => [path1],
+        'versions' => %w(one),
+        'version_timestamps' => { 'one' => time1 },
+      )
+    end
+  end
+end

--- a/spec/use_cases/link_ticket_spec.rb
+++ b/spec/use_cases/link_ticket_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 require 'link_ticket'
 
 RSpec.describe LinkTicket do
-  let(:ticket_repository) { double }
+  let(:ticket_repository) { instance_double(Repositories::TicketRepository) }
 
   let(:apps_with_versions) { { 'frontend' => 'abc', 'backend' => 'def' } }
   let(:args) {
@@ -33,11 +33,11 @@ RSpec.describe LinkTicket do
 
       it 'posts a comment' do
         expect(JiraClient).to receive(:post_comment).with(jira_key, expected_comment)
-        LinkTicket.run(args)
+        described_class.run(args)
       end
 
       it 'returns a success message' do
-        result = LinkTicket.run(args)
+        result = described_class.run(args)
         expect(result).to be_a_success
         expect(result.value).to eq(expected_message)
       end
@@ -51,7 +51,7 @@ RSpec.describe LinkTicket do
         allow(JiraClient).to receive(:post_comment).and_raise(JiraClient::InvalidKeyError)
       end
       it 'fails with message' do
-        result = LinkTicket.run(args)
+        result = described_class.run(args)
         expect(result).to fail_with(:invalid_key)
         expect(result.value.message).to eq(expected_message)
       end
@@ -64,11 +64,11 @@ RSpec.describe LinkTicket do
       let(:ticket) { Ticket.new(paths: [feature_review_path(apps_with_versions)], key: jira_key) }
 
       before do
-        expect(ticket_repository).to receive(:tickets_for_path).and_return([ticket])
+        allow(ticket_repository).to receive(:tickets_for_path).and_return([ticket])
       end
 
       it 'fails with message' do
-        result = LinkTicket.run(args)
+        result = described_class.run(args)
         expect(result).to fail_with(:duplicate_key)
         expect(result.value.message).to eq(expected_message)
       end
@@ -82,7 +82,7 @@ RSpec.describe LinkTicket do
       end
 
       it 'fails with message' do
-        result = LinkTicket.run(args)
+        result = described_class.run(args)
         expect(result).to fail_with(:post_failed)
         expect(result.value.message).to eq(expected_message)
       end
@@ -96,7 +96,7 @@ RSpec.describe LinkTicket do
     }
 
     it 'fails validation' do
-      result = LinkTicket.run(args)
+      result = described_class.run(args)
       expect(result).to fail_with(:invalid_key)
       expect(result.value.message).to eq(expected_message)
     end

--- a/spec/use_cases/unlink_ticket_spec.rb
+++ b/spec/use_cases/unlink_ticket_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'unlink_ticket'
+
+RSpec.describe UnlinkTicket do
+  let(:ticket_repository) { instance_double(Repositories::TicketRepository) }
+
+  let(:apps_with_versions) { { 'frontend' => 'abc', 'backend' => 'def' } }
+  let(:args) {
+    {
+      jira_key: jira_key,
+      feature_review_path: feature_review_path(apps_with_versions),
+      root_url: 'http://test.com/',
+    }
+  }
+
+  before do
+    allow(Repositories::TicketRepository).to receive(:new).and_return(ticket_repository)
+    allow(ticket_repository).to receive(:tickets_for_path).and_return([])
+    allow(JiraClient).to receive(:post_comment)
+  end
+
+  describe '.class' do
+    subject(:unlink_comment) { described_class.run(args) }
+
+    context 'the ticket ID is an invalid format' do
+      let(:jira_key) { 'INVALID' }
+      let(:expected_message) {
+        "Failed to unlink #{jira_key}. Please check that the ticket ID is correct."
+      }
+
+      it 'fails validation' do
+        result = subject
+        expect(result).to fail_with(:invalid_key)
+        expect(result.value.message).to eq(expected_message)
+      end
+    end
+
+    context 'the ticket ID is a valid format' do
+      let(:jira_key) { 'JIRA-123' }
+
+      context 'when the ticket is not linked' do
+        let(:expected_message) { "Failed to unlink #{jira_key}. Existing link couldn't be found." }
+
+        before do
+          allow(JiraClient).to receive(:post_comment).and_raise(StandardError)
+        end
+
+        it 'fails with message' do
+          expect(subject).to fail_with(:missing_key)
+          expect(subject.value.message).to eq(expected_message)
+        end
+      end
+
+      context 'when the ticket is linked' do
+        context 'when posting returns an error' do
+          let(:expected_message) { "Failed to unlink #{jira_key}. Something went wrong." }
+          let(:ticket) { Ticket.new(paths: [feature_review_path(apps_with_versions)], key: jira_key) }
+
+          before do
+            allow(JiraClient).to receive(:post_comment).and_raise(StandardError)
+            allow(ticket_repository).to receive(:tickets_for_path).and_return([ticket])
+          end
+
+          it 'fails with message' do
+            expect(subject).to fail_with(:post_failed)
+            expect(subject.value.message).to eq(expected_message)
+          end
+        end
+
+        context 'when posting is successful' do
+          let(:expected_message) {
+            "Feature Review was unlinked from #{jira_key}."\
+              ' Refresh this page in a moment and the ticket will disappear.'
+          }
+          let(:ticket) { Ticket.new(paths: [feature_review_path(apps_with_versions)], key: jira_key) }
+
+          before do
+            allow(ticket_repository).to receive(:tickets_for_path).and_return([ticket])
+          end
+
+          it 'sends a message to Jira' do
+            expect(JiraClient).to receive(:post_comment).with(jira_key, a_kind_of(String))
+
+            subject
+          end
+
+          it 'returns status update message' do
+            expect(subject).to be_a_success
+            expect(subject.value).to eq(expected_message)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?
Adds ability to unlink a Jira ticket from a feature review

### Where should the reviewer start?
Posting a comment to Jira - `app/use_cases/unlink_ticket.rb`
Processing webhook Jira notification - `app/models/repositories/ticket_repository.rb`

### Any background context you want to provide?
*intentionally left blank*

### Any specific implementation changes that would benefit highlighting?
I've decided to use the same process as we use for linking tickets (ST -> Jira -> ST)

### What are the relevant tickets / PRs?
- [x] JIRA :gem:: https://jira.fundingcircle.com/browse/NS-1506
