### PR TITLE
[PO-2870] Improve alerts for unauthorised deploys

### DIFF
--- a/app/models/deploy_alert.rb
+++ b/app/models/deploy_alert.rb
@@ -4,50 +4,59 @@ require 'git_repository_loader'
 require 'git_repository_location'
 
 class DeployAlert
-  attr_reader :deploy_env
+  attr_reader :current_deploy, :previous_deploy, :deploy_auditor
+
+  def initialize(current_deploy, previous_deploy = nil)
+    @current_deploy = current_deploy
+    @previous_deploy = previous_deploy
+    @deploy_auditor = DeployAuditor.new(current_deploy, previous_deploy)
+  end
 
   def self.auditable?(current_deploy)
     return false unless current_deploy.environment == 'production'
     GitRepositoryLocation.app_names.include?(current_deploy.app_name)
   end
 
-  def self.audit_message(current_deploy, previous_deploy = nil)
-    deploy_auditor = DeployAuditor.new(current_deploy, previous_deploy)
+  def self.audit_message(*args)
+    new(*args).audit_message
+  end
 
+  def audit_message
     if deploy_auditor.unknown_version?
-      alert_unknown_version(current_deploy)
+      alert_unknown_version
     elsif deploy_auditor.not_on_master?
-      alert_not_on_master(current_deploy)
+      alert_not_on_master
     elsif deploy_auditor.rollback?
-      alert_rollback(current_deploy)
+      alert_rollback
     elsif !deploy_auditor.recent_releases_authorised?
-      alert_not_authorised(current_deploy, deploy_auditor)
+      alert_not_authorised
     end
   end
 
-  def self.alert_not_authorised(deploy, deploy_auditor)
-    "#{alert_header(deploy)}Release not authorised; Feature Review not approved.\n" \
+  private
+
+  def alert_not_authorised
+    "#{alert_header}Release not authorised; Feature Review not approved.\n" \
     "#{deploy_auditor.unauthorised_releases}"
   end
 
-  def self.alert_not_on_master(deploy)
-    "#{alert_header(deploy)}Version does not exist on GitHub master branch."
+  def alert_not_on_master
+    "#{alert_header}Version does not exist on GitHub master branch."
   end
 
-  def self.alert_unknown_version(deploy)
-    "#{alert_header(deploy)}Deploy event sent to Shipment Tracker contains an unknown software version."
+  def alert_unknown_version
+    "#{alert_header}Deploy event sent to Shipment Tracker contains an unknown software version."
   end
 
-  def self.alert_rollback(deploy)
-    "#{alert_header(deploy)}Old release deployed. Was the rollback intentional?"
+  def alert_rollback
+    "#{alert_header}Old release deployed. Was the rollback intentional?"
   end
 
-  def self.alert_header(deploy)
-    time = deploy.deployed_at.strftime('%F %H:%M%:z')
-    "#{deploy.region.upcase} Deploy Alert for #{deploy.app_name} at #{time}.\n" \
-    "#{deploy.deployed_by} deployed #{deploy.version || 'unknown version'}.\n"
+  def alert_header
+    time = current_deploy.deployed_at.strftime('%F %H:%M%:z')
+    "#{current_deploy.region.upcase} Deploy Alert for #{current_deploy.app_name} at #{time}.\n" \
+    "#{current_deploy.deployed_by} deployed #{current_deploy.version || 'unknown version'}.\n"
   end
-  private_class_method :alert_header
 
   class DeployAuditor
     def initialize(current_deploy, previous_deploy = nil)

--- a/app/views/unapproved_deployments/show.html.haml
+++ b/app/views/unapproved_deployments/show.html.haml
@@ -44,7 +44,7 @@
           %div= feature_review_link(feature_review)
       %td= time_with_timezone(deploy.deployed_at)
       %td= deploy.deployed_by
-      %td= deploy.deploy_alert
+      %td= simple_format(deploy.deploy_alert)
 
 
 %h2 Repository Owner Commentaries

--- a/features/deploy_alert.feature
+++ b/features/deploy_alert.feature
@@ -32,8 +32,8 @@ Scenario: Release has no approved Feature Reviews
   When commit "#merge1" of "frontend" is deployed by "Joe" to production at "2016-01-22 17:34:20"
   Then a deploy alert should be dispatched for
     | method | app_name | version | time                      | deployer | message                                              | to                    |
-    | slack  | frontend | #merge1 | 2016-01-22 17:34+00:00    | Joe      | Release not authorised; Feature Review not approved. |                       |
-    | email  | frontend | #merge1 | 2016-01-22 17:34:20+00:00 | Joe      | Release not authorised; Feature Review not approved. | bob@fundingcircle.com |
+    | slack  | frontend | #merge1 | 2016-01-22 17:34+00:00    | Joe      | Release not authorised; Feature Review not approved.\n* Alice 8549b56d80ba94577c14a0d5286a9fec924b20a6 Not Approved |                       |
+    | email  | frontend | #merge1 | 2016-01-22 17:34:20+00:00 | Joe      | Release not authorised; Feature Review not approved.\n* Alice 8549b56d80ba94577c14a0d5286a9fec924b20a6 Not Approved | bob@fundingcircle.com |
 
 Scenario: Dependent release has no approved Feature Reviews
   Given an application called "frontend"
@@ -75,7 +75,7 @@ Scenario: Dependent release has no approved Feature Reviews
   When commit "#merge2" of "frontend" is deployed by "Joe" to production at "2016-01-24 17:34:20"
   Then a deploy alert should be dispatched for
     | app_name | version | time                   | deployer | message                                              |
-    | frontend | #merge2 | 2016-01-24 17:34+00:00 | Joe      | Release not authorised; Feature Review not approved. |
+    | frontend | #merge2 | 2016-01-24 17:34+00:00 | Joe      | Release not authorised; Feature Review not approved.\n* Alice 8549b56d80ba94577c14a0d5286a9fec924b20a6 Not Approved |
 
 Scenario: Rollback to an older software version
   Given an application called "frontend"

--- a/spec/models/deploy_alert_spec.rb
+++ b/spec/models/deploy_alert_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe DeployAlert do
         version: '#new',
         region: 'gb',
         deployed_at: Time.current,
-        deployed_by: 'Devloper',
+        deployed_by: 'Developer',
       )
     }
 
@@ -74,7 +74,7 @@ RSpec.describe DeployAlert do
         version: '#old',
         region: 'gb',
         deployed_at: 1.hour.ago,
-        deployed_by: 'Devloper',
+        deployed_by: 'Developer',
       )
     }
 
@@ -107,7 +107,7 @@ RSpec.describe DeployAlert do
             app_name: 'some_app',
             version: nil,
             region: 'gb',
-            deployed_by: 'Devloper',
+            deployed_by: 'Developer',
             deployed_at: Time.current,
           )
         }
@@ -129,7 +129,7 @@ RSpec.describe DeployAlert do
             app_name: 'some_app',
             version: 'asdfoim?asgd/adsg/\asdg\sd',
             region: 'gb',
-            deployed_by: 'Devloper',
+            deployed_by: 'Developer',
             deployed_at: Time.current,
           )
         }
@@ -148,11 +148,14 @@ RSpec.describe DeployAlert do
     describe 'Alert: unauthorised release' do
       context 'when it is the first production deploy' do
         context 'when release is not authorized' do
-          let(:release) { instance_double(Release, authorised?: false) }
+          let(:commit) { instance_double(GitCommit, id: 'commit_id', author_name: 'Developer') }
+          let(:release) { instance_double(Release, authorised?: false, commit: commit) }
 
           it 'returns an alert message for unauthorised release' do
             actual = DeployAlert.audit_message(current_deploy)
-            expected = message(current_deploy, 'Release not authorised; Feature Review not approved.')
+            expected = message(current_deploy, "Release not authorised; Feature Review not approved.\n" \
+                               "* #{release.commit.author_name} #{release.commit.id} " \
+                               "#{release.authorised? ? 'Approved' : 'Not Approved'}")
 
             expect(actual).to eq(expected)
           end
@@ -169,12 +172,14 @@ RSpec.describe DeployAlert do
 
       context 'when there are previous deploys to production' do
         context 'when release is not authorized' do
-          let(:release) { instance_double(Release, authorised?: false) }
+          let(:commit) { instance_double(GitCommit, id: 'commit_id', author_name: 'Developer') }
+          let(:release) { instance_double(Release, authorised?: false, commit: commit) }
 
           it 'returns an alert message for unauthorised release' do
             actual = DeployAlert.audit_message(current_deploy, previous_deploy)
-            expected = message(current_deploy, 'Release not authorised; Feature Review not approved.')
-
+            expected = message(current_deploy, "Release not authorised; Feature Review not approved.\n" \
+                               "* #{release.commit.author_name} #{release.commit.id} " \
+                               "#{release.authorised? ? 'Approved' : 'Not Approved'}")
             expect(actual).to eq(expected)
           end
         end
@@ -209,7 +214,7 @@ RSpec.describe DeployAlert do
               version: nil,
               region: 'gb',
               deployed_at: 1.hour.ago,
-              deployed_by: 'Devloper',
+              deployed_by: 'Developer',
             )
           }
 


### PR DESCRIPTION
When a deploy happens all other merges that happened since the last deployment are considered. If any of these have not been authorised, a list of their SHAs will be added in the deploy alert message.

Relates:
- [x] JIRA :gem:: https://jira.fundingcircle.com/browse/PO-2870