### PR TITLE
Force html format for unapproved deployments

### DIFF
--- a/app/controllers/unapproved_deployments_controller.rb
+++ b/app/controllers/unapproved_deployments_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class UnapprovedDeploymentsController < ApplicationController
-  before_action :update_region_cookies, only: [:show]
+  before_action :force_html_format, only: :show
+  before_action :update_region_cookies, only: :show
 
   def show
     update_region_cookies


### PR DESCRIPTION
It's the same issue as the one fixed in #127 
The page for applications ending in `.js` is not rendered correctly at the moment.