### PR TITLE
Track unapproved deployments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     json (1.8.3)
     jwt (1.5.2)
     kgio (2.10.0)
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -342,8 +342,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thin (1.5.1)
       daemons (>= 1.0.9)
@@ -432,5 +432,8 @@ DEPENDENCIES
   virtus
   webmock
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/app/jobs/deploy_alert_job.rb
+++ b/app/jobs/deploy_alert_job.rb
@@ -6,43 +6,83 @@ require 'clients/slack'
 class DeployAlertJob < ActiveJob::Base
   queue_as :default
 
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
   def perform(deploy_attrs)
-    current_deploy = Deploy.new(deploy_attrs[:current_deploy])
-    previous_deploy = Deploy.new(deploy_attrs[:previous_deploy]) if deploy_attrs[:previous_deploy]
+    Auditor.new(deploy_attrs).audit
+  end
 
-    message = DeployAlert.audit_message(current_deploy, previous_deploy)
+  class Auditor
+    def initialize(args = {})
+      @current_deploy = Deploy.new(args[:current_deploy])
+      @previous_deploy = Deploy.new(args[:previous_deploy]) if args[:previous_deploy]
+    end
 
-    if message
-      app_name = current_deploy['app_name']
-      releases_url = releases_link(app_name, current_deploy['region'])
+    attr_reader :current_deploy, :previous_deploy
 
-      SlackClient.send_deploy_alert(
-        message,
-        releases_url,
-        app_name,
-        current_deploy['deployed_by'],
-      )
+    def app_name
+      current_deploy['app_name']
+    end
 
+    def region
+      current_deploy['region']
+    end
+
+    def deployer
+      current_deploy['deployed_by']
+    end
+
+    def deployed_at
+      current_deploy['deployed_at']
+    end
+
+    def deploy_uuid
+      current_deploy['uuid']
+    end
+
+    def audit
+      message = DeployAlert.audit_message(current_deploy, previous_deploy)
+
+      return unless message
+
+      create_deploy_alert_event(message)
+      notify_slack(message)
+      notify_repo_owners(message)
+    end
+
+    def create_deploy_alert_event(message)
+      if deploy_uuid.present?
+        Events::DeployAlertEvent.create!(
+          details: { deploy_uuid: deploy_uuid, message: message },
+        )
+      else
+        Rails.logger.warn "No uuid for #{current_deploy.inspect}"
+      end
+    end
+
+    def notify_slack(message)
+      SlackClient.send_deploy_alert(message, releases_url, app_name, deployer)
+    end
+
+    def notify_repo_owners(message)
       repo_owners = Repositories::RepoOwnershipRepository.new.owners_of(app_name)
 
-      if repo_owners.present?
-        DeployAlertMailer.deploy_alert_email(
-          repo_owners: repo_owners,
-          repo: app_name,
-          region: current_deploy['region'],
-          deployer: current_deploy['deployed_by'],
-          deployed_at: current_deploy['deployed_at'],
-          alert: message,
-          releases_url: releases_url,
-        ).deliver_now
-      end
+      return if repo_owners.blank?
+
+      DeployAlertMailer.deploy_alert_email(
+        repo_owners: repo_owners,
+        repo: app_name,
+        region: region,
+        deployer: deployer,
+        deployed_at: deployed_at,
+        alert: message,
+        releases_url: releases_url,
+      ).deliver_now
+    end
+
+    def releases_url
+      params = { region: region }
+      "#{Rails.application.routes.url_helpers.releases_url}/#{app_name}?#{params.to_query}"
     end
   end
 
-  def releases_link(app_name, region)
-    params = { region: region }
-    "#{Rails.application.routes.url_helpers.releases_url}/#{app_name}?#{params.to_query}"
-  end
+  private_constant :Auditor
 end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -11,6 +11,7 @@ class Deploy
     attribute :region, String
     attribute :version, String
     attribute :environment, String
+    attribute :uuid, String
   end
 
   def commit

--- a/app/models/events/deploy_alert_event.rb
+++ b/app/models/events/deploy_alert_event.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'events/base_event'
+
+module Events
+  class DeployAlertEvent < Events::BaseEvent
+    def deploy_uuid
+      details['deploy_uuid']
+    end
+
+    def message
+      details['message']
+    end
+  end
+end

--- a/app/models/repositories/base.rb
+++ b/app/models/repositories/base.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Repositories
+  class Base
+    attr_reader :store
+    delegate :table_name, to: :store
+
+    def identifier
+      table_name
+    end
+
+    def last_applied_event_id
+      Snapshots::EventCount.pointer_for(identifier)
+    end
+  end
+end

--- a/app/models/repositories/build_repository.rb
+++ b/app/models/repositories/build_repository.rb
@@ -5,13 +5,10 @@ require 'events/jenkins_event'
 require 'snapshots/build'
 
 module Repositories
-  class BuildRepository
+  class BuildRepository < Base
     def initialize(store = Snapshots::Build)
       @store = store
     end
-
-    attr_reader :store
-    delegate :table_name, to: :store
 
     def apply(event)
       return unless event.is_a?(Events::CircleCiEvent) || event.is_a?(Events::JenkinsEvent)

--- a/app/models/repositories/deploy_alert_repository.rb
+++ b/app/models/repositories/deploy_alert_repository.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'events/deploy_alert_event'
+require 'snapshots/deploy'
+
+module Repositories
+  class DeployAlertRepository
+    def initialize(store = Snapshots::Deploy)
+      @store = store
+    end
+
+    attr_reader :store
+    delegate :table_name, to: :store
+
+    def apply(event)
+      return unless event.is_a?(Events::DeployAlertEvent)
+
+      deploy = store.find_by!(uuid: event.deploy_uuid)
+      deploy.deploy_alert = event.message
+      deploy.save!
+    end
+  end
+end

--- a/app/models/repositories/deploy_alert_repository.rb
+++ b/app/models/repositories/deploy_alert_repository.rb
@@ -4,6 +4,10 @@ require 'snapshots/deploy'
 
 module Repositories
   class DeployAlertRepository < Base
+    def identifier
+      'deploy_alert_repository'
+    end
+
     def initialize(store = Snapshots::Deploy)
       @store = store
     end

--- a/app/models/repositories/deploy_alert_repository.rb
+++ b/app/models/repositories/deploy_alert_repository.rb
@@ -3,13 +3,10 @@ require 'events/deploy_alert_event'
 require 'snapshots/deploy'
 
 module Repositories
-  class DeployAlertRepository
+  class DeployAlertRepository < Base
     def initialize(store = Snapshots::Deploy)
       @store = store
     end
-
-    attr_reader :store
-    delegate :table_name, to: :store
 
     def apply(event)
       return unless event.is_a?(Events::DeployAlertEvent)

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -66,6 +66,7 @@ module Repositories
         region: event.locale,
         environment: event.environment,
         version: event.version,
+        uuid: event.uuid,
         deployed_by: event.deployed_by,
         deployed_at: event.created_at,
       )

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -5,13 +5,10 @@ require 'deploy'
 require 'deploy_alert_job'
 
 module Repositories
-  class DeployRepository
+  class DeployRepository < Base
     def initialize(store = Snapshots::Deploy)
       @store = store
     end
-
-    attr_reader :store
-    delegate :table_name, to: :store
 
     def deploys_for(apps: nil, server:, at: nil)
       deploys(apps, server, at)

--- a/app/models/repositories/manual_test_repository.rb
+++ b/app/models/repositories/manual_test_repository.rb
@@ -4,13 +4,10 @@ require 'qa_submission'
 require 'snapshots/manual_test'
 
 module Repositories
-  class ManualTestRepository
+  class ManualTestRepository < Base
     def initialize(store = Snapshots::ManualTest)
       @store = store
     end
-
-    attr_reader :store
-    delegate :table_name, to: :store
 
     def qa_submission_for(versions:, at: nil)
       qa_submission(versions, at)

--- a/app/models/repositories/release_exception_repository.rb
+++ b/app/models/repositories/release_exception_repository.rb
@@ -3,16 +3,13 @@ require 'events/release_exception_event'
 require 'snapshots/release_exception'
 
 module Repositories
-  class ReleaseExceptionRepository
+  class ReleaseExceptionRepository < Base
     def initialize(store = Snapshots::ReleaseException)
       @store = store
     end
 
-    attr_reader :store
-    delegate :table_name, to: :store
-
     def release_exception_for(versions:, at: nil)
-      submitted_at_query = at ? table['submitted_at'].lteq(at) : nil
+      submitted_at_query = at ? store.arel_table['submitted_at'].lteq(at) : nil
 
       store
         .where(submitted_at_query)
@@ -50,10 +47,6 @@ module Repositories
 
     def prepared_versions(versions)
       versions.sort
-    end
-
-    def table
-      store.arel_table
     end
   end
 end

--- a/app/models/repositories/released_ticket_repository.rb
+++ b/app/models/repositories/released_ticket_repository.rb
@@ -7,16 +7,13 @@ require 'released_ticket'
 require 'snapshots/deploy'
 
 module Repositories
-  class ReleasedTicketRepository
+  class ReleasedTicketRepository < Base
     def initialize(store = Snapshots::ReleasedTicket)
       @store = store
       @deploy_store = Snapshots::Deploy
       @feature_review_factory = Factories::FeatureReviewFactory.new
       @git_repository_loader = GitRepositoryLoader.from_rails_config
     end
-
-    attr_reader :store
-    delegate :table_name, to: :store
 
     def tickets_for_query(query_text:, versions:, per_page: ShipmentTracker::NUMBER_OF_TICKETS_TO_DISPLAY,
       from_date: nil, to_date: nil)

--- a/app/models/repositories/repo_ownership_repository.rb
+++ b/app/models/repositories/repo_ownership_repository.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 module Repositories
-  class RepoOwnershipRepository
+  class RepoOwnershipRepository < Base
     def initialize(store = Snapshots::RepoOwnership)
       @store = store
     end
-
-    attr_reader :store
-    delegate :table_name, to: :store
 
     # Events::RepoOwnershipEvent
     def apply(event)

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -6,11 +6,7 @@ require 'snapshots/ticket'
 require 'ticket'
 
 module Repositories
-  class TicketRepository
-    attr_reader :store
-
-    delegate :table_name, to: :store
-
+  class TicketRepository < Base
     def initialize(store = Snapshots::Ticket, git_repository_location: GitRepositoryLocation)
       @store = store
       @git_repository_location = git_repository_location

--- a/app/models/repositories/uatest_repository.rb
+++ b/app/models/repositories/uatest_repository.rb
@@ -5,14 +5,11 @@ require 'events/uat_event'
 require 'uatest'
 
 module Repositories
-  class UatestRepository
+  class UatestRepository < Base
     def initialize(store = Snapshots::Uatest, deploy_repository: Repositories::DeployRepository.new)
       @store = store
       @deploy_repository = deploy_repository
     end
-
-    attr_reader :store
-    delegate :table_name, to: :store
 
     def uatest_for(versions:, server:, at: nil)
       query = at ? store.arel_table['event_created_at'].lteq(at) : nil

--- a/app/models/repositories/updater.rb
+++ b/app/models/repositories/updater.rb
@@ -50,7 +50,7 @@ module Repositories
     private
 
     def apply(repository:, event:)
-      Rails.logger.info "[#{Time.current}] Apply event for #{repository.class} - #{repository.table_name}"
+      Rails.logger.info "[#{Time.current}] Apply event #{event.id} for #{repository.class} - #{repository.table_name}"
       repository.apply(event)
       Snapshots::EventCount.update_pointer(repository.identifier, event.id)
     end

--- a/app/models/snapshots/event_count.rb
+++ b/app/models/snapshots/event_count.rb
@@ -5,7 +5,7 @@ module Snapshots
   class EventCount < ActiveRecord::Base
     class << self
       def global_event_pointer
-        find_by_snapshot_name('global_event_pointer')&.event_id || 0
+        pointer_for('global_event_pointer')
       end
 
       def global_event_pointer=(event_id)

--- a/app/models/snapshots/event_count.rb
+++ b/app/models/snapshots/event_count.rb
@@ -3,8 +3,30 @@ require 'active_record'
 
 module Snapshots
   class EventCount < ActiveRecord::Base
-    def self.repo_event_id_hash
-      pluck(:snapshot_name, :event_id).to_h
+    class << self
+      def global_event_pointer
+        find_by_snapshot_name('global_event_pointer')&.event_id || 0
+      end
+
+      def global_event_pointer=(event_id)
+        transaction do
+          record = find_or_create_by(snapshot_name: 'global_event_pointer')
+          record.event_id = event_id
+          record.save!
+        end
+
+        event_id
+      end
+
+      def pointer_for(identifier)
+        find_by(snapshot_name: identifier)&.event_id || 0
+      end
+
+      def update_pointer(identifier, event_id)
+        event_count = find_or_initialize_by(snapshot_name: identifier)
+        event_count.event_id = event_id
+        event_count.save!
+      end
     end
   end
 end

--- a/config/initializers/event_types.rb
+++ b/config/initializers/event_types.rb
@@ -36,4 +36,8 @@ Rails.application.config.event_types = [
     name: 'Project Owner Exception',
     endpoint: 'release_exception',
     event_class: Events::ReleaseExceptionEvent, internal: true),
+  EventType.new(
+    name: 'Deploy Alert',
+    endpoint: 'deploy_alert',
+    event_class: Events::DeployAlertEvent, internal: true),
 ]

--- a/config/initializers/repositories.rb
+++ b/config/initializers/repositories.rb
@@ -7,10 +7,8 @@ Rails.configuration.repositories = [
   Repositories::ReleaseExceptionRepository.new,
   Repositories::TicketRepository.new,
 
-  # ReleasedTickets repo depends on DeployRepository
+  # Depends on DeployRepository:
   Repositories::ReleasedTicketRepository.new,
-
-  # UatestRepository must always be last as it depends on DeployRepository.
-  # Until we make snapshot updating more robust (e.g. jobs queue or table locking) this will have to remain.
   Repositories::UatestRepository.new,
+  Repositories::DeployAlertRepository.new,
 ]

--- a/config/initializers/repositories.rb
+++ b/config/initializers/repositories.rb
@@ -12,3 +12,7 @@ Rails.configuration.repositories = [
   Repositories::UatestRepository.new,
   Repositories::DeployAlertRepository.new,
 ]
+
+Rails.configuration.repositories_that_do_not_run_in_the_background = [
+  Repositories::RepoOwnershipRepository,
+]

--- a/db/migrate/20170127101420_add_uuid_to_events.rb
+++ b/db/migrate/20170127101420_add_uuid_to_events.rb
@@ -1,0 +1,7 @@
+class AddUuidToEvents < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+    add_column :events, :uuid, :uuid, null: false, default: 'uuid_generate_v4()'
+    add_index :events, :uuid, unique: true
+  end
+end

--- a/db/migrate/20170127120354_add_uuid_to_deploys.rb
+++ b/db/migrate/20170127120354_add_uuid_to_deploys.rb
@@ -1,0 +1,6 @@
+class AddUuidToDeploys < ActiveRecord::Migration
+  def change
+    add_column :deploys, :uuid, :uuid
+    add_index :deploys, :uuid, unique: true
+  end
+end

--- a/db/migrate/20170127123616_add_deploy_alert_to_deploys.rb
+++ b/db/migrate/20170127123616_add_deploy_alert_to_deploys.rb
@@ -1,0 +1,6 @@
+class AddDeployAlertToDeploys < ActiveRecord::Migration
+  def change
+    add_column :deploys, :deploy_alert, :string
+    add_index :deploys, :deploy_alert
+  end
+end

--- a/db/migrate/20170407150443_set_the_global_event_pointer.rb
+++ b/db/migrate/20170407150443_set_the_global_event_pointer.rb
@@ -1,0 +1,25 @@
+class SetTheGlobalEventPointer < ActiveRecord::Migration
+  module Events
+    class BaseEvent < ActiveRecord::Base
+      self.table_name = 'events'
+    end
+  end
+
+  module Snapshots
+    class EventCount < ActiveRecord::Base
+    end
+  end
+
+  def up
+    record = Snapshots::EventCount.create!(
+      snapshot_name: 'global_event_pointer',
+      event_id: Events::BaseEvent.last.id,
+    )
+
+    say "Global Event Pointer (last applied event id): #{record.event_id}"
+  end
+
+  def down
+    Snapshots::EventCount.find_by(snapshot_name: 'global_event_pointer')&.destroy
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,12 +2,16 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.5.5
+-- Dumped by pg_dump version 9.5.5
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -35,6 +39,20 @@ CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA public;
 --
 
 COMMENT ON EXTENSION hstore IS 'data type for storing sets of (key, value) pairs';
+
+
+--
+-- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UUIDs)';
 
 
 SET search_path = public, pg_catalog;
@@ -75,7 +93,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: builds; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: builds; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE builds (
@@ -107,7 +125,7 @@ ALTER SEQUENCE builds_id_seq OWNED BY builds.id;
 
 
 --
--- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE delayed_jobs (
@@ -146,7 +164,7 @@ ALTER SEQUENCE delayed_jobs_id_seq OWNED BY delayed_jobs.id;
 
 
 --
--- Name: deploys; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: deploys; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE deploys (
@@ -157,7 +175,9 @@ CREATE TABLE deploys (
     deployed_by character varying,
     deployed_at timestamp without time zone,
     environment character varying,
-    region character varying
+    region character varying,
+    uuid uuid,
+    deploy_alert character varying
 );
 
 
@@ -181,7 +201,7 @@ ALTER SEQUENCE deploys_id_seq OWNED BY deploys.id;
 
 
 --
--- Name: event_counts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: event_counts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE event_counts (
@@ -211,7 +231,7 @@ ALTER SEQUENCE event_counts_id_seq OWNED BY event_counts.id;
 
 
 --
--- Name: events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: events; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE events (
@@ -219,7 +239,8 @@ CREATE TABLE events (
     details json,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    type character varying
+    type character varying,
+    uuid uuid DEFAULT uuid_generate_v4()
 );
 
 
@@ -243,7 +264,7 @@ ALTER SEQUENCE events_id_seq OWNED BY events.id;
 
 
 --
--- Name: git_repository_locations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: git_repository_locations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE git_repository_locations (
@@ -276,7 +297,7 @@ ALTER SEQUENCE git_repository_locations_id_seq OWNED BY git_repository_locations
 
 
 --
--- Name: manual_tests; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: manual_tests; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE manual_tests (
@@ -309,7 +330,7 @@ ALTER SEQUENCE manual_tests_id_seq OWNED BY manual_tests.id;
 
 
 --
--- Name: release_exceptions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: release_exceptions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE release_exceptions (
@@ -318,7 +339,6 @@ CREATE TABLE release_exceptions (
     versions text[] DEFAULT '{}'::text[],
     approved boolean,
     comment text,
-    submitted_at timestamp without time zone NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     path character varying
@@ -345,7 +365,7 @@ ALTER SEQUENCE release_exceptions_id_seq OWNED BY release_exceptions.id;
 
 
 --
--- Name: released_tickets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: released_tickets; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE released_tickets (
@@ -381,7 +401,7 @@ ALTER SEQUENCE released_tickets_id_seq OWNED BY released_tickets.id;
 
 
 --
--- Name: repo_owners; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: repo_owners; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE repo_owners (
@@ -413,7 +433,7 @@ ALTER SEQUENCE repo_owners_id_seq OWNED BY repo_owners.id;
 
 
 --
--- Name: repo_ownerships; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: repo_ownerships; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE repo_ownerships (
@@ -445,7 +465,7 @@ ALTER SEQUENCE repo_ownerships_id_seq OWNED BY repo_ownerships.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE schema_migrations (
@@ -454,7 +474,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: tickets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tickets; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE tickets (
@@ -490,7 +510,7 @@ ALTER SEQUENCE tickets_id_seq OWNED BY tickets.id;
 
 
 --
--- Name: tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tokens; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE tokens (
@@ -523,7 +543,7 @@ ALTER SEQUENCE tokens_id_seq OWNED BY tokens.id;
 
 
 --
--- Name: uatests; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: uatests; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE uatests (
@@ -654,7 +674,7 @@ ALTER TABLE ONLY uatests ALTER COLUMN id SET DEFAULT nextval('uatests_id_seq'::r
 
 
 --
--- Name: builds_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: builds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY builds
@@ -662,7 +682,7 @@ ALTER TABLE ONLY builds
 
 
 --
--- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY delayed_jobs
@@ -670,7 +690,7 @@ ALTER TABLE ONLY delayed_jobs
 
 
 --
--- Name: deploys_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: deploys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY deploys
@@ -678,7 +698,7 @@ ALTER TABLE ONLY deploys
 
 
 --
--- Name: event_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: event_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY event_counts
@@ -686,7 +706,7 @@ ALTER TABLE ONLY event_counts
 
 
 --
--- Name: events_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY events
@@ -694,7 +714,7 @@ ALTER TABLE ONLY events
 
 
 --
--- Name: git_repository_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: git_repository_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY git_repository_locations
@@ -702,7 +722,7 @@ ALTER TABLE ONLY git_repository_locations
 
 
 --
--- Name: manual_tests_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: manual_tests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY manual_tests
@@ -710,7 +730,7 @@ ALTER TABLE ONLY manual_tests
 
 
 --
--- Name: release_exceptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: release_exceptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY release_exceptions
@@ -718,7 +738,7 @@ ALTER TABLE ONLY release_exceptions
 
 
 --
--- Name: released_tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: released_tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY released_tickets
@@ -726,7 +746,7 @@ ALTER TABLE ONLY released_tickets
 
 
 --
--- Name: repo_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: repo_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY repo_owners
@@ -734,7 +754,7 @@ ALTER TABLE ONLY repo_owners
 
 
 --
--- Name: repo_ownerships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: repo_ownerships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY repo_ownerships
@@ -742,7 +762,7 @@ ALTER TABLE ONLY repo_ownerships
 
 
 --
--- Name: tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tickets
@@ -750,7 +770,7 @@ ALTER TABLE ONLY tickets
 
 
 --
--- Name: tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tokens
@@ -758,7 +778,7 @@ ALTER TABLE ONLY tokens
 
 
 --
--- Name: uatests_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: uatests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY uatests
@@ -766,140 +786,154 @@ ALTER TABLE ONLY uatests
 
 
 --
--- Name: delayed_jobs_priority; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs_priority; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX delayed_jobs_priority ON delayed_jobs USING btree (priority, run_at);
 
 
 --
--- Name: index_builds_on_version; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_builds_on_version; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_builds_on_version ON builds USING btree (version);
 
 
 --
--- Name: index_deploys_on_app_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_deploys_on_app_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_deploys_on_app_name ON deploys USING btree (app_name);
 
 
 --
--- Name: index_deploys_on_server_and_app_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_deploys_on_deploy_alert; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_deploys_on_deploy_alert ON deploys USING btree (deploy_alert);
+
+
+--
+-- Name: index_deploys_on_server_and_app_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_deploys_on_server_and_app_name ON deploys USING btree (server, app_name);
 
 
 --
--- Name: index_deploys_on_version; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_deploys_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_deploys_on_uuid ON deploys USING btree (uuid);
+
+
+--
+-- Name: index_deploys_on_version; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_deploys_on_version ON deploys USING btree (version);
 
 
 --
--- Name: index_git_repository_locations_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_events_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_events_on_uuid ON events USING btree (uuid);
+
+
+--
+-- Name: index_git_repository_locations_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_git_repository_locations_on_name ON git_repository_locations USING btree (name);
 
 
 --
--- Name: index_manual_tests_on_versions; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_manual_tests_on_versions; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_manual_tests_on_versions ON manual_tests USING gin (versions);
 
 
 --
--- Name: index_release_exceptions_on_repo_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_release_exceptions_on_repo_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_release_exceptions_on_repo_owner_id ON release_exceptions USING btree (repo_owner_id);
 
 
 --
--- Name: index_release_exceptions_on_submitted_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_release_exceptions_on_submitted_at ON release_exceptions USING btree (submitted_at);
-
-
---
--- Name: index_released_tickets_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_released_tickets_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_released_tickets_on_key ON released_tickets USING btree (key);
 
 
 --
--- Name: index_released_tickets_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_released_tickets_on_tsv; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_released_tickets_on_tsv ON released_tickets USING gin (tsv);
 
 
 --
--- Name: index_released_tickets_on_versions; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_released_tickets_on_versions; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_released_tickets_on_versions ON released_tickets USING gin (versions);
 
 
 --
--- Name: index_repo_owners_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_repo_owners_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_repo_owners_on_email ON repo_owners USING btree (email);
 
 
 --
--- Name: index_repo_ownerships_on_app_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_repo_ownerships_on_app_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_repo_ownerships_on_app_name ON repo_ownerships USING btree (app_name);
 
 
 --
--- Name: index_tickets_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tickets_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tickets_on_key ON tickets USING btree (key);
 
 
 --
--- Name: index_tickets_on_paths; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tickets_on_paths; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tickets_on_paths ON tickets USING gin (paths);
 
 
 --
--- Name: index_tickets_on_versions; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tickets_on_versions; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tickets_on_versions ON tickets USING gin (versions);
 
 
 --
--- Name: index_tokens_on_value; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tokens_on_value; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_tokens_on_value ON tokens USING btree (value);
 
 
 --
--- Name: index_uatests_on_versions; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_uatests_on_versions; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_uatests_on_versions ON uatests USING gin (versions);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
@@ -924,7 +958,7 @@ ALTER TABLE ONLY release_exceptions
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user",public;
+SET search_path TO "$user", public;
 
 INSERT INTO schema_migrations (version) VALUES ('20150427164403');
 
@@ -968,6 +1002,10 @@ INSERT INTO schema_migrations (version) VALUES ('20150823124740');
 
 INSERT INTO schema_migrations (version) VALUES ('20150823124742');
 
+INSERT INTO schema_migrations (version) VALUES ('20150908100119');
+
+INSERT INTO schema_migrations (version) VALUES ('20150910115332');
+
 INSERT INTO schema_migrations (version) VALUES ('20150910135208');
 
 INSERT INTO schema_migrations (version) VALUES ('20150915150206');
@@ -979,6 +1017,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150915161859');
 INSERT INTO schema_migrations (version) VALUES ('20150921110831');
 
 INSERT INTO schema_migrations (version) VALUES ('20150921115023');
+
+INSERT INTO schema_migrations (version) VALUES ('20150921115024');
 
 INSERT INTO schema_migrations (version) VALUES ('20150928130626');
 
@@ -1007,4 +1047,10 @@ INSERT INTO schema_migrations (version) VALUES ('20161216125029');
 INSERT INTO schema_migrations (version) VALUES ('20170105131624');
 
 INSERT INTO schema_migrations (version) VALUES ('20170126115241');
+
+INSERT INTO schema_migrations (version) VALUES ('20170127101420');
+
+INSERT INTO schema_migrations (version) VALUES ('20170127120354');
+
+INSERT INTO schema_migrations (version) VALUES ('20170127123616');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -339,6 +339,7 @@ CREATE TABLE release_exceptions (
     versions text[] DEFAULT '{}'::text[],
     approved boolean,
     comment text,
+    submitted_at timestamp without time zone NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     path character varying
@@ -863,6 +864,13 @@ CREATE INDEX index_release_exceptions_on_repo_owner_id ON release_exceptions USI
 
 
 --
+-- Name: index_release_exceptions_on_submitted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_release_exceptions_on_submitted_at ON release_exceptions USING btree (submitted_at);
+
+
+--
 -- Name: index_released_tickets_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1002,10 +1010,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150823124740');
 
 INSERT INTO schema_migrations (version) VALUES ('20150823124742');
 
-INSERT INTO schema_migrations (version) VALUES ('20150908100119');
-
-INSERT INTO schema_migrations (version) VALUES ('20150910115332');
-
 INSERT INTO schema_migrations (version) VALUES ('20150910135208');
 
 INSERT INTO schema_migrations (version) VALUES ('20150915150206');
@@ -1017,8 +1021,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150915161859');
 INSERT INTO schema_migrations (version) VALUES ('20150921110831');
 
 INSERT INTO schema_migrations (version) VALUES ('20150921115023');
-
-INSERT INTO schema_migrations (version) VALUES ('20150921115024');
 
 INSERT INTO schema_migrations (version) VALUES ('20150928130626');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.5
--- Dumped by pg_dump version 9.5.5
+-- Dumped from database version 9.5.6
+-- Dumped by pg_dump version 9.5.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1055,4 +1055,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170127101420');
 INSERT INTO schema_migrations (version) VALUES ('20170127120354');
 
 INSERT INTO schema_migrations (version) VALUES ('20170127123616');
+
+INSERT INTO schema_migrations (version) VALUES ('20170407150443');
 

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -132,8 +132,5 @@ end
 # rubocop:enable LineLength
 
 When 'snapshots are regenerated' do
-  repos = Rails.configuration.repositories
-  updater = Repositories::Updater.new(repos)
-  updater.reset
-  updater.run
+  Repositories::Updater.from_rails_config.recreate
 end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -61,7 +61,7 @@ namespace :jobs do
         num_events = Events::BaseEvent.where('id > ?', from_event_id).where('id <= ?', last_event_id).count
 
         end_time = Time.current
-        puts "[#{end_time}] Cached #{num_events} events in #{end_time - start_time} seconds"
+        puts "[#{end_time}] Applied #{num_events} events in #{end_time - start_time} seconds"
 
         break if @shutdown
 

--- a/spec/factories/deploy_alert_event.rb
+++ b/spec/factories/deploy_alert_event.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'events/deploy_alert_event'
+
+FactoryGirl.define do
+  factory :deploy_alert_event, class: Events::DeployAlertEvent do
+    transient do
+      uuid { SecureRandom.uuid }
+      message 'Deploy alert from factory.'
+    end
+
+    details {
+      {
+        'deploy_uuid' => uuid,
+        'message' => message,
+      }
+    }
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/factories/deploy_event.rb
+++ b/spec/factories/deploy_event.rb
@@ -25,7 +25,7 @@ FactoryGirl.define do
       }
     }
 
-    uuid { SecureRandom.uuid }
+    uuid nil
 
     initialize_with { new(attributes) }
   end

--- a/spec/factories/deploy_event.rb
+++ b/spec/factories/deploy_event.rb
@@ -25,6 +25,8 @@ FactoryGirl.define do
       }
     }
 
+    uuid { SecureRandom.uuid }
+
     initialize_with { new(attributes) }
   end
 end

--- a/spec/factories/deploy_snapshot.rb
+++ b/spec/factories/deploy_snapshot.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'snapshots/deploy'
+
+FactoryGirl.define do
+  factory :deploy_snapshot, class: Snapshots::Deploy do
+    server 'uat.example.com'
+    sequence(:version) { |n| "#{n}abcabcabcabcabcabcabcabcabcabcabcabcabc"[0..39] }
+    app_name 'hello_world'
+    region 'us'
+    deployed_at { Time.now.utc.to_i }
+    deployed_by 'frank@example.com'
+    environment 'uat'
+    deploy_alert nil
+    uuid nil
+  end
+end

--- a/spec/models/repositories/base_spec.rb
+++ b/spec/models/repositories/base_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'repositories/base'
+
+module Spec
+  class TestRepositoriesBase < Repositories::Base
+    def initialize(store)
+      @store = store
+    end
+
+    def apply
+    end
+  end
+end
+
+RSpec.describe 'Repositories::Base' do
+  def repository_for(store)
+    Spec::TestRepositoriesBase.new(store)
+  end
+
+  describe '#indentifier' do
+    it 'is the table name of the store' do
+      expect(repository_for(double('store', table_name: 'test-store')).identifier).to eq('test-store')
+    end
+  end
+
+  describe '#last_applied_event_id' do
+    it 'returns the last event applied by the repo' do
+      repository = repository_for(double('store', table_name: 'test-store'))
+
+      expect(Snapshots::EventCount).to receive(:pointer_for).with('test-store')
+
+      repository.last_applied_event_id
+    end
+  end
+end

--- a/spec/models/repositories/deploy_alert_repository_spec.rb
+++ b/spec/models/repositories/deploy_alert_repository_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Repositories::DeployAlertRepository do
+  describe '#apply' do
+    it 'will store the deploy alert for the deploy with the specific uuid' do
+      event = build(
+        :deploy_alert_event,
+        uuid: 'bad85eb9-0713-4da7-8d36-07a8e4b00eab',
+        message: 'A deploy alert!!',
+      )
+
+      snapshot = create(
+        :deploy_snapshot,
+        uuid: 'bad85eb9-0713-4da7-8d36-07a8e4b00eab',
+        deploy_alert: nil,
+      )
+
+      expect { described_class.new.apply(event) }.to(
+        change { snapshot.reload.deploy_alert }.to('A deploy alert!!'),
+      )
+    end
+  end
+end

--- a/spec/models/repositories/deploy_repository_spec.rb
+++ b/spec/models/repositories/deploy_repository_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Repositories::DeployRepository do
           'deployed_at' => '',
           'environment' => environment,
           'region' => 'us',
+          'deploy_alert' => nil,
         },
         previous_deploy: nil,
       }
@@ -65,7 +66,7 @@ RSpec.describe Repositories::DeployRepository do
         ),
       )
 
-      expect(Snapshots::Deploy.find_by_uuid('bad85eb9-0713-4da7-8d36-07a8e4b00eab'))
+      expect(Snapshots::Deploy.find_by(uuid: 'bad85eb9-0713-4da7-8d36-07a8e4b00eab'))
         .to have_attributes(
           version: expand_sha('xyz'),
           environment: 'production',

--- a/spec/models/repositories/updater_spec.rb
+++ b/spec/models/repositories/updater_spec.rb
@@ -4,108 +4,54 @@ require 'repositories/updater'
 
 RSpec.describe Repositories::Updater do
   describe '.from_rails_config' do
-    let(:expected_updater) { double('updater') }
-
-    before do
-      allow(Repositories::Updater).to receive(:new)
-        .with(Rails.configuration.repositories)
-        .and_return(expected_updater)
-    end
-
     it 'returns a configured updater' do
-      expect(Repositories::Updater.from_rails_config).to eq(expected_updater)
+      expect(Repositories::Updater.from_rails_config.repositories).to eq(Rails.configuration.repositories)
     end
   end
 
-  let(:repository_1) {
-    instance_double(
-      Repositories::BuildRepository,
-      'repository_1',
-      store: Snapshots::Build,
-      table_name: 'tbl_1',
-    )
-  }
-  let(:repository_2) {
-    instance_double(
-      Repositories::DeployRepository,
-      'repository_2',
-      store: Snapshots::Deploy,
-      table_name: 'tbl_2',
-    )
-  }
-  let(:repositories) { [repository_1, repository_2] }
+  def repository_stub(repository)
+    allow(repository).to receive(:apply)
 
-  let(:events) { [build(:jira_event), build(:jira_event)] }
+    repository
+  end
+
+  let(:repository_1) { repository_stub(Repositories::BuildRepository.new(Snapshots::Build)) }
+  let(:repository_2) { repository_stub(Repositories::DeployRepository.new(Snapshots::Deploy)) }
+  let(:repositories) { [repository_1, repository_2] }
 
   subject(:updater) { Repositories::Updater.new(repositories) }
 
   describe '#run' do
-    it 'feeds events to each repository and updates the counts' do
-      events.each(&:save!)
+    it 'feeds the events in ordered manner to each of the repositories' do
+      events = create_list :jira_event, 2
 
       expect(repository_1).to receive(:apply).with(events[0]).ordered
-      expect(repository_1).to receive(:apply).with(events[1]).ordered
-
       expect(repository_2).to receive(:apply).with(events[0]).ordered
+
+      expect(repository_1).to receive(:apply).with(events[1]).ordered
       expect(repository_2).to receive(:apply).with(events[1]).ordered
 
       updater.run
 
-      last_id = events[1].id
-      expect(Snapshots::EventCount.find_by(snapshot_name: repository_1.table_name).event_id).to eq(last_id)
-      expect(Snapshots::EventCount.find_by(snapshot_name: repository_2.table_name).event_id).to eq(last_id)
+      expect(repository_1.last_applied_event_id).to eq(events.last.id)
+      expect(repository_2.last_applied_event_id).to eq(events.last.id)
     end
 
     context 'when given a hash with snapshot names and event ids' do
-      let(:events) {
-        [
-          build(:jira_event),
-          build(:jira_event),
-          build(:jira_event),
-        ]
-      }
-
       it 'only snapshots up to the given event id for each repository' do
         allow(repository_1).to receive(:apply)
         allow(repository_2).to receive(:apply)
 
-        events.each(&:save!)
+        events = create_list :jira_event, 3
 
-        updater.run(repository_1.table_name => events[0].id, repository_2.table_name => events[1].id)
+        updater.run(upto_event: events.second.id)
 
-        expect(Snapshots::EventCount.find_by(snapshot_name: repository_1.table_name).event_id)
-          .to eq(events[0].id)
-        expect(Snapshots::EventCount.find_by(snapshot_name: repository_2.table_name).event_id)
-          .to eq(events[1].id)
-      end
-    end
-
-    context 'when the application is updated and we have different repositories specified' do
-      let(:events) { [build(:jira_event), build(:jira_event)] }
-      let(:new_events) { [build(:jira_event)] }
-
-      it 'only feeds events that are new for each repository' do
-        events.each(&:save!)
-
-        expect(repository_1).to receive(:apply).with(events[0]).ordered
-        expect(repository_1).to receive(:apply).with(events[1]).ordered
-
-        Repositories::Updater.new([repository_1]).run
-
-        new_events.each(&:save!)
-
-        expect(repository_1).to receive(:apply).with(new_events[0]).ordered
-        expect(repository_2).to receive(:apply).with(events[0]).ordered
-        expect(repository_2).to receive(:apply).with(events[1]).ordered
-        expect(repository_2).to receive(:apply).with(new_events[0]).ordered
-
-        Repositories::Updater.new([repository_1, repository_2]).run
+        expect(repository_1.last_applied_event_id).to eq(events.second.id)
+        expect(repository_2.last_applied_event_id).to eq(events.second.id)
       end
     end
 
     context 'when there are no new events' do
-      let(:events) { [] }
-
       it 'does not update the event count' do
         expect_any_instance_of(Snapshots::EventCount).to_not receive(:save)
 
@@ -131,14 +77,12 @@ RSpec.describe Repositories::Updater do
 
         expect(repository).to receive(:apply).and_return(true)
 
-        Repositories::Updater.new([repository]).run({}, true)
+        Repositories::Updater.new([repository]).run(apply_to_all: true)
       end
     end
   end
 
   describe '#reset' do
-    let(:events) { [build(:circle_ci_event), build(:deploy_event)] }
-
     let(:store_1) { Snapshots::Build }
     let(:store_2) { Snapshots::Deploy }
 
@@ -146,7 +90,10 @@ RSpec.describe Repositories::Updater do
     let(:repository_2) { Repositories::DeployRepository.new(store_2) }
 
     it 'wipes all repositories and what events they require' do
-      events.each(&:save!)
+      events = [
+        create(:circle_ci_event),
+        create(:deploy_event),
+      ]
 
       updater.run
 
@@ -159,8 +106,8 @@ RSpec.describe Repositories::Updater do
       expect(store_2.count).to eq(0)
 
       expect(repository_1).to receive(:apply).with(events[0]).ordered
-      expect(repository_1).to receive(:apply).with(events[1]).ordered
       expect(repository_2).to receive(:apply).with(events[0]).ordered
+      expect(repository_1).to receive(:apply).with(events[1]).ordered
       expect(repository_2).to receive(:apply).with(events[1]).ordered
 
       updater.run
@@ -174,7 +121,7 @@ RSpec.describe Repositories::Updater do
       repository = Repositories::RepoOwnershipRepository.new
       allow(repository).to receive(:apply)
 
-      Repositories::Updater.new([repository]).run({}, true)
+      Repositories::Updater.new([repository]).run(apply_to_all: true)
 
       last_updated_event = Snapshots::EventCount.last
 

--- a/spec/models/snapshots/event_count_spec.rb
+++ b/spec/models/snapshots/event_count_spec.rb
@@ -2,17 +2,16 @@
 require 'rails_helper'
 
 RSpec.describe Snapshots::EventCount do
-  describe '.repo_event_id_hash' do
-    before do
-      Snapshots::EventCount.create([
-        { snapshot_name: 'foo', event_id: 1 },
-        { snapshot_name: 'bar', event_id: 2 },
-      ])
+  describe '.global_event_pointer' do
+    it 'is 0 by default' do
+      expect(described_class.global_event_pointer).to eq(0)
     end
+  end
 
-    it 'returns a hash with all snapshot names and event ids' do
-      result = Snapshots::EventCount.repo_event_id_hash
-      expect(result).to eq('foo' => 1, 'bar' => 2)
+  describe '.global_event_pointer=' do
+    it 'could be changed' do
+      expect(described_class.global_event_pointer = 10).to eq(10)
+      expect(described_class.global_event_pointer).to eq(10)
     end
   end
 end


### PR DESCRIPTION
The PR aims to record the deploy alerts in the deploy snapshots

```
DeployAlertEvent
  - deploy snapshot uuid
  - message

Snapshots::Deploy
  - deploy_alert - string
```

To do this a uuid is added to all events. The uuid from the deploy event will be saved in the deploy snapshot. It will be used to refer to the snapshot in a later stage from the deploy alert event.

Old deploy snapshot for the moment will not have a uuid. Maybe they could be migrated based on the timestamps :man_shrugging: 

Events are now applied in order. New repositories will not apply all the old
events from the start by default. You'll have to do a recreate manually.

Add Repositories::Base - all repositories inherit from this one

Use global event pointer and do not use the per repository event counts
The code for tracking events per repository is still there. Most
probably it could be removed. Only the global event pointer is used in
the updater.