### PR TITLE
GQ-28-Add repository owners

### DIFF
--- a/app/controllers/git_repository_locations_controller.rb
+++ b/app/controllers/git_repository_locations_controller.rb
@@ -22,7 +22,37 @@ class GitRepositoryLocationsController < ApplicationController
     end
   end
 
+  def edit
+    load_edit_env
+
+    @form = form_for(@git_repository_location)
+  end
+
+  def update
+    load_edit_env
+
+    edit_params = params.require(:forms_edit_git_repository_location_form).permit(:repo_owners)
+    @form = form_for(@git_repository_location, edit_params)
+
+    if @form.call
+      flash[:success] = "Repository #{@repository_name} successfully updated!"
+      redirect_to action: :index
+    else
+      render 'edit'
+    end
+  end
+
   private
+
+  def form_for(repo, params = {})
+    Forms::EditGitRepositoryLocationForm.new(repo: repo, current_user: current_user, params: params)
+  end
+
+  def load_edit_env
+    @git_repository_location = GitRepositoryLocation.find(params[:id])
+    @repository_name = @git_repository_location.name
+    @repository_uri = @git_repository_location.uri
+  end
 
   def success_msg(repo_name)
     render_to_string partial: 'partials/add_repo_success_msg', locals: { repo_name: repo_name }

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module FormHelper
+  def form_errors(record)
+    return if record.errors.blank?
+
+    content_tag(:ul, class: 'list-group') do
+      record.errors.full_messages.map { |error|
+        content_tag(:li, class: 'list-group-item list-group-item-danger') do
+          error
+        end
+      }.join("\n").html_safe
+    end
+  end
+end

--- a/app/helpers/repo_owners_helper.rb
+++ b/app/helpers/repo_owners_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module RepoOwnersHelper
+  def format_owner_emails(owners = [])
+    owners = Array.wrap(owners)
+
+    RepoOwner.to_mail_address_list(owners).addresses.map { |email|
+      content_tag :span, h(email.format), class: 'text-nowrap'
+    }.join(', ').html_safe
+  end
+end

--- a/app/models/events/repo_ownership_event.rb
+++ b/app/models/events/repo_ownership_event.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'events/base_event'
+
+module Events
+  class RepoOwnershipEvent < Events::BaseEvent
+    def app_name
+      details.fetch('app_name')
+    end
+
+    def repo_owners
+      details['repo_owners']
+    end
+  end
+end

--- a/app/models/factories/event_factory.rb
+++ b/app/models/factories/event_factory.rb
@@ -12,7 +12,7 @@ module Factories
     def create(endpoint, payload, user_email)
       type = event_type_repository.find_by_endpoint(endpoint)
       details = decorate_with_email(payload, type, user_email)
-      type.event_class.create(details: details)
+      type.event_class.create!(details: details)
     end
 
     private

--- a/app/models/forms/edit_git_repository_location_form.rb
+++ b/app/models/forms/edit_git_repository_location_form.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'mail'
+
+module Forms
+  class EditGitRepositoryLocationForm
+    include ActiveModel::Model
+
+    def initialize(repo:, current_user:, params: {})
+      @repo = repo
+      @params = params
+      @current_user = current_user
+
+      super(params)
+
+      @repo_owners ||= ''
+    end
+
+    attr_accessor :repo_owners
+    attr_reader :repo, :params, :current_user
+
+    validates :repo_owners, with: :validate_repo_owners, allow_blank: true
+
+    alias git_repository_location repo
+
+    def call
+      return false unless valid?
+
+      event = Events::RepoOwnershipEvent.create!(
+        details: {
+          app_name: repo.name,
+          repo_owners: owners_address_list.format(keep_brackets: true),
+          email: current_user.email,
+        },
+      )
+
+      repo_ownership_repository.apply(event)
+    end
+
+    def repo_owners_data
+      if valid?
+        RepoOwner.to_mail_address_list(repo_ownership_repository.owners_of(repo)).format.gsub(', ', "\n")
+      else
+        params[:repo_owners]
+      end
+    end
+
+    private
+
+    def repo_ownership_repository
+      @repo_ownership_repository ||= Repositories::RepoOwnershipRepository.new
+    end
+
+    def owners_address_list
+      @owners_address_list ||= parse_repo_owners
+    end
+
+    def parse_repo_owners
+      address_list = repo_owners.split(/\n|,/).map(&:strip).select(&:present?).join(', ')
+
+      MailAddressList.new(address_list)
+    end
+
+    def validate_repo_owners
+      return if owners_address_list.valid?
+
+      errors.add(:repo_owners, 'is invalid')
+    end
+  end
+end

--- a/app/models/git_repository_location.rb
+++ b/app/models/git_repository_location.rb
@@ -4,7 +4,7 @@ require 'git_clone_url'
 class GitRepositoryLocation < ActiveRecord::Base
   before_validation on: :create do
     self.uri = uri&.strip
-    self.name = extract_name(uri)
+    self.name ||= extract_name(uri)
   end
 
   validates :uri, presence: true
@@ -49,7 +49,15 @@ class GitRepositoryLocation < ActiveRecord::Base
     end
   end
 
+  def owners
+    repo_ownership_repository.owners_of(self)
+  end
+
   private
+
+  def repo_ownership_repository
+    Repositories::RepoOwnershipRepository.new
+  end
 
   def self.url_from_uri(uri)
     parsed_uri = GitCloneUrl.parse(uri)

--- a/app/models/mail_address_list.rb
+++ b/app/models/mail_address_list.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'mail'
+
+class MailAddressList
+  extend Forwardable
+
+  def_delegator :address_list, :addresses
+  def_delegator :addresses, :each
+
+  def initialize(addresses = nil)
+    @raw_addresses =
+      case addresses
+      when String
+        addresses
+      when Array
+        addresses.map { |current|
+          name = current[:name]
+          email = current.fetch(:email)
+
+          name.present? ? "#{name} <#{email}>" : email
+        }.join(', ')
+      else
+        ''
+      end
+  end
+
+  def valid?
+    address_list.addresses.all? do |email|
+      email.address =~ /\A#{EmailValidator::EMAIL_REGEX}\z/i
+    end
+  rescue => _
+    false
+  end
+
+  def format(keep_brackets: false)
+    address_list.addresses.map { |email|
+      result = email.format
+
+      if keep_brackets && email.raw == "<#{result}>"
+        email.raw
+      else
+        result
+      end
+    }.join(', ')
+  end
+
+  def include?(email_address)
+    addresses.map(&:address).include?(email_address)
+  end
+
+  private
+
+  attr_reader :raw_addresses
+
+  def address_list
+    @address_list ||= Mail::AddressList.new(raw_addresses)
+  end
+end

--- a/app/models/repo_owner.rb
+++ b/app/models/repo_owner.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class RepoOwner < ActiveRecord::Base
+  class << self
+    def to_mail_address_list(owners)
+      MailAddressList.new(owners.map { |owner| { name: owner.name, email: owner.email } })
+    end
+  end
+
+  validates :email, presence: true, uniqueness: true, email: true
+
+  def owner_of?(repo)
+    Repositories::RepoOwnershipRepository.new.owners_of(repo).include?(self)
+  end
+end

--- a/app/models/repositories/repo_ownership_repository.rb
+++ b/app/models/repositories/repo_ownership_repository.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module Repositories
+  class RepoOwnershipRepository
+    def initialize(store = Snapshots::RepoOwnership)
+      @store = store
+    end
+
+    attr_reader :store
+    delegate :table_name, to: :store
+
+    # Events::RepoOwnershipEvent
+    def apply(event)
+      return unless event.is_a?(Events::RepoOwnershipEvent)
+
+      repo_ownership = store.for(GitRepositoryLocation.new(name: event.app_name))
+      repo_ownership.repo_owners = event.repo_owners
+      repo_ownership.save!
+
+      repo_ownership.owner_emails.each do |email|
+        owner = RepoOwner.find_or_initialize_by(email: email.address)
+        owner.name = email.display_name if email.raw.include?('<')
+        owner.save!
+        owner
+      end
+    end
+
+    def owners_of(repo)
+      store.for(repo).owner_emails.addresses.map do |email|
+        RepoOwner.find_by!(email: email.address)
+      end
+    end
+  end
+end

--- a/app/models/snapshots/repo_ownership.rb
+++ b/app/models/snapshots/repo_ownership.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'active_record'
+
+module Snapshots
+  class RepoOwnership < ActiveRecord::Base
+    class << self
+      def for(repo)
+        find_or_initialize_by(app_name: repo.name)
+      end
+    end
+
+    def owner_emails
+      MailAddressList.new(repo_owners)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,12 @@ class User
   def logged_in?
     email.present?
   end
+
+  def owner_of?(repository)
+    logged_in? && as_repo_owner.owner_of?(repository)
+  end
+
+  def as_repo_owner
+    @repo_owner ||= RepoOwner.find_by(email: email) || RepoOwner.new(email: email, name: first_name)
+  end
 end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class EmailValidator < ActiveModel::EachValidator
+  EMAIL_REGEX = /([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})/i
+
+  def validate_each(record, attribute, value)
+    return if value =~ /\A#{EMAIL_REGEX}\z/i
+
+    record.errors[attribute] << (options[:message] || 'is not an email')
+  end
+end

--- a/app/views/git_repository_locations/edit.html.haml
+++ b/app/views/git_repository_locations/edit.html.haml
@@ -1,0 +1,15 @@
+- title @repository_name
+
+= form_for(@form, url: git_repository_location_path(@form.git_repository_location), method: :patch) do |f|
+  = form_errors(@form)
+
+  .form-group
+    %strong Git URI
+    %span.form-control.cursor-none{disabled: true}= @repository_uri
+
+  .form-group
+    = f.label(:repo_owners, class: 'control-label')
+    = f.text_area(:repo_owners, placeholder: "John Doe <repo-owner@example.com>\nsecond-repo-owner@example.com, third-repo-owner@example.com", value: @form.repo_owners_data, class: 'form-control', rows: 5)
+
+  .form-group
+    = f.submit('Update Git Repository', class: 'btn btn-primary')

--- a/app/views/git_repository_locations/index.html.haml
+++ b/app/views/git_repository_locations/index.html.haml
@@ -23,5 +23,5 @@
     %tr
       %td= git_repository_location.name
       %td= git_repository_location.uri
-      %td= RepoOwner.to_mail_address_list(git_repository_location.owners).format
+      %td= format_owner_emails(git_repository_location.owners)
       %td= link_to 'edit', edit_git_repository_location_path(git_repository_location)

--- a/app/views/git_repository_locations/index.html.haml
+++ b/app/views/git_repository_locations/index.html.haml
@@ -1,6 +1,6 @@
 - title 'Repositories'
 
-= form_for('repository_locations_form', url: git_repository_locations_path, class: 'form-horizontal') do |form|
+= form_for('repository_locations_form', url: git_repository_locations_path, html: { class: 'form-horizontal' }) do |form|
   .form-group.row
     = form.label(:uri, 'Git URI', class: 'col-md-1 control-label')
     .col-md-4
@@ -18,8 +18,10 @@
     .col-md-offset-1.col-md-4
       = form.submit('Add Git Repository', class: 'btn btn-primary')
 
-- table headers: ['Name', 'URI'], classes: 'git_repository_locations' do
+- table headers: ['Name', 'URI', t('.repo_owners')], classes: 'git_repository_locations' do
   - @git_repository_locations.each do |git_repository_location|
     %tr
       %td= git_repository_location.name
       %td= git_repository_location.uri
+      %td= RepoOwner.to_mail_address_list(git_repository_location.owners).format
+      %td= link_to 'edit', edit_git_repository_location_path(git_repository_location)

--- a/config/initializers/event_types.rb
+++ b/config/initializers/event_types.rb
@@ -28,4 +28,8 @@ Rails.application.config.event_types = [
     name: 'Manual test',
     endpoint: 'manual_test',
     event_class: Events::ManualTestEvent, internal: true),
+  EventType.new(
+    name: 'Repo Ownership',
+    endpoint: 'repo_ownership',
+    event_class: Events::RepoOwnershipEvent, internal: true),
 ]

--- a/config/initializers/repositories.rb
+++ b/config/initializers/repositories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 Rails.configuration.repositories = [
+  Repositories::RepoOwnershipRepository.new,
   Repositories::DeployRepository.new,
   Repositories::BuildRepository.new,
   Repositories::ManualTestRepository.new,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,14 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activemodel:
+    attributes:
+      'forms/edit_git_repository_location_form':
+        repo_owners: 'Repo Owners'
+  activerecord:
+    models:
+      repo_owner: 'Repo Owner'
+    attributes:
+      git_repository_location:
+        repo_owner: 'Repo Owner'
+  git_repository_locations:
+    index:
+      repo_owners: 'Repo Owners'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   resources :releases, only: [:index, :show]
 
-  resources :repositories, only: [:index, :create],
+  resources :repositories, only: [:index, :create, :edit, :update],
                            controller: 'git_repository_locations', as: 'git_repository_locations'
 
   resources :tokens, only: [:index, :create, :update, :destroy]

--- a/db/migrate/20161216125029_create_repo_owners_and_repo_ownerships.rb
+++ b/db/migrate/20161216125029_create_repo_owners_and_repo_ownerships.rb
@@ -1,0 +1,19 @@
+class CreateRepoOwnersAndRepoOwnerships < ActiveRecord::Migration
+  def change
+    create_table :repo_owners do |t|
+      t.string :name
+      t.string :email, null: false
+      t.timestamps null: false
+    end
+
+    add_index :repo_owners, :email, unique: true
+
+    create_table :repo_ownerships do |t|
+      t.string :app_name, null: false
+      t.string :repo_owners
+      t.timestamps null: false
+    end
+
+    add_index :repo_ownerships, :app_name, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,12 +2,16 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.5.5
+-- Dumped by pg_dump version 9.5.5
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -75,7 +79,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: builds; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: builds; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE builds (
@@ -107,7 +111,7 @@ ALTER SEQUENCE builds_id_seq OWNED BY builds.id;
 
 
 --
--- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE delayed_jobs (
@@ -146,7 +150,7 @@ ALTER SEQUENCE delayed_jobs_id_seq OWNED BY delayed_jobs.id;
 
 
 --
--- Name: deploys; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: deploys; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE deploys (
@@ -181,7 +185,7 @@ ALTER SEQUENCE deploys_id_seq OWNED BY deploys.id;
 
 
 --
--- Name: event_counts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: event_counts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE event_counts (
@@ -211,7 +215,7 @@ ALTER SEQUENCE event_counts_id_seq OWNED BY event_counts.id;
 
 
 --
--- Name: events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: events; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE events (
@@ -243,7 +247,7 @@ ALTER SEQUENCE events_id_seq OWNED BY events.id;
 
 
 --
--- Name: git_repository_locations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: git_repository_locations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE git_repository_locations (
@@ -276,7 +280,7 @@ ALTER SEQUENCE git_repository_locations_id_seq OWNED BY git_repository_locations
 
 
 --
--- Name: manual_tests; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: manual_tests; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE manual_tests (
@@ -309,7 +313,7 @@ ALTER SEQUENCE manual_tests_id_seq OWNED BY manual_tests.id;
 
 
 --
--- Name: released_tickets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: released_tickets; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE released_tickets (
@@ -345,7 +349,71 @@ ALTER SEQUENCE released_tickets_id_seq OWNED BY released_tickets.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: repo_owners; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE repo_owners (
+    id integer NOT NULL,
+    name character varying,
+    email character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: repo_owners_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE repo_owners_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: repo_owners_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE repo_owners_id_seq OWNED BY repo_owners.id;
+
+
+--
+-- Name: repo_ownerships; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE repo_ownerships (
+    id integer NOT NULL,
+    app_name character varying NOT NULL,
+    repo_owners character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: repo_ownerships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE repo_ownerships_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: repo_ownerships_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE repo_ownerships_id_seq OWNED BY repo_ownerships.id;
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE schema_migrations (
@@ -354,7 +422,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: tickets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tickets; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE tickets (
@@ -390,7 +458,7 @@ ALTER SEQUENCE tickets_id_seq OWNED BY tickets.id;
 
 
 --
--- Name: tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tokens; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE tokens (
@@ -423,7 +491,7 @@ ALTER SEQUENCE tokens_id_seq OWNED BY tokens.id;
 
 
 --
--- Name: uatests; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: uatests; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE uatests (
@@ -515,6 +583,20 @@ ALTER TABLE ONLY released_tickets ALTER COLUMN id SET DEFAULT nextval('released_
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY repo_owners ALTER COLUMN id SET DEFAULT nextval('repo_owners_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY repo_ownerships ALTER COLUMN id SET DEFAULT nextval('repo_ownerships_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY tickets ALTER COLUMN id SET DEFAULT nextval('tickets_id_seq'::regclass);
 
 
@@ -533,7 +615,7 @@ ALTER TABLE ONLY uatests ALTER COLUMN id SET DEFAULT nextval('uatests_id_seq'::r
 
 
 --
--- Name: builds_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: builds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY builds
@@ -541,7 +623,7 @@ ALTER TABLE ONLY builds
 
 
 --
--- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY delayed_jobs
@@ -549,7 +631,7 @@ ALTER TABLE ONLY delayed_jobs
 
 
 --
--- Name: deploys_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: deploys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY deploys
@@ -557,7 +639,7 @@ ALTER TABLE ONLY deploys
 
 
 --
--- Name: event_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: event_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY event_counts
@@ -565,7 +647,7 @@ ALTER TABLE ONLY event_counts
 
 
 --
--- Name: events_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY events
@@ -573,7 +655,7 @@ ALTER TABLE ONLY events
 
 
 --
--- Name: git_repository_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: git_repository_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY git_repository_locations
@@ -581,7 +663,7 @@ ALTER TABLE ONLY git_repository_locations
 
 
 --
--- Name: manual_tests_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: manual_tests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY manual_tests
@@ -589,7 +671,7 @@ ALTER TABLE ONLY manual_tests
 
 
 --
--- Name: released_tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: released_tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY released_tickets
@@ -597,7 +679,23 @@ ALTER TABLE ONLY released_tickets
 
 
 --
--- Name: tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: repo_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY repo_owners
+    ADD CONSTRAINT repo_owners_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: repo_ownerships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY repo_ownerships
+    ADD CONSTRAINT repo_ownerships_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tickets
@@ -605,7 +703,7 @@ ALTER TABLE ONLY tickets
 
 
 --
--- Name: tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tokens
@@ -613,7 +711,7 @@ ALTER TABLE ONLY tokens
 
 
 --
--- Name: uatests_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: uatests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY uatests
@@ -621,112 +719,126 @@ ALTER TABLE ONLY uatests
 
 
 --
--- Name: delayed_jobs_priority; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs_priority; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX delayed_jobs_priority ON delayed_jobs USING btree (priority, run_at);
 
 
 --
--- Name: index_builds_on_version; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_builds_on_version; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_builds_on_version ON builds USING btree (version);
 
 
 --
--- Name: index_deploys_on_app_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_deploys_on_app_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_deploys_on_app_name ON deploys USING btree (app_name);
 
 
 --
--- Name: index_deploys_on_server_and_app_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_deploys_on_server_and_app_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_deploys_on_server_and_app_name ON deploys USING btree (server, app_name);
 
 
 --
--- Name: index_deploys_on_version; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_deploys_on_version; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_deploys_on_version ON deploys USING btree (version);
 
 
 --
--- Name: index_git_repository_locations_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_git_repository_locations_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_git_repository_locations_on_name ON git_repository_locations USING btree (name);
 
 
 --
--- Name: index_manual_tests_on_versions; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_manual_tests_on_versions; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_manual_tests_on_versions ON manual_tests USING gin (versions);
 
 
 --
--- Name: index_released_tickets_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_released_tickets_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_released_tickets_on_key ON released_tickets USING btree (key);
 
 
 --
--- Name: index_released_tickets_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_released_tickets_on_tsv; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_released_tickets_on_tsv ON released_tickets USING gin (tsv);
 
 
 --
--- Name: index_released_tickets_on_versions; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_released_tickets_on_versions; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_released_tickets_on_versions ON released_tickets USING gin (versions);
 
 
 --
--- Name: index_tickets_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_repo_owners_on_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_repo_owners_on_email ON repo_owners USING btree (email);
+
+
+--
+-- Name: index_repo_ownerships_on_app_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_repo_ownerships_on_app_name ON repo_ownerships USING btree (app_name);
+
+
+--
+-- Name: index_tickets_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tickets_on_key ON tickets USING btree (key);
 
 
 --
--- Name: index_tickets_on_paths; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tickets_on_paths; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tickets_on_paths ON tickets USING gin (paths);
 
 
 --
--- Name: index_tickets_on_versions; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tickets_on_versions; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tickets_on_versions ON tickets USING gin (versions);
 
 
 --
--- Name: index_tokens_on_value; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tokens_on_value; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_tokens_on_value ON tokens USING btree (value);
 
 
 --
--- Name: index_uatests_on_versions; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_uatests_on_versions; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_uatests_on_versions ON uatests USING gin (versions);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
@@ -743,7 +855,7 @@ CREATE TRIGGER released_tickets_tsv_update BEFORE INSERT OR UPDATE ON released_t
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user",public;
+SET search_path TO "$user", public;
 
 INSERT INTO schema_migrations (version) VALUES ('20150427164403');
 
@@ -787,6 +899,10 @@ INSERT INTO schema_migrations (version) VALUES ('20150823124740');
 
 INSERT INTO schema_migrations (version) VALUES ('20150823124742');
 
+INSERT INTO schema_migrations (version) VALUES ('20150908100119');
+
+INSERT INTO schema_migrations (version) VALUES ('20150910115332');
+
 INSERT INTO schema_migrations (version) VALUES ('20150910135208');
 
 INSERT INTO schema_migrations (version) VALUES ('20150915150206');
@@ -798,6 +914,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150915161859');
 INSERT INTO schema_migrations (version) VALUES ('20150921110831');
 
 INSERT INTO schema_migrations (version) VALUES ('20150921115023');
+
+INSERT INTO schema_migrations (version) VALUES ('20150921115024');
 
 INSERT INTO schema_migrations (version) VALUES ('20150928130626');
 
@@ -820,3 +938,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160318164129');
 INSERT INTO schema_migrations (version) VALUES ('20160324142505');
 
 INSERT INTO schema_migrations (version) VALUES ('20160825111503');
+
+INSERT INTO schema_migrations (version) VALUES ('20161216125029');
+

--- a/features/repository_locations.feature
+++ b/features/repository_locations.feature
@@ -10,9 +10,9 @@ Scenario: Add repositories
   When I enter a valid uri "ssh://github.com/new_app"
   When I enter a valid uri "ssh://github.com/new_app_2.git"
   Then I should see the repository locations:
-    | Name      | URI                            |
-    | new_app   | ssh://github.com/new_app       |
-    | new_app_2 | ssh://github.com/new_app_2.git |
+    | Name      | URI                            | Repo Owners |
+    | new_app   | ssh://github.com/new_app       |             |
+    | new_app_2 | ssh://github.com/new_app_2.git |             |
 
 @disable_repo_verification
 Scenario: Add repository with auto-generated tokens
@@ -23,3 +23,24 @@ Scenario: Add repository with auto-generated tokens
     | Source               | Name     | Endpoint        |
     | CircleCI (webhook)   | app_name | circleci        |
     | Deployment           | app_name | deploy          |
+
+@disable_repo_verification
+Scenario: Add owners of a repository
+  Given "new-app" repository
+  And I am on the edit repository location form for "new-app"
+  When I enter owner emails "repo-owner@example.com, second-repo-owner@example.com"
+  And I click "Update Git Repository"
+  Then I should see the repository locations:
+    | Name      | URI                | Repo Owners                                           |
+    | new-app   | uri_for("new-app") | repo-owner@example.com, second-repo-owner@example.com |
+
+@disable_repo_verification
+Scenario: Edit owners of a repository
+  Given "new-app" repository
+  And owner of "new-app" is "test@example.com"
+  And I am on the edit repository location form for "new-app"
+  When I enter owner emails "repo-owner@example.com, second-repo-owner@example.com"
+  And I click "Update Git Repository"
+  Then I should see the repository locations:
+    | Name      | URI                | Repo Owners                                           |
+    | new-app   | uri_for("new-app") | repo-owner@example.com, second-repo-owner@example.com |

--- a/features/step_definitions/repository_locations_steps.rb
+++ b/features/step_definitions/repository_locations_steps.rb
@@ -8,10 +8,40 @@ When 'I enter a valid uri "$uri"' do |uri|
 end
 
 Then 'I should see the repository locations:' do |table|
-  expected_git_repository_locations = table.hashes
+  expected_git_repository_locations = table.hashes.map { |row|
+    expand_uri = row['URI'].strip.match(/uri_for\("(.*)"\)/)
+
+    if expand_uri
+      row['URI'] = scenario_context.repository_location_for(expand_uri[1]).uri
+    end
+
+    row
+  }
   expect(git_repository_location_page.git_repository_locations).to eq(expected_git_repository_locations)
 end
 
 When 'I visit the tokens page' do
   tokens_page.visit
+end
+
+Given '"$application" repository' do |application|
+  scenario_context.setup_application(application)
+end
+
+Given 'I am on the edit repository location form for "$application"' do |application|
+  repo = scenario_context.repository_location_for(application)
+  edit_git_repository_location_page.visit(repo)
+end
+
+Given 'owner of "$application" is "$owner"' do |application, owner|
+  repo = scenario_context.repository_location_for(application)
+  scenario_context.add_owner_to(repo, owner)
+end
+
+When 'I enter owner emails "$repo_owners"' do |repo_owners|
+  edit_git_repository_location_page.fill_in_repo_owners(repo_owners: repo_owners)
+end
+
+When 'I click "$button"' do |button|
+  edit_git_repository_location_page.click(button)
 end

--- a/features/support/pages.rb
+++ b/features/support/pages.rb
@@ -7,6 +7,13 @@ module Pages
     )
   end
 
+  def edit_git_repository_location_page
+    Pages::EditGitRepositoryLocationPage.new(
+      page: page,
+      url_helpers: Rails.application.routes.url_helpers,
+    )
+  end
+
   def prepare_feature_review_page
     Pages::PrepareFeatureReviewPage.new(
       page: page,

--- a/features/support/pages/repository_location_page.rb
+++ b/features/support/pages/repository_location_page.rb
@@ -24,4 +24,27 @@ module Pages
 
     attr_reader :page, :url_helpers
   end
+
+  class EditGitRepositoryLocationPage
+    def initialize(page:, url_helpers:)
+      @page        = page
+      @url_helpers = url_helpers
+    end
+
+    def visit(application)
+      page.visit url_helpers.edit_git_repository_location_path(application)
+    end
+
+    def fill_in_repo_owners(repo_owners:)
+      page.fill_in 'Repo Owners', with: repo_owners
+    end
+
+    def click(button)
+      page.click_link_or_button(button)
+    end
+
+    private
+
+    attr_reader :page, :url_helpers
+  end
 end

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -24,6 +24,7 @@ module Support
       @reviews = {}
       @review_urls = {}
       @stubbed_requests = {}
+      @repository_locations = {}
     end
 
     def setup_application(name)
@@ -36,11 +37,25 @@ module Support
       @application = name
       @repos[name] = test_repo
 
-      GitRepositoryLocation.create(uri: test_repo.uri, name: name)
+      @repository_locations[name] = GitRepositoryLocation.create(uri: test_repo.uri, name: name)
+    end
+
+    def add_owner_to(repository_location, owners)
+      result = Forms::EditGitRepositoryLocationForm.new(
+        repo: repository_location,
+        current_user: User.new(email: 'current-user@example.com'),
+        params: { repo_owners: owners },
+      ).call
+
+      fail "Could not add owners #{owners} to #{repository_location.name}" unless result
     end
 
     def repository_for(application)
       @repos[application]
+    end
+
+    def repository_location_for(application)
+      @repository_locations[application]
     end
 
     def resolve_version(version)

--- a/spec/controllers/git_repository_locations_controller_spec.rb
+++ b/spec/controllers/git_repository_locations_controller_spec.rb
@@ -43,4 +43,60 @@ RSpec.describe GitRepositoryLocationsController do
       it { is_expected.to redirect_to(git_repository_locations_path) }
     end
   end
+
+  describe 'GET #edit', :logged_in do
+    it 'can be rendered' do
+      repo = FactoryGirl.create(:git_repository_location)
+
+      get :edit, id: repo
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'PATCH #update', :logged_in do
+    context 'with correct parameters' do
+      let(:repo) { FactoryGirl.create(:git_repository_location) }
+      let(:params) {
+        {
+          id: repo,
+          forms_edit_git_repository_location_form: { repo_owners: 'test@example.com' },
+        }
+      }
+
+      it 'sets the owner of the repo' do
+        patch :update, params
+
+        expect(repo.owners.first.email).to eq('test@example.com')
+      end
+
+      it 'redirects to edit and sets successful flash' do
+        patch :update, params
+
+        expect(response).to redirect_to(action: :index)
+        expect(flash[:success]).to be_present
+      end
+    end
+
+    context 'with incorrect parameters' do
+      let(:repo) { FactoryGirl.create(:git_repository_location) }
+      let(:params) {
+        {
+          id: repo,
+          forms_edit_git_repository_location_form: { repo_owners: 'testexample.com' },
+        }
+      }
+
+      it 'does not change the owner of the repo' do
+        expect { patch :update, params }.not_to change { repo.reload }
+      end
+
+      it 'renders edit and does not set successful flash' do
+        patch :update, params
+
+        expect(response).to render_template(:edit)
+        expect(flash[:success]).not_to be_present
+      end
+    end
+  end
 end

--- a/spec/factories/git_repository_location.rb
+++ b/spec/factories/git_repository_location.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :git_repository_location do
+    name { |n| "Black Pearl #{n}" }
+    uri { |n| "https://github.com/FundingCircle/shipment_tracker-#{n}.git" }
+  end
+end

--- a/spec/factories/repo_owner.rb
+++ b/spec/factories/repo_owner.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :repo_owner do
+    name 'Foo'
+    email { |n| "foo#{n}@bar.baz" }
+  end
+end

--- a/spec/factories/repo_ownership_event.rb
+++ b/spec/factories/repo_ownership_event.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'events/repo_ownership_event'
+
+FactoryGirl.define do
+  factory :repo_ownership_event, class: Events::RepoOwnershipEvent do
+    transient do
+      app_name 'test-app'
+      repo_owners ''
+    end
+
+    details {
+      {
+        'app_name' => app_name,
+        'repo_owners' => repo_owners,
+      }
+    }
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/factories/repo_ownership_snapshot.rb
+++ b/spec/factories/repo_ownership_snapshot.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+require 'snapshots/repo_ownership'
+
+FactoryGirl.define do
+  factory :repo_ownership_snapshot, class: Snapshots::RepoOwnership do
+    app_name 'test-app'
+    repo_owners ''
+  end
+end

--- a/spec/helpers/repo_owners_helper_spec.rb
+++ b/spec/helpers/repo_owners_helper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe RepoOwnersHelper do
+  describe '#format_owner_emails' do
+    it 'works with 1 repo owner' do
+      repo_owner = RepoOwner.new name: 'John', email: 'test@test.com'
+
+      expect(helper.format_owner_emails(repo_owner))
+        .to eq('<span class="text-nowrap">John &lt;test@test.com&gt;</span>')
+    end
+
+    it 'works with array of owners' do
+      repo_owner = RepoOwner.new name: 'John', email: 'test@test.com'
+      repo_owner2 = RepoOwner.new email: 'test2@test.com'
+
+      expect(helper.format_owner_emails([repo_owner, repo_owner2])).to eq(
+        [
+          '<span class="text-nowrap">John &lt;test@test.com&gt;</span>',
+          '<span class="text-nowrap">test2@test.com</span>',
+        ].join(', '),
+      )
+    end
+
+    it 'returns an empty string when nothing is provided' do
+      expect(helper.format_owner_emails).to eq('')
+      expect(helper.format_owner_emails([])).to eq('')
+    end
+  end
+end

--- a/spec/models/events/repo_ownership_event_spec.rb
+++ b/spec/models/events/repo_ownership_event_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Events::RepoOwnershipEvent do
+  describe 'init' do
+    it 'works' do
+      event = described_class.new(
+        details: {
+          'app_name' => 'Some_App',
+          'repo_owners' => 'Test <test@example.com>, test2@example.com',
+        },
+      )
+
+      expect(event.app_name).to eq('Some_App')
+      expect(event.repo_owners).to eq('Test <test@example.com>, test2@example.com')
+    end
+  end
+end

--- a/spec/models/forms/edit_git_repository_location_form_spec.rb
+++ b/spec/models/forms/edit_git_repository_location_form_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Forms::EditGitRepositoryLocationForm do
+  def form_for(form_data = {}, options = {})
+    repo = options.fetch(:repo, FactoryGirl.create(:git_repository_location))
+    current_user = options.fetch('current_user', double('User', email: 'test@test.com'))
+
+    described_class.new(repo: repo, params: form_data, current_user: current_user)
+  end
+
+  describe 'validation' do
+    describe 'for repo_owners' do
+      it 'could be blank' do
+        expect(form_for(repo_owners: '')).to be_valid
+        expect(form_for(repo_owners: nil)).to be_valid
+      end
+
+      describe 'a signle repo owner' do
+        it 'expects an email or a name with email' do
+          expect(form_for(repo_owners: 'test@example.com')).to be_valid
+          expect(form_for(repo_owners: 'Test Example<test@example.com>')).to be_valid
+        end
+
+        it 'will fail if the provided value is neither an email nor a name with email' do
+          ['test', 'test test@example.com'].each do |example|
+            form = form_for(repo_owners: example)
+
+            expect(form).not_to be_valid
+            expect(form.errors[:repo_owners]).to be_present
+          end
+        end
+      end
+
+      it 'works with a list of repo owners separated by a new line or comma' do
+        [
+          "test@example.com\nTest Example <test@example.com>",
+          "\n\nTest <test@example.com>  \n\n\nTest Example <test2@example.com>  \n\n\n",
+          "Test <test@example.com>, Test Example <test2@example.com>\nTest Example <test3@example.com>",
+        ].each do |data|
+          expect(form_for(repo_owners: data)).to be_valid
+        end
+      end
+    end
+  end
+
+  describe '#call' do
+    it 'will generate a repo ownership event' do
+      repo = FactoryGirl.create(:git_repository_location, name: 'my-app')
+      current_user = double('User', email: 'test@test.com')
+      input_data = "test@example.com, test3@example.com \n\n\nTest Example <test2@example.com>  \n\n\n"
+
+      form = form_for({ repo_owners: input_data }, repo: repo, current_user: current_user)
+
+      expect(Events::RepoOwnershipEvent).to(
+        receive(:create!).with(
+          details: {
+            app_name: 'my-app',
+            repo_owners: 'test@example.com, test3@example.com, Test Example <test2@example.com>',
+            email: 'test@test.com',
+          },
+        ),
+      )
+
+      form.call
+    end
+  end
+end

--- a/spec/models/git_repository_location_spec.rb
+++ b/spec/models/git_repository_location_spec.rb
@@ -147,4 +147,20 @@ RSpec.describe GitRepositoryLocation, :disable_repo_verification do
       expect(repository_loction.full_repo_name).to eq('owner/repo')
     end
   end
+
+  describe '#owners' do
+    it 'is empty array if there are no repo owners' do
+      expect(described_class.new(name: 'test-repo').owners).to eq([])
+    end
+
+    it 'returns an array the current repo owners' do
+      repo = described_class.new(name: 'test-repo')
+      repo_owners = [RepoOwner.new]
+
+      expect_any_instance_of(Repositories::RepoOwnershipRepository)
+        .to receive(:owners_of).with(repo).and_return(repo_owners)
+
+      expect(repo.owners).to eq(repo_owners)
+    end
+  end
 end

--- a/spec/models/mail_address_list_spec.rb
+++ b/spec/models/mail_address_list_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MailAddressList do
+  describe '.new' do
+    it 'is an empty address list by default' do
+      expect(described_class.new.addresses).to be_empty
+    end
+
+    it 'is an empty address list when nil is provided' do
+      expect(described_class.new(nil).addresses).to be_empty
+    end
+
+    it 'can be created with a string' do
+      expect(described_class.new('test@test.com, test2@test.com').format)
+        .to eq('test@test.com, test2@test.com')
+    end
+
+    it 'can be created by and array of hashes' do
+      expect(
+        described_class.new([
+          { name: 'Test', email: 'test@test.com' },
+          { email: 'test2@test.com' },
+        ]).format,
+      ).to eq('Test <test@test.com>, test2@test.com')
+    end
+  end
+
+  describe '#valid?' do
+    it 'is true when it can parse the list of emails' do
+      expect(described_class.new('')).to be_valid
+      expect(described_class.new('test@test.com')).to be_valid
+      expect(described_class.new('test@test.com, test2@test.com')).to be_valid
+      expect(described_class.new('<test@test.com>')).to be_valid
+      expect(described_class.new('Test <test@test.com>')).to be_valid
+      expect(
+        described_class.new(
+          [
+            'Test <test@test.com>',
+            'test2@test.com',
+          ].join(', '),
+        ),
+      ).to be_valid
+    end
+
+    it 'is false when there is an the emails are invalid' do
+      expect(described_class.new('test.com')).not_to be_valid
+      expect(described_class.new('test@test@test.com')).not_to be_valid
+      expect(described_class.new('test@test')).not_to be_valid
+      expect(described_class.new('test@test, test@test.com')).not_to be_valid
+    end
+  end
+
+  describe '#format' do
+    it 'empty address list is formatted as an empty string' do
+      expect(described_class.new('').format).to eq('')
+    end
+
+    it 'formats the emails and stripts all unneeded spaces' do
+      expect(
+        described_class.new(
+          [
+            '      Test<test@test.com>    ',
+            'Test2        <test2@test.com>',
+            '  test2@test.com    ',
+            '<test2@test.com>',
+          ].join(', '),
+        ).format,
+      ).to eq(
+        [
+          'Test <test@test.com>',
+          'Test2 <test2@test.com>',
+          'test2@test.com',
+          'test2@test.com',
+        ].join(', '),
+      )
+    end
+
+    context 'with keep_brackets true' do
+      it 'will keep the brackets around emails without display_name' do
+        expect(
+          described_class.new(
+            [
+              '      Test<test@test.com>    ',
+              'Test2        <test2@test.com>',
+              '  test2@test.com    ',
+              '<test2@test.com>',
+            ].join(', '),
+          ).format(keep_brackets: true),
+        ).to eq(
+          [
+            'Test <test@test.com>',
+            'Test2 <test2@test.com>',
+            'test2@test.com',
+            '<test2@test.com>',
+          ].join(', '),
+        )
+      end
+    end
+  end
+
+  describe '#addresses' do
+    it 'returns an array of Mail::Address' do
+      addresses = described_class.new('<test@test.com>').addresses
+
+      expect(addresses.size).to eq(1)
+      expect(addresses.first).to be_a(Mail::Address)
+    end
+
+    it 'is empty array when there are no addresses' do
+      expect(described_class.new('').addresses).to eq([])
+    end
+  end
+
+  describe '#each' do
+    it 'iterates over the addresses' do
+      address_list = described_class.new('test@test.com, test2@test.com')
+
+      iterated_emails = []
+
+      address_list.each { |email| iterated_emails << email }
+
+      expect(iterated_emails).to eq(address_list.addresses)
+    end
+  end
+
+  describe '#include?' do
+    it 'is true when the email is in the address list' do
+      expect(described_class.new('test@test.com')).to include('test@test.com')
+      expect(described_class.new('test@test.com, test2@test.com')).to include('test2@test.com')
+      expect(described_class.new('<test@test.com>')).to include('test@test.com')
+      expect(described_class.new('Test <test@test.com>')).to include('test@test.com')
+    end
+  end
+end

--- a/spec/models/repo_owner_spec.rb
+++ b/spec/models/repo_owner_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe RepoOwner do
+  describe '.to_mail_address_list' do
+    it 'will return a MailAddressList with the emails of the repo owners' do
+      mail_list = RepoOwner.to_mail_address_list([
+        FactoryGirl.build(:repo_owner, name: 'John', email: 'john@test.com'),
+        FactoryGirl.build(:repo_owner, name: nil, email: 'ivan@test.com'),
+      ])
+
+      expect(mail_list).to be_kind_of(MailAddressList)
+      expect(mail_list.format).to eq('John <john@test.com>, ivan@test.com')
+    end
+  end
+
+  describe 'validations' do
+    it 'is invalid when there is already a project owner with that email' do
+      FactoryGirl.create(:repo_owner, email: 'test@duplication.com')
+      repo_owner = FactoryGirl.build(:repo_owner, email: 'test@duplication.com')
+
+      repo_owner.valid?
+
+      expect(repo_owner.errors[:email]).to be_present
+    end
+
+    it 'is invalid if there is no email' do
+      repo_owner = FactoryGirl.build(:repo_owner, email: nil)
+
+      repo_owner.valid?
+
+      expect(repo_owner.errors[:email]).to be_present
+    end
+
+    it 'is invalid if the email is bad' do
+      repo_owner = FactoryGirl.build(:repo_owner, email: 'ninja')
+
+      repo_owner.valid?
+
+      expect(repo_owner.errors[:email]).to be_present
+    end
+  end
+
+  describe '#owner_of?' do
+    it 'is true when there is an active ownership between the repo and the owner' do
+      repo_owner = FactoryGirl.build(:repo_owner)
+      repo = double('Repo')
+
+      expect_any_instance_of(Repositories::RepoOwnershipRepository)
+        .to receive(:owners_of).with(repo).and_return([repo_owner])
+
+      expect(repo_owner.owner_of?(repo)).to eq(true)
+    end
+
+    it "is false when there isn't an active ownership" do
+      repo_owner = FactoryGirl.build(:repo_owner)
+      repo = double('Repo')
+
+      expect_any_instance_of(Repositories::RepoOwnershipRepository)
+        .to receive(:owners_of).with(repo).and_return([])
+
+      expect(repo_owner.owner_of?(repo)).to eq(false)
+    end
+  end
+end

--- a/spec/models/repositories/repo_ownership_repository_spec.rb
+++ b/spec/models/repositories/repo_ownership_repository_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Repositories::RepoOwnershipRepository do
+  subject(:repository) { described_class.new }
+
+  def apply_changes_to_repo_owners(*repo_owners_data)
+    repo_owners_data.each do |repo_owners|
+      repository.apply(build(:repo_ownership_event, repo_owners))
+    end
+  end
+
+  describe '#apply' do
+    it 'will store a snapshot of the repo owners for a repo' do
+      event = build(
+        :repo_ownership_event,
+        app_name: 'test',
+        repo_owners: 'Test <test@test.com>, test2@test.com',
+      )
+
+      repository.apply(event)
+
+      expect(Snapshots::RepoOwnership.last)
+        .to have_attributes(app_name: 'test', repo_owners: 'Test <test@test.com>, test2@test.com')
+    end
+
+    it 'will create a RepoOwner record each of the owner without existing one' do
+      event = build(
+        :repo_ownership_event,
+        app_name: 'test',
+        repo_owners: 'Test <test@test.com>, test2@test.com',
+      )
+
+      repository.apply(event)
+
+      repo_owners = RepoOwner.all
+
+      expect(repo_owners.size).to eq(2)
+      expect(repo_owners.first).to have_attributes(name: 'Test', email: 'test@test.com')
+      expect(repo_owners.second).to have_attributes(name: nil, email: 'test2@test.com')
+    end
+
+    it 'will update already existing repo owners' do
+      repo_owner = create(:repo_owner, name: 'Test', email: 'test@test.com')
+      repo_owner2 = create(:repo_owner, name: 'Test2', email: 'test2@test.com')
+
+      event = build(
+        :repo_ownership_event,
+        app_name: 'test',
+        repo_owners: 'Hello <test@test.com>, <test2@test.com>',
+      )
+
+      repository.apply(event)
+
+      expect(RepoOwner.count).to eq(2)
+
+      expect(repo_owner.reload).to have_attributes(name: 'Hello', email: 'test@test.com')
+      expect(repo_owner2.reload).to have_attributes(name: nil, email: 'test2@test.com')
+    end
+
+    it 'will update the already existing snapshot' do
+      event = build(
+        :repo_ownership_event,
+        app_name: 'test',
+        repo_owners: 'Test <test@test.com>, test2@test.com',
+      )
+      event2 = build(
+        :repo_ownership_event,
+        app_name: 'test',
+        repo_owners: 'test2@test.com',
+      )
+
+      repository.apply(event)
+
+      snapshot = Snapshots::RepoOwnership.last
+
+      expect { repository.apply(event2) }.to change { snapshot.reload.repo_owners }
+    end
+  end
+
+  describe '#owners_of' do
+    it 'returns the repo owners of certain repository' do
+      apply_changes_to_repo_owners(
+        { app_name: 'test', repo_owners: 'John <test@example.com>, Ivan <test2@example.com>' },
+        app_name: 'test2', repo_owners: 'John Snow <test@example.com>',
+      )
+
+      repo = create(:git_repository_location, name: 'test')
+
+      owners = repository.owners_of(repo)
+
+      expect(owners.size).to eq(2)
+      expect(owners.map { |owner| [owner.name, owner.email] })
+        .to match_array([['John Snow', 'test@example.com'], ['Ivan', 'test2@example.com']])
+    end
+
+    it 'is an empty array by default' do
+      repo = build(:git_repository_location, name: 'test')
+
+      expect(repository.owners_of(repo)).to eq([])
+    end
+  end
+end

--- a/spec/models/snapshots/repo_ownership_spec.rb
+++ b/spec/models/snapshots/repo_ownership_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Snapshots::RepoOwnership do
+  describe '.for' do
+    it 'returns the snapshot for specific git repository' do
+      repo = double('Repo', name: 'test-repo')
+      snapshot = create(:repo_ownership_snapshot, app_name: 'test-repo')
+
+      expect(described_class.for(repo)).to eq(snapshot)
+    end
+
+    context 'when there is no snapshot' do
+      it 'it returns a non-persisted one with the correct app_name' do
+        repo = double('Repo', name: 'test-repo')
+
+        snapshot = described_class.for(repo)
+
+        expect(snapshot.app_name).to eq('test-repo')
+        expect(snapshot).to_not be_persisted
+      end
+    end
+  end
+
+  describe '#owner_emails' do
+    it 'returns a mail address list from the snapshotted repo owner emails' do
+      snapshot = build(:repo_ownership_snapshot, repo_owners: 'Test <test@example.com>, foo@bar.baz')
+
+      expect(snapshot.owner_emails).to be_kind_of(MailAddressList)
+      expect(snapshot.owner_emails.format).to eq('Test <test@example.com>, foo@bar.baz')
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe User do
+  def create_user(data = {})
+    User.new(data)
+  end
+
+  describe '#logged_in?' do
+    it 'is true if the user has an email' do
+      expect(create_user(email: 'test@example.com')).to be_logged_in
+    end
+
+    it 'is not logged in if the user does not have an email' do
+      expect(create_user).not_to be_logged_in
+    end
+  end
+
+  describe '.as_repo_owner' do
+    it 'will return a repo owner that has the same email if such exists' do
+      repo_owner = FactoryGirl.create(:repo_owner, email: 'test@example.com')
+      user = create_user(first_name: 'Test', email: 'test@example.com')
+
+      expect(user.as_repo_owner).to eq(repo_owner)
+    end
+
+    it 'will return a new repo owner when there is none in the database' do
+      user = create_user(first_name: 'Test', email: 'test@example.com')
+
+      expect(user.as_repo_owner.name).to eq('Test')
+      expect(user.as_repo_owner.email).to eq('test@example.com')
+      expect(user.as_repo_owner).to_not be_persisted
+    end
+  end
+
+  describe '#owner_of?' do
+    it 'is true when the related repo owner has access to the repo' do
+      repo_owner = FactoryGirl.build(:repo_owner, email: 'test@example.com')
+      user = create_user(first_name: 'Test', email: 'test@example.com')
+
+      allow(RepoOwner).to receive(:find_by).with(email: 'test@example.com').and_return(repo_owner)
+
+      repo = instance_double(GitRepositoryLocation)
+
+      expect(repo_owner).to receive(:owner_of?).with(repo).and_return(true)
+      expect(user.owner_of?(repo)).to be true
+    end
+
+    it "is false when the related repo owner doesn't have access to the repo" do
+      repo_owner = FactoryGirl.build(:repo_owner, email: 'test@example.com')
+      user = create_user(first_name: 'Test', email: 'test@example.com')
+
+      allow(RepoOwner).to receive(:find_by).with(email: 'test@example.com').and_return(repo_owner)
+
+      repo = instance_double(GitRepositoryLocation)
+
+      expect(repo_owner).to receive(:owner_of?).with(repo).and_return(false)
+      expect(user.owner_of?(repo)).to be false
+    end
+
+    it 'is false when there is no related repo owner' do
+      user = create_user(first_name: 'Test', email: 'different@example.com')
+
+      repo = FactoryGirl.build(:git_repository_location)
+
+      expect(user.owner_of?(repo)).to be false
+    end
+  end
+end

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe EmailValidator do
+  class SampleRecord
+    include ActiveModel::Model
+
+    attr_accessor :email
+
+    validates :email, email: true
+  end
+
+  describe '.valid?' do
+    describe 'valid email adresses' do
+      [
+        'valid@dantooine.com',
+        'Valid@test.dantooine.com',
+        'valid+valid123@test.dantooine.com',
+        'vaLid_valid123@test.dantooine.com',
+        'valid-valid+123@test.dantooine.co.uk',
+        'valid-valid+1.23@test.dantooine.com.au',
+        'valid@dantooine.co.uk',
+        'v@dantooine.com',
+        'valid@dantooine.ca',
+        'valid_@dantooine.com',
+        'valid123.456@dantooine.org',
+        'valid123.456@dantooine.travel',
+        'valid123.456@dantooine.museum',
+        'valid@dantooine.mobi',
+        'valid@dantooine.info',
+        'valid-@dantooine.com',
+        'fake@p-t.k12.ok.us',
+      ].each do |email|
+        specify email do
+          expect(SampleRecord.new(email: email).valid?).to eq(true)
+        end
+      end
+    end
+
+    describe 'invalid email addresses' do
+      [
+        'no_at_symbol',
+        'invalid@dantooine-com',
+        'invalid@ex_mple.com',
+        'invalid@e..dantooine.com',
+        'invalid@p-t..dantooine.com',
+        'invalid@dantooine.com.',
+        'invalid@dantooine.com_',
+        'invalid@dantooine.com-',
+        'invalid-dantooine.com',
+        'invalid@dantooine.b#r.com',
+        'invalid@dantooine.c',
+        'invali d@dantooine.com',
+        'invalid@dantooine.123',
+        "valid@dantooine.com\n",
+        "\nvalid@dantooine.com",
+        ' valid@dantooine.com',
+        'valid@dantooine.com ',
+        "valid@dantooine.com\nvalid@dantooine.com",
+        "valid@dantooine.com\nninja",
+        "ninja\nvalid@dantooine.com",
+      ].each do |email|
+        specify email.inspect do
+          expect(SampleRecord.new(email: email).valid?).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add an option to specify "Repo Owner" to a repository.

To add an repo owner you specify either:
 * `test@foo.com` - will search for a project owner with that email or create one
 * `John Snow <test@foo.com>` - will search with the email and create / update the project owner by setting also his name

You can specify multiple repo owners like this:

```
repo-owner1@test.com, repo-owner2@test.com
repo-owner3@test.com
```

- [x] Add features specs