### PR TITLE
Consider Unknown versions in unapproved deploys report

### DIFF
--- a/app/views/unapproved_deployments/show.html.haml
+++ b/app/views/unapproved_deployments/show.html.haml
@@ -33,7 +33,8 @@
   - @unapproved_deploys.each do |deploy|
     - feature_reviews = feature_reviews_for_versions(@app_name, [deploy.version])
     %tr.pending-release{class: ('danger' unless feature_reviews.any?(&:authorised?))}
-      %td.monospace= commit_link(deploy.version, @github_repo_url)
+      %td.monospace
+        = deploy.version.present? ? commit_link(deploy.version, @github_repo_url) : 'Unknown Version'
       - tickets = tickets_for_versions([deploy.version])
       %td
         - tickets.each do |ticket|

--- a/app/views/unapproved_deployments/show.html.haml
+++ b/app/views/unapproved_deployments/show.html.haml
@@ -55,13 +55,12 @@
   %thead
     %tr
       %th{width: '10%'} Version
-      %th{width: '10%'} Tickets
+      %th{width: '15%'} Tickets
       %th{width: '10%'} Feature Reviews
       %th{width: '15%'} Repo Owner
-      %th{width: '25%'} Release Exception
-      %th{width: '10%'} Release Exception posted at
-      %th{width: '10%'} Deployed By
-      %th{width: '10%'} Deployed At
+      %th{width: '30%'} Release Exception
+      %th{width: '20%'} Release Exception posted at
+
   %tbody
   - @release_exceptions.each do |release_exception|
     %tr.deployed-release
@@ -77,7 +76,4 @@
       %td= release_exception.repo_owner.email
       %td= release_exception.comment
       %td= time_with_timezone(release_exception.submitted_at)
-      - deploy = @deploy_repository.deploys_for_versions(release_exception.versions, environment: 'production', region: @region).first
-      %td= deploy.present? ? deploy.deployed_by : 'Not Deployed'
-      %td= deploy.present? ? time_with_timezone(deploy.deployed_at) : 'Not Deployed'
 


### PR DESCRIPTION
When a deployment notification is sent without specified commit SHA, the deployment is not associated with any software version. That leads to undefined method errors on the unapproved deployments page. 🙅 

Honeybadger link: https://app.honeybadger.io/projects/44071/faults/33406513

Release exception are currently not associated with deploys, because deploys are related to merge commit, but release exception to the previous commits. That's why there is no benefits at the moment to search for deploys related to release exceptions.