### PR TITLE
Ensure Bundler gem exists

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,8 @@ test:
     - bundle exec rubocop -D
   post:
     - bundle exec rake codeclimate
-    - "curl --header 'Accept: application/json' https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?circle-token=$CIRCLE_TOKEN | curl --request POST --header 'Content-Type:application/json' --data @- --fail $SHIPMENT_TRACKER_POST_URL"
+    - |
+      if [ "$CIRCLE_PROJECT_USERNAME" == "FundingCircle" ]; then
+        curl --header 'Accept: application/json' https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?circle-token=$CIRCLE_TOKEN \
+        | curl --request POST --header 'Content-Type:application/json' --data @- --fail $SHIPMENT_TRACKER_POST_URL
+      fi

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - gem update bundler
+    - gem install bundler --no-doc
 test:
   override:
     - bundle exec rake spec


### PR DESCRIPTION
💁  The [current master build can fail](https://circleci.com/gh/sgerrand/shipment_tracker/1) due to `rvm` ✨  and differences in the build environment (my fork is using Ubuntu 14.04, this repository is still using 12.04):

```
bash: line 1: bundle: command not found
bash: line 1: bundle: command not found

bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3  returned exit code 127

Action failed: bundle install
```

Not a great experience for potential contributors. 😾 

Using `gem upgrade <gem>` inside rvm produces unpredictable results. Changing over to `gem install <gem>` ensures that the gem is both installed and up-to-date.