### PR TITLE
Make sure that we have only events that can be applied by repositories

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,24 +3,49 @@ class EventsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
-    event_factory.create(params[:type], request.request_parameters.except('event'), current_user.email)
+    event =
+      event_factory.build(
+        endpoint: params[:type],
+        payload: request.request_parameters.except('event'),
+        user: current_user,
+      )
 
-    if redirect_path
-      flash[:success] = 'Thank you for your submission. It will appear in a moment.'
-      redirect_to redirect_path
+    if event.save
+      successful_response(event)
+    else
+      failure_response(event)
     end
-
-    self.response_body = 'ok'
   end
 
   private
+
+  def successful_response(_)
+    if redirect_path
+      flash[:success] = 'Thank you for your submission. It will appear in a moment.'
+      redirect_to redirect_path
+    else
+      render status: 200, text: 'ok'
+    end
+  end
+
+  def failure_response(event)
+    Rails.logger.info("Could not create event: #{event.inspect}")
+
+    if event.errors[:base].include?('forbidden')
+      unauthenticated_strategy
+    elsif redirect_path
+      flash[:error] = event.errors.full_messages
+      redirect_to redirect_path
+    else
+      render status: 400, text: "Error - #{event.errors.full_messages}"
+    end
+  end
 
   def redirect_path
     @redirect_path ||= path_from_url(params[:return_to])
   end
 
   def unauthenticated_strategy
-    self.status = 403
-    self.response_body = 'Forbidden'
+    render status: 403, text: 'Forbidden'
   end
 end

--- a/app/models/repositories/release_exception_repository.rb
+++ b/app/models/repositories/release_exception_repository.rb
@@ -23,7 +23,7 @@ module Repositories
     end
 
     def apply(event)
-      return unless event.is_a?(Events::ReleaseExceptionEvent) && valid_repo_owner?(event)
+      return unless event.is_a?(Events::ReleaseExceptionEvent)
 
       store.create!(
         repo_owner_id: event.repo_owner.id,
@@ -36,12 +36,6 @@ module Repositories
     end
 
     private
-
-    def valid_repo_owner?(event)
-      event.git_repos.any? do |git_repo|
-        event.repo_owner.owner_of?(git_repo)
-      end
-    end
 
     def prepared_versions(versions)
       versions.sort

--- a/spec/models/events/release_exception_event_spec.rb
+++ b/spec/models/events/release_exception_event_spec.rb
@@ -81,4 +81,36 @@ RSpec.describe Events::ReleaseExceptionEvent do
       end
     end
   end
+
+  describe 'validation' do
+    context 'when the owner owns at least 1 of the repos' do
+      it 'creates an exception' do
+        repo = create(:git_repository_location, name: 'frontend')
+        owner = create(:repo_owner, email: 'test@example.com')
+
+        expect_any_instance_of(Repositories::RepoOwnershipRepository)
+          .to receive(:owners_of).with(repo).and_return([owner])
+
+        event = build(
+          :release_exception_event,
+          apps: [%w(frontend abc)],
+          email: 'test@example.com',
+        )
+
+        expect(event).to be_valid
+      end
+    end
+
+    context 'when the owner does not own any of the repos' do
+      it 'create an exception' do
+        event = build(
+          :release_exception_event,
+          apps: [%w(frontend abc)],
+          email: 'test2@example.com',
+        )
+
+        expect(event).not_to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/factories/event_factory_spec.rb
+++ b/spec/models/factories/event_factory_spec.rb
@@ -2,46 +2,70 @@
 require 'rails_helper'
 
 RSpec.describe Factories::EventFactory do
-  let(:repository) { instance_double(EventTypeRepository) }
-  subject(:factory) { described_class.new(repository) }
+  def factory_for(event_types = nil)
+    repository = instance_double(EventTypeRepository)
 
-  describe '#create' do
-    let(:payload) { { 'foo' => 'bar' } }
-    let(:user_email) { 'foo@bar.com' }
-    let(:event_type) {
-      EventType.new(endpoint: 'circleci', event_class: Events::CircleCiEvent)
-    }
-
-    before do
+    event_types.each do |event_type|
       allow(repository).to receive(:find_by_endpoint).with(event_type.endpoint).and_return(event_type)
     end
 
-    let(:created_event) { subject.create(event_type.endpoint, payload, user_email) }
+    described_class.new(repository)
+  end
 
-    it 'returns an instance of the correct class' do
-      expect(created_event).to be_an_instance_of(Events::CircleCiEvent)
+  class ExternalEvent < Events::BaseEvent
+  end
+
+  class InternalEvent < Events::BaseEvent
+  end
+
+  subject(:factory) do
+    event_types ||= [
+      EventType.new(endpoint: 'internal', event_class: InternalEvent, internal: true),
+      EventType.new(endpoint: 'external', event_class: ExternalEvent, internal: false),
+    ]
+
+    factory_for(event_types)
+  end
+
+  describe '#build' do
+    it 'builds an event for a specific endpoint' do
+      internal_event = factory.build(endpoint: 'internal', payload: { 'foo' => 'bar' })
+      expect(internal_event).to be_kind_of(InternalEvent)
+      expect(internal_event.details).to eq('foo' => 'bar')
+
+      external_event = factory.build(endpoint: 'external', payload: { 'foo2' => 'bar2' })
+      expect(external_event).to be_kind_of(ExternalEvent)
+      expect(external_event.details).to eq('foo2' => 'bar2')
     end
 
-    it 'stores the payload in the event details' do
-      expect(created_event.details).to eq('foo' => 'bar')
+    context 'when handling internal events' do
+      it 'will include the current user email in the event details' do
+        event = factory.build(
+          endpoint: 'internal',
+          payload: { 'foo' => 'bar' },
+          user: User.new(email: 'test@example.com'),
+        )
+
+        expect(event.details).to eq('foo' => 'bar', 'email' => 'test@example.com')
+      end
     end
 
-    context 'with an internal event type' do
-      let(:event_type) {
-        EventType.new(endpoint: 'manual_test', event_class: Events::ManualTestEvent, internal: true)
-      }
+    context 'when handling external events' do
+      it 'will not try to set the email for the current user' do
+        event = factory.build(
+          endpoint: 'external',
+          payload: { 'foo' => 'bar' },
+          user: User.new(email: 'test@example.com'),
+        )
 
-      it 'stores the payload in the event details, including the user email' do
-        expect(created_event.details).to eq('foo' => 'bar', 'email' => 'foo@bar.com')
+        expect(event.details).to eq('foo' => 'bar')
       end
+    end
 
-      context 'when the user email is nil' do
-        let(:user_email) { nil }
-
-        it 'omits the email from the payload' do
-          expect(created_event.details).to eq('foo' => 'bar')
-        end
-      end
+    it "will raise an exception when there isn't a suitable event type for the endpoint" do
+      expect do
+        described_class.new(EventTypeRepository.new).build(endpoint: 'test', payload: {})
+      end.to raise_error(StandardError)
     end
   end
 end

--- a/spec/models/repositories/release_exception_repository_spec.rb
+++ b/spec/models/repositories/release_exception_repository_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Repositories::ReleaseExceptionRepository do
         )
       }
 
-      it 'does not create an exception' do
-        expect { repository.apply event }.not_to change { Snapshots::ReleaseException.count }
+      it 'create an exception' do
+        expect { repository.apply event }.to change { Snapshots::ReleaseException.count }.by(1)
       end
     end
   end


### PR DESCRIPTION
When applying ReleaseExceptionEvent we validate that the repo owner has
access to the repo. When we recreate the database this will fail.

The validation should happen before we create the event so we can
recreate the database easily without having to deal with invalid events.