### PR TITLE
[PO-2994] Release Exception/Unapproved Deployments report

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -121,3 +121,7 @@ strong.summary {
   margin-top: 30px;
   margin-bottom: 20px;
 }
+
+.unapproved-deploys-form {
+  margin-top: 30px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,4 +29,15 @@ class ApplicationController < ActionController::Base
   rescue URI::InvalidURIError
     nil
   end
+
+  protected
+
+  def update_region_cookies
+    cookies.permanent[:deploy_region] ||= Rails.configuration.default_deploy_region
+    cookies.permanent[:deploy_region] = params[:region] if params[:region]
+  end
+
+  def force_html_format
+    request.format = 'html'
+  end
 end

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -7,7 +7,7 @@ class ReleasesController < ApplicationController
   end
 
   def show
-    update_cookies
+    update_region_cookies
     redirect_to release_path(app_name, region: region) unless params[:region]
     projection = build_projection
     @pending_releases = projection.pending_releases
@@ -38,11 +38,6 @@ class ReleasesController < ApplicationController
 
   def region
     @region = cookies[:deploy_region]
-  end
-
-  def update_cookies
-    cookies.permanent[:deploy_region] ||= Rails.configuration.default_deploy_region
-    cookies.permanent[:deploy_region] = params[:region] if params[:region]
   end
 
   def git_repository

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -48,8 +48,4 @@ class ReleasesController < ApplicationController
   def git_repository
     git_repository_loader.load(app_name)
   end
-
-  def force_html_format
-    request.format = 'html'
-  end
 end

--- a/app/controllers/unapproved_deployments_controller.rb
+++ b/app/controllers/unapproved_deployments_controller.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 class UnapprovedDeploymentsController < ApplicationController
+  before_action :update_region_cookies, only: [:show]
+
   def show
-    update_cookies
-    redirect_to unapproved_deployment_path(app_name, region: region) unless params[:region]
+    update_region_cookies
     fetch_unapproved_deploys
     fetch_release_exceptions
 
     @app_name = app_name
     @github_repo_url = GitRepositoryLocation.github_url_for_app(app_name)
-  rescue GitRepositoryLoader::NotFound
-    render text: 'Repository not found', status: :not_found
   end
 
   private
@@ -42,16 +41,7 @@ class UnapprovedDeploymentsController < ApplicationController
     @region = cookies[:deploy_region]
   end
 
-  def update_cookies
-    cookies.permanent[:deploy_region] ||= Rails.configuration.default_deploy_region
-    cookies.permanent[:deploy_region] = params[:region] if params[:region]
-  end
-
   def git_repository
     git_repository_loader.load(app_name)
-  end
-
-  def force_html_format
-    request.format = 'html'
   end
 end

--- a/app/controllers/unapproved_deployments_controller.rb
+++ b/app/controllers/unapproved_deployments_controller.rb
@@ -13,12 +13,35 @@ class UnapprovedDeploymentsController < ApplicationController
 
   private
 
+  def start_date
+    return @start_date if @start_date.present?
+
+    default_start_date = 1.month.ago.to_date
+    @start_date = params[:start_date].present? ? Date.strptime(params[:start_date], '%Y-%m-%d') : default_start_date
+  end
+
+  def end_date
+    return @end_date if @end_date.present?
+
+    default_end_date = Time.zone.today
+    @end_date = params[:end_date].present? ? Date.strptime(params[:end_date], '%Y-%m-%d') : default_end_date
+  end
+
   def fetch_unapproved_deploys
-    @unapproved_deploys = deploy_repository.unapproved_production_deploys_for(app_name: app_name, region: region)
+    @unapproved_deploys = deploy_repository.unapproved_production_deploys_for(
+      app_name: app_name,
+      region: region,
+      from_date: start_date,
+      to_date: end_date,
+    )
   end
 
   def fetch_release_exceptions
-    @release_exceptions = release_exception_repository.release_exception_for_application(app_name: app_name)
+    @release_exceptions = release_exception_repository.release_exception_for_application(
+      app_name: app_name,
+      from_date: start_date,
+      to_date: end_date,
+    )
   end
 
   def deploy_repository

--- a/app/controllers/unapproved_deployments_controller.rb
+++ b/app/controllers/unapproved_deployments_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+class UnapprovedDeploymentsController < ApplicationController
+  def show
+    update_cookies
+    redirect_to unapproved_deployment_path(app_name, region: region) unless params[:region]
+    fetch_unapproved_deploys
+    fetch_release_exceptions
+
+    @app_name = app_name
+    @github_repo_url = GitRepositoryLocation.github_url_for_app(app_name)
+  rescue GitRepositoryLoader::NotFound
+    render text: 'Repository not found', status: :not_found
+  end
+
+  private
+
+  def fetch_unapproved_deploys
+    @unapproved_deploys = deploy_repository.unapproved_production_deploys_for(app_name: app_name, region: region)
+  end
+
+  def fetch_release_exceptions
+    @release_exceptions = release_exception_repository.release_exception_for_application(app_name: app_name)
+  end
+
+  def deploy_repository
+    @deploy_repository ||= Repositories::DeployRepository.new
+  end
+
+  def release_exception_repository
+    @release_exception_repository ||= Repositories::ReleaseExceptionRepository.new
+  end
+
+  def app_name
+    if request.path_parameters[:format]
+      "#{params[:id]}.#{request.path_parameters[:format]}"
+    else
+      params[:id]
+    end
+  end
+
+  def region
+    @region = cookies[:deploy_region]
+  end
+
+  def update_cookies
+    cookies.permanent[:deploy_region] ||= Rails.configuration.default_deploy_region
+    cookies.permanent[:deploy_region] = params[:region] if params[:region]
+  end
+
+  def git_repository
+    git_repository_loader.load(app_name)
+  end
+
+  def force_html_format
+    request.format = 'html'
+  end
+end

--- a/app/helpers/unapproved_deployments_helper.rb
+++ b/app/helpers/unapproved_deployments_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module UnapprovedDeploymentsHelper
+  def tickets_for_versions(versions)
+    Repositories::TicketRepository.new.tickets_for_versions(versions)
+  end
+
+  def feature_reviews_for_versions(app_name, versions)
+    commits = versions.map { |version| GitCommit.new(id: version) }
+    Queries::DecoratedFeatureReviewsQuery.new(app_name, commits).get
+  end
+end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -7,6 +7,7 @@ class Deploy
     attribute :correct, Boolean
     attribute :deployed_by, String
     attribute :deployed_at, Time
+    attribute :deploy_alert, String
     attribute :server, String
     attribute :region, String
     attribute :version, String

--- a/app/models/release_exception.rb
+++ b/app/models/release_exception.rb
@@ -11,6 +11,10 @@ class ReleaseException
     attribute :versions, Array, default: []
   end
 
+  def commits
+    versions.map { |version| GitCommit.new(id: version) }
+  end
+
   def repo_owner
     RepoOwner.find(repo_owner_id)
   end

--- a/app/models/release_exception.rb
+++ b/app/models/release_exception.rb
@@ -8,6 +8,7 @@ class ReleaseException
     attribute :approved, Boolean
     attribute :submitted_at, Time
     attribute :path, String
+    attribute :versions, Array, default: []
   end
 
   def repo_owner

--- a/app/models/repositories/deploy_repository.rb
+++ b/app/models/repositories/deploy_repository.rb
@@ -14,6 +14,12 @@ module Repositories
       deploys(apps, server, at)
     end
 
+    def unapproved_production_deploys_for(app_name:, region:)
+      store
+        .where(app_name: app_name, environment: 'production', region: region)
+        .where.not(deploy_alert: nil)
+    end
+
     def deploys_for_versions(versions, environment:, region:)
       query = store.select('DISTINCT ON (version) *')
       query = query.where(store.arel_table['version'].in(versions))

--- a/app/models/repositories/release_exception_repository.rb
+++ b/app/models/repositories/release_exception_repository.rb
@@ -8,11 +8,13 @@ module Repositories
       @store = store
     end
 
-    def release_exception_for_application(app_name:, at: nil)
-      submitted_at_query = at ? store.arel_table['submitted_at'].lteq(at) : nil
+    def release_exception_for_application(app_name:, from_date: nil, to_date: nil)
+      time_period_query = if from_date.present? && to_date.present?
+                            store.arel_table['submitted_at'].between(from_date.beginning_of_day..to_date.end_of_day)
+                          end
 
       store
-        .where(submitted_at_query)
+        .where(time_period_query)
         .where('path like ?', "%#{app_name}%")
         .map { |result| ReleaseException.new(result.attributes) }
     end

--- a/app/models/repositories/release_exception_repository.rb
+++ b/app/models/repositories/release_exception_repository.rb
@@ -8,6 +8,15 @@ module Repositories
       @store = store
     end
 
+    def release_exception_for_application(app_name:, at: nil)
+      submitted_at_query = at ? store.arel_table['submitted_at'].lteq(at) : nil
+
+      store
+        .where(submitted_at_query)
+        .where('path like ?', "%#{app_name}%")
+        .map { |result| ReleaseException.new(result.attributes) }
+    end
+
     def release_exception_for(versions:, at: nil)
       submitted_at_query = at ? store.arel_table['submitted_at'].lteq(at) : nil
 

--- a/app/views/releases/index.html.haml
+++ b/app/views/releases/index.html.haml
@@ -3,4 +3,9 @@
 %ul
   - @app_names.each do |app_name|
     %li
-      = link_to app_name, release_path(app_name)
+      %h5= app_name
+      %ul
+        %li
+          = link_to 'Pending and Deployed Releases', release_path(app_name)
+        %li
+          = link_to 'Unapproved Releases and Release Exception', unapproved_deployment_path(app_name)

--- a/app/views/releases/index.html.haml
+++ b/app/views/releases/index.html.haml
@@ -8,4 +8,4 @@
         %li
           = link_to 'Pending and Deployed Releases', release_path(app_name)
         %li
-          = link_to 'Unapproved Releases and Release Exception', unapproved_deployment_path(app_name)
+          = link_to 'Unapproved Releases and Release Exceptions', unapproved_deployment_path(app_name)

--- a/app/views/releases/index.html.haml
+++ b/app/views/releases/index.html.haml
@@ -2,7 +2,7 @@
 %p Click on an application below to view the pending and deployed releases.
 %ul
   - @app_names.each do |app_name|
-    %li
+    %li{id: app_name}
       %h5= app_name
       %ul
         %li

--- a/app/views/unapproved_deployments/show.html.haml
+++ b/app/views/unapproved_deployments/show.html.haml
@@ -17,25 +17,30 @@
 
 %h2 Unapproved Deployments
 %p
-  A list of all unapproved releases
+  A list of all releases, which were not approved at deployment time
   %br A release is unapproved if none of the associated tickets have been approved in JIRA and no repository owner has pointed a reason why there is no approved JIRA ticket.
 
 %table.table.table-condensed
   %thead
     %tr
       %th{width: '10%'} Version
-      %th{width: '25%'} Tickets
-      %th{width: '15%'} Deployed at
+      %th{width: '10%'} Tickets
+      %th{width: '10%'} Feature Reviews
+      %th{width: '20%'} Deployed at
       %th{width: '10%'} Deployed by
       %th{width: '40%'} Deploy Alert
   %tbody
   - @unapproved_deploys.each do |deploy|
-    %tr.pending-release.danger
+    - feature_reviews = feature_reviews_for_versions(@app_name, [deploy.version])
+    %tr.pending-release{class: ('danger' unless feature_reviews.any?(&:authorised?))}
       %td.monospace= commit_link(deploy.version, @github_repo_url)
-      - tickets = Repositories::TicketRepository.new.tickets_for_versions([deploy.version])
+      - tickets = tickets_for_versions([deploy.version])
       %td
         - tickets.each do |ticket|
           %div= jira_link(ticket.key)
+      %td
+        - feature_reviews.each do |feature_review|
+          %div= feature_review_link(feature_review)
       %td= time_with_timezone(deploy.deployed_at)
       %td= deploy.deployed_by
       %td= deploy.deploy_alert
@@ -51,19 +56,24 @@
     %tr
       %th{width: '10%'} Version
       %th{width: '10%'} Tickets
+      %th{width: '10%'} Feature Reviews
       %th{width: '15%'} Repo Owner
-      %th{width: '30%'} Release Exception
-      %th{width: '15%'} Release Exception posted at
-      %th{width: '15%'} Deployed By
-      %th{width: '15%'} Deployed At
+      %th{width: '25%'} Release Exception
+      %th{width: '10%'} Release Exception posted at
+      %th{width: '10%'} Deployed By
+      %th{width: '10%'} Deployed At
   %tbody
   - @release_exceptions.each do |release_exception|
     %tr.deployed-release
       %td.monospace= commit_link(release_exception.versions.last, @github_repo_url)
-      - tickets = Repositories::TicketRepository.new.tickets_for_versions(release_exception.versions)
+      - tickets = tickets_for_versions(release_exception.versions)
       %td
         - tickets.each do |ticket|
           %div= jira_link(ticket.key)
+      - feature_reviews = feature_reviews_for_versions(@app_name, release_exception.versions)
+      %td
+        - feature_reviews.each do |feature_review|
+          %div= feature_review_link(feature_review)
       %td= release_exception.repo_owner.email
       %td= release_exception.comment
       %td= time_with_timezone(release_exception.submitted_at)

--- a/app/views/unapproved_deployments/show.html.haml
+++ b/app/views/unapproved_deployments/show.html.haml
@@ -6,6 +6,15 @@
       %a(href="?region=#{tab_region}")
         %span #{flag_icon(tab_region.to_sym)} #{tab_region.upcase}
 
+%form.form-inline.unapproved-deploys-form{'accept-charset' => 'UTF-8', action: "/unapproved_deployments/#{@app_name}", method: 'get'}
+  .form-group
+    #datepicker.input-daterange.input-group
+      %span.input-group-addon From
+      %input#from_date.input-sm.form-control{name: 'start_date', type: 'text', style: 'width: 120px; height: 34px;', value: @start_date}/
+      %span.input-group-addon To
+      %input#to_date.input-sm.form-control{name: 'end_date', type: 'text', style: 'width: 120px; height: 34px;', value: @end_date}/
+  %input.btn.btn-primary{type: 'Submit', value: 'Search'}/
+
 %h2 Unapproved Deployments
 %p
   A list of all unapproved releases
@@ -32,7 +41,7 @@
       %td= deploy.deploy_alert
 
 
-%h2 Release Exceptions
+%h2 Repository Owner Commentaries
 %p
   A list of all releases, which were approved with a release exception published by a repository owner
   %br

--- a/app/views/unapproved_deployments/show.html.haml
+++ b/app/views/unapproved_deployments/show.html.haml
@@ -1,0 +1,64 @@
+- title "Unapproved Deployments for #{@app_name}"
+
+%ul.nav.nav-tabs
+  - Rails.configuration.deploy_regions.each do |tab_region|
+    %li{ class: ('active' if (tab_region == @region)), role: "presentation" }
+      %a(href="?region=#{tab_region}")
+        %span #{flag_icon(tab_region.to_sym)} #{tab_region.upcase}
+
+%h2 Unapproved Deployments
+%p
+  A list of all unapproved releases
+  %br A release is unapproved if none of the associated tickets have been approved in JIRA and no repository owner has pointed a reason why there is no approved JIRA ticket.
+
+%table.table.table-condensed
+  %thead
+    %tr
+      %th{width: '10%'} Version
+      %th{width: '25%'} Tickets
+      %th{width: '15%'} Deployed at
+      %th{width: '10%'} Deployed by
+      %th{width: '40%'} Deploy Alert
+  %tbody
+  - @unapproved_deploys.each do |deploy|
+    %tr.pending-release.danger
+      %td.monospace= commit_link(deploy.version, @github_repo_url)
+      - tickets = Repositories::TicketRepository.new.tickets_for_versions([deploy.version])
+      %td
+        - tickets.each do |ticket|
+          %div= jira_link(ticket.key)
+      %td= time_with_timezone(deploy.deployed_at)
+      %td= deploy.deployed_by
+      %td= deploy.deploy_alert
+
+
+%h2 Release Exceptions
+%p
+  A list of all releases, which were approved with a release exception published by a repository owner
+  %br
+
+%table.table.table-condensed
+  %thead
+    %tr
+      %th{width: '10%'} Version
+      %th{width: '10%'} Tickets
+      %th{width: '15%'} Repo Owner
+      %th{width: '30%'} Release Exception
+      %th{width: '15%'} Release Exception posted at
+      %th{width: '15%'} Deployed By
+      %th{width: '15%'} Deployed At
+  %tbody
+  - @release_exceptions.each do |release_exception|
+    %tr.deployed-release
+      %td.monospace= commit_link(release_exception.versions.last, @github_repo_url)
+      - tickets = Repositories::TicketRepository.new.tickets_for_versions(release_exception.versions)
+      %td
+        - tickets.each do |ticket|
+          %div= jira_link(ticket.key)
+      %td= release_exception.repo_owner.email
+      %td= release_exception.comment
+      %td= time_with_timezone(release_exception.submitted_at)
+      - deploy = @deploy_repository.deploys_for_versions(release_exception.versions, environment: 'production', region: @region).first
+      %td= deploy.deployed_by
+      %td= time_with_timezone(deploy.deployed_at)
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
 
   resources :releases, only: [:index, :show]
 
+  resources :unapproved_deployments, only: [:show]
+
   resources :repositories, only: [:index, :create, :edit, :update],
                            controller: 'git_repository_locations', as: 'git_repository_locations'
 

--- a/features/support/pages/releases_page.rb
+++ b/features/support/pages/releases_page.rb
@@ -8,7 +8,10 @@ module Pages
 
     def visit(app)
       page.visit url_helpers.releases_path
-      page.click_on(app)
+
+      page.within(:xpath, "//li[@id=\"#{app}\"]") do
+        page.click_on('Pending and Deployed Releases')
+      end
     end
 
     def pending_releases

--- a/spec/controllers/unapproved_deployments_controller_spec.rb
+++ b/spec/controllers/unapproved_deployments_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe UnapprovedDeploymentsController do
+  context 'when logged out' do
+    it { is_expected.to require_authentication_on(:get, :show, id: 'frontend') }
+  end
+
+  describe 'GET #show', :logged_in do
+    let(:app_name) { 'frontend' }
+    let(:release_exceptions) { double(:release_exceptions) }
+    let(:unapproved_deploys) { double(:unapproved_deploys) }
+
+    before do
+      allow_any_instance_of(Repositories::DeployRepository)
+        .to receive(:unapproved_production_deploys_for)
+        .with(any_args)
+        .and_return(unapproved_deploys)
+
+      allow_any_instance_of(Repositories::ReleaseExceptionRepository)
+        .to receive(:release_exception_for_application)
+        .with(any_args)
+        .and_return(release_exceptions)
+    end
+
+    it 'shows the list of commits for an app' do
+      get :show, id: app_name, region: 'gb'
+
+      expect(response).to have_http_status(:success)
+      expect(assigns(:app_name)).to eq(app_name)
+      expect(assigns(:release_exceptions)).to eq(release_exceptions)
+      expect(assigns(:unapproved_deploys)).to eq(unapproved_deploys)
+    end
+  end
+end

--- a/spec/models/repositories/deploy_repository_spec.rb
+++ b/spec/models/repositories/deploy_repository_spec.rb
@@ -6,8 +6,21 @@ RSpec.describe Repositories::DeployRepository do
 
   def apply_deploys(*deploy_events_data)
     deploy_events_data.each do |deploy_event_data|
-      repository.apply(build(:deploy_event, deploy_event_data))
+      deploy_event = create(:deploy_event, deploy_event_data)
+      repository.apply(deploy_event.reload)
     end
+  end
+
+  def apply_deploy_alert_for(version:, environment:, region:)
+    deploy = repository
+             .deploys_for_versions([version], environment: environment, region: region)
+             .first
+
+    Repositories::DeployAlertRepository.new.apply(
+      Events::DeployAlertEvent.new(
+        details: { deploy_uuid: deploy.uuid, message: 'Not Good!' },
+      ),
+    )
   end
 
   def expand_sha(sha)
@@ -119,11 +132,14 @@ RSpec.describe Repositories::DeployRepository do
           defaults.merge(version: expand_sha('jkl'), locale: 'gb'),
         )
 
-        expect(repository.deploys_for_versions(versions, environment: environment, region: 'us'))
-          .to match_array([
-            Deploy.new(defaults.merge(version: versions.first, deployed_by: 'Car', region: 'us')),
-            Deploy.new(defaults.merge(version: versions.second, region: 'us')),
-          ])
+        deploys = repository.deploys_for_versions(versions, environment: environment, region: 'us')
+
+        expect(deploys.map { |deploy|
+          deploy.attributes.slice(:version, :deployed_by, :region)
+        }).to match_array([
+          { version: versions.first, deployed_by: 'Car', region: 'us' },
+          { version: versions.second, deployed_by: 'Bob', region: 'us' },
+        ])
       end
     end
 
@@ -153,16 +169,14 @@ RSpec.describe Repositories::DeployRepository do
       apply_deploys(defaults.merge(version: expand_sha('abc')))
       results = repository.deploys_for(apps: apps, server: server)
 
-      expect(results).to eq([
-        Deploy.new(defaults.merge(version: expand_sha('abc'), correct: true, region: 'gb')),
-      ])
+      expect(results.count).to eq(1)
+      expect(results.first).to have_attributes(version: expand_sha('abc'), correct: true, region: 'gb')
 
       apply_deploys(defaults.merge(version: expand_sha('def')))
       results = repository.deploys_for(apps: apps, server: server)
 
-      expect(results).to eq([
-        Deploy.new(defaults.merge(version: expand_sha('def'), correct: false, region: 'gb')),
-      ])
+      expect(results.count).to eq(1)
+      expect(results.first).to have_attributes(version: expand_sha('def'), correct: false, region: 'gb')
     end
 
     it 'is case insensitive when a repo name and the event app name do not match in case' do
@@ -170,7 +184,8 @@ RSpec.describe Repositories::DeployRepository do
 
       results = repository.deploys_for(apps: apps, server: server)
 
-      expect(results).to eq([Deploy.new(defaults.merge(app_name: 'frontend', correct: true, region: 'gb'))])
+      expect(results.count).to eq(1)
+      expect(results.first).to have_attributes(app_name: 'frontend', correct: true, region: 'gb')
     end
 
     it 'ignores the deploys event when it is for another server' do
@@ -202,9 +217,12 @@ RSpec.describe Repositories::DeployRepository do
           defaults.merge(app_name: 'backend'),
         )
 
-        expect(repository.deploys_for(apps: apps, server: server)).to match_array([
-          Deploy.new(defaults.merge(app_name: 'frontend', correct: true, region: 'gb')),
-          Deploy.new(defaults.merge(app_name: 'backend', correct: true, region: 'gb')),
+        deploys = repository.deploys_for(apps: apps, server: server)
+        expect(deploys.map { |deploy|
+          deploy.attributes.slice(:app_name, :correct, :region)
+        }).to match_array([
+          { app_name: 'frontend', correct: true, region: 'gb' },
+          { app_name: 'backend', correct: true, region: 'gb' },
         ])
       end
     end
@@ -221,17 +239,11 @@ RSpec.describe Repositories::DeployRepository do
 
         results = repository.deploys_for(server: 'x.io')
 
-        expect(results).to match_array([
-          Deploy.new(
-            defaults.merge(
-              app_name: 'a', server: 'x.io', version: expand_sha('1'), correct: false, region: 'us',
-            ),
-          ),
-          Deploy.new(
-            defaults.merge(
-              app_name: 'b', server: 'x.io', version: expand_sha('2'), correct: false, region: 'us',
-            ),
-          ),
+        expect(results.map { |deploy|
+          deploy.attributes.slice(:app_name, :server, :version, :correct, :region)
+        }).to match_array([
+          { app_name: 'a', server: 'x.io', version: expand_sha('1'), correct: false, region: 'us' },
+          { app_name: 'b', server: 'x.io', version: expand_sha('2'), correct: false, region: 'us' },
         ])
       end
     end
@@ -257,19 +269,40 @@ RSpec.describe Repositories::DeployRepository do
           at: time + 1.second,
         )
 
-        expect(results).to match_array([
-          Deploy.new(
-            app_name: 'app1',
-            server: 'x.io',
-            version: expand_sha('abc'),
-            deployed_by: 'dj',
-            region: 'us',
-            correct: true,
-            environment: 'uat',
-            deployed_at: time,
-          ),
-        ])
+        expect(results.count).to eq(1)
+        expect(results.first).to have_attributes(
+          app_name: 'app1',
+          server: 'x.io',
+          version: expand_sha('abc'),
+          deployed_by: 'dj',
+          region: 'us',
+          correct: true,
+          environment: 'uat',
+          deployed_at: time,
+        )
       end
+    end
+  end
+
+  describe '#unapproved_production_deploys_for' do
+    let(:defaults) { { app_name: 'frontend', deployed_by: 'Bob', locale: 'gb' } }
+
+    it 'returns the unapproved production deploys for a specified region' do
+      apply_deploys(
+        defaults.merge(environment: 'uat', version: expand_sha('def')),
+        defaults.merge(environment: 'uat', version: expand_sha('ghi')),
+        defaults.merge(environment: 'production', version: expand_sha('abc')),
+        defaults.merge(environment: 'production', version: expand_sha('xyz')),
+        defaults.merge(environment: 'production', version: expand_sha('xyz'), locale: 'us'),
+      )
+
+      apply_deploy_alert_for(version: expand_sha('xyz'), environment: 'production', region: 'gb')
+
+      deploys = repository.unapproved_production_deploys_for(app_name: 'frontend', region: 'gb')
+      expect(deploys.count).to eq(1)
+      expect(deploys.first.region).to eq('gb')
+      expect(deploys.first.environment).to eq('production')
+      expect(deploys.first.deploy_alert).to eq('Not Good!')
     end
   end
 
@@ -306,17 +339,20 @@ RSpec.describe Repositories::DeployRepository do
       end
 
       it 'returns the latest non-production deploy for the version under review' do
-        expect(repository.last_staging_deploy_for_versions([version])).to eq(
-          Deploy.new(defaults.merge(server: 'b', version: version, region: 'de')),
-        )
+        deploy = repository.last_staging_deploy_for_versions([version])
+
+        expect(deploy.version).to eq(version)
+        expect(deploy.server).to eq('b')
+        expect(deploy.region).to eq('de')
       end
 
       it 'looks for any non-production environments' do
         apply_deploys(defaults.merge(server: 'c', environment: 'uat', version: version))
 
-        expect(repository.last_staging_deploy_for_versions([version])).to eq(
-          Deploy.new(defaults.merge(server: 'c', version: version, region: 'de')),
-        )
+        deploy = repository.last_staging_deploy_for_versions([version])
+        expect(deploy.version).to eq(version)
+        expect(deploy.server).to eq('c')
+        expect(deploy.region).to eq('de')
       end
     end
   end

--- a/spec/models/repositories/release_exception_repository_spec.rb
+++ b/spec/models/repositories/release_exception_repository_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe Repositories::ReleaseExceptionRepository do
     allow(CommitStatusUpdateJob).to receive(:perform_later)
   end
 
+  describe '#release_exception_for_application' do
+    it 'returns all release exceptions for a given app' do
+      events = [
+        create_exception_event(apps: [%w(app1 3)]),
+        create_exception_event(apps: [%w(app2 2)]),
+        create_exception_event(apps: [%w(app1 1)]),
+      ]
+
+      events.each do |event|
+        repository.apply(event)
+      end
+
+      result = repository.release_exception_for_application(app_name: 'app1')
+
+      expect(result.count).to eq(2)
+    end
+  end
+
   describe '#apply' do
     context 'event is made by a repo owner' do
       let(:event) {
@@ -77,6 +95,7 @@ RSpec.describe Repositories::ReleaseExceptionRepository do
       email: 'test@example.com',
       comment: 'Good to go',
       approved: false,
+      created_at: Time.now,
     }
 
     build(:release_exception_event, default.merge(options))


### PR DESCRIPTION
Creates a report page of unapproved deployments and release exception for a given app.

Original ticket: https://jira.fundingcircle.com/browse/GQ-30

The new page is accessible from Releases -> choose app from the list -> click "Unapproved Releases and Release Exception" for chosen app

There is a datepicker for the time period. 
The first table shows all unapproved deployments.
The second table shows all release exceptions written and whether they were submitted after or before the deployment.

The page looks like the current releases show page.