### PR TITLE
[PO-3612] QA text persistence

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -122,3 +122,11 @@ strong.summary {
 .unapproved-deploys-form {
   margin-top: 30px;
 }
+
+.qa-comments-list{
+  list-style-type: none;
+}
+
+.qa-comment {
+  margin-top: 15px;
+}

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -34,7 +34,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def app_url_for_version(version)
-    app_name = related_app_versions.find{ |_, versions| versions.include?(version) }
+    app_name = related_app_versions.find { |_, versions| versions.include?(version) }
     return unless app_name
 
     github_repo_urls[app_name.first]

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -7,15 +7,15 @@ require 'qa_submission'
 require 'ticket'
 
 class FeatureReviewWithStatuses < SimpleDelegator
-  attr_reader :builds, :qa_submission, :release_exception, :tickets, :time
+  attr_reader :builds, :qa_submissions, :release_exception, :tickets, :time
 
-  def initialize(feature_review, builds: {}, qa_submission: nil, tickets: [], release_exception: nil, at: nil)
+  def initialize(feature_review, builds: {}, qa_submissions: nil, tickets: [], release_exception: nil, at: nil)
     super(feature_review)
     @feature_review = feature_review
     @time = at
     @builds = builds
     @release_exception = release_exception
-    @qa_submission = qa_submission
+    @qa_submissions = qa_submissions
     @tickets = tickets
   end
 
@@ -31,6 +31,11 @@ class FeatureReviewWithStatuses < SimpleDelegator
 
       [app_name, latest_commit]
     end
+  end
+
+  def app_url_for_version(version)
+    app_name = related_app_versions.find{ |_, versions| versions.include?(version) }.first
+    github_repo_urls[app_name]
   end
 
   def build_status
@@ -51,8 +56,8 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def qa_status
-    return unless qa_submission
-    qa_submission.accepted ? :success : :failure
+    return unless qa_submissions.present?
+    qa_submissions.last.accepted ? :success : :failure
   end
 
   def summary_status

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -34,8 +34,10 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def app_url_for_version(version)
-    app_name = related_app_versions.find{ |_, versions| versions.include?(version) }.first
-    github_repo_urls[app_name]
+    app_name = related_app_versions.find{ |_, versions| versions.include?(version) }
+    return unless app_name
+
+    github_repo_urls[app_name.first]
   end
 
   def build_status

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,8 @@ module ApplicationHelper
   end
 
   def commit_link(version, github_repo_url)
+    return unless version && github_repo_url
+
     github_commit_url = "#{github_repo_url}/commit/#{version}"
     link_to short_sha(version), github_commit_url, target: '_blank'
   end

--- a/app/models/factories/feature_review_factory.rb
+++ b/app/models/factories/feature_review_factory.rb
@@ -26,7 +26,7 @@ module Factories
       apps = query_hash.fetch('apps', {})
       versions = get_related_versions(apps)
 
-      create(
+      FeatureReview.new(
         path: whitelisted_path(uri, query_hash),
         versions: versions,
       )
@@ -36,17 +36,13 @@ module Factories
       uri = Addressable::URI.parse('/feature_reviews').normalize
       query_hash = { 'apps' => apps }
 
-      create(
+      FeatureReview.new(
         path: whitelisted_path(uri, query_hash),
         versions: get_app_versions(apps),
       )
     end
 
     private
-
-    def create(attrs)
-      FeatureReview.new(attrs)
-    end
 
     def get_related_versions(apps)
       related_versions = GitRepositoryLoader.from_rails_config

--- a/app/models/factories/feature_review_factory.rb
+++ b/app/models/factories/feature_review_factory.rb
@@ -23,38 +23,18 @@ module Factories
     def create_from_url_string(url)
       uri = Addressable::URI.parse(url).normalize
       query_hash = Rack::Utils.parse_nested_query(uri.query)
-      apps = query_hash.fetch('apps', {})
-      versions = get_related_versions(apps)
 
-      FeatureReview.new(
-        path: whitelisted_path(uri, query_hash),
-        versions: versions,
-      )
+      FeatureReview.new(path: whitelisted_path(uri, query_hash))
     end
 
     def create_from_apps(apps)
       uri = Addressable::URI.parse('/feature_reviews').normalize
       query_hash = { 'apps' => apps }
 
-      FeatureReview.new(
-        path: whitelisted_path(uri, query_hash),
-        versions: get_app_versions(apps),
-      )
+      FeatureReview.new(path: whitelisted_path(uri, query_hash))
     end
 
     private
-
-    def get_related_versions(apps)
-      related_versions = GitRepositoryLoader.from_rails_config
-                                            .load(apps.keys.first)
-                                            .get_dependent_commits(apps.values.first)
-                                            .map(&:id)
-      related_versions + get_app_versions(apps)
-    end
-
-    def get_app_versions(apps)
-      apps.values.reject(&:blank?)
-    end
 
     def whitelisted_path(uri, query_hash)
       "#{uri.path}?#{query_hash.extract!(*QUERY_PARAM_WHITELIST).to_query}"

--- a/app/models/feature_review.rb
+++ b/app/models/feature_review.rb
@@ -9,7 +9,6 @@ class FeatureReview
 
   values do
     attribute :path, String
-    attribute :versions, Array
   end
 
   def app_versions
@@ -18,6 +17,19 @@ class FeatureReview
 
   def app_names
     app_versions.keys
+  end
+
+  def versions
+    app_versions.values.sort
+  end
+
+  def related_app_versions
+    app_versions.each_with_object({}) do |(app, version), hash|
+      hash[app] = GitRepositoryLoader.from_rails_config
+                                     .load(app)
+                                     .get_dependent_commits(version)
+                                     .map(&:id) + [version]
+    end
   end
 
   def query_hash

--- a/app/models/qa_submission.rb
+++ b/app/models/qa_submission.rb
@@ -3,6 +3,7 @@ class QaSubmission
   include Virtus.value_object
 
   values do
+    attribute :versions, Array
     attribute :email, String
     attribute :comment, String
     attribute :accepted, Boolean

--- a/app/models/queries/feature_review_query.rb
+++ b/app/models/queries/feature_review_query.rb
@@ -44,7 +44,7 @@ module Queries
 
     def qa_submissions
       manual_test_repository.qa_submissions_for(
-        versions: feature_review.related_app_versions,
+        versions: feature_review.related_app_versions.values.flatten,
         at: time,
       )
     end

--- a/app/models/queries/feature_review_query.rb
+++ b/app/models/queries/feature_review_query.rb
@@ -44,14 +44,14 @@ module Queries
 
     def qa_submission
       manual_test_repository.qa_submission_for(
-        versions: feature_review.versions,
+        versions: feature_review.related_app_versions.values.flatten,
         at: time,
       )
     end
 
     def release_exception
       release_exception_repository.release_exception_for(
-        versions: feature_review.versions,
+        versions: feature_review.app_versions,
         at: time,
       )
     end

--- a/app/models/queries/feature_review_query.rb
+++ b/app/models/queries/feature_review_query.rb
@@ -28,7 +28,7 @@ module Queries
       @feature_review_with_statuses = FeatureReviewWithStatuses.new(
         feature_review,
         builds: builds,
-        qa_submission: qa_submission,
+        qa_submissions: qa_submissions,
         release_exception: release_exception,
         tickets: tickets,
         at: time,
@@ -42,16 +42,16 @@ module Queries
       )
     end
 
-    def qa_submission
-      manual_test_repository.qa_submission_for(
-        versions: feature_review.related_app_versions.values.flatten,
+    def qa_submissions
+      manual_test_repository.qa_submissions_for(
+        versions: feature_review.related_app_versions,
         at: time,
       )
     end
 
     def release_exception
       release_exception_repository.release_exception_for(
-        versions: feature_review.app_versions,
+        versions: feature_review.versions,
         at: time,
       )
     end

--- a/app/models/repositories/manual_test_repository.rb
+++ b/app/models/repositories/manual_test_repository.rb
@@ -31,14 +31,14 @@ module Repositories
       query = at ? table['created_at'].lteq(at) : nil
       store
         .where(query)
-        .where(table['versions'].eq(prepared_versions(versions)))
+        .where('versions && ?', prepared_versions(versions))
         .order('id DESC')
         .first
         .try { |result| QaSubmission.new(result.attributes) }
     end
 
     def prepared_versions(versions)
-      versions.sort
+      "{#{versions.sort.join(',')}}"
     end
 
     def table

--- a/app/models/repositories/manual_test_repository.rb
+++ b/app/models/repositories/manual_test_repository.rb
@@ -9,14 +9,13 @@ module Repositories
       @store = store
     end
 
-    def qa_submission_for(versions:, at: nil)
+    def qa_submissions_for(versions:, at: nil)
       query = at ? table['created_at'].lteq(at) : nil
       store
         .where(query)
         .where('versions && ?', prepared_versions(versions))
-        .order('id DESC')
-        .first
-        .try { |result| QaSubmission.new(result.attributes) }
+        .order('id ASC')
+        .map{ |manual_test| create_qa_submission(manual_test) }
     end
 
     def apply(event)
@@ -39,6 +38,10 @@ module Repositories
 
     def table
       store.arel_table
+    end
+
+    def create_qa_submission(manual_test)
+      manual_test.try { |result| QaSubmission.new(result.attributes) }
     end
   end
 end

--- a/app/models/repositories/manual_test_repository.rb
+++ b/app/models/repositories/manual_test_repository.rb
@@ -10,7 +10,13 @@ module Repositories
     end
 
     def qa_submission_for(versions:, at: nil)
-      qa_submission(versions, at)
+      query = at ? table['created_at'].lteq(at) : nil
+      store
+        .where(query)
+        .where('versions && ?', prepared_versions(versions))
+        .order('id DESC')
+        .first
+        .try { |result| QaSubmission.new(result.attributes) }
     end
 
     def apply(event)
@@ -26,16 +32,6 @@ module Repositories
     end
 
     private
-
-    def qa_submission(versions, at)
-      query = at ? table['created_at'].lteq(at) : nil
-      store
-        .where(query)
-        .where('versions && ?', prepared_versions(versions))
-        .order('id DESC')
-        .first
-        .try { |result| QaSubmission.new(result.attributes) }
-    end
 
     def prepared_versions(versions)
       "{#{versions.sort.join(',')}}"

--- a/app/models/repositories/manual_test_repository.rb
+++ b/app/models/repositories/manual_test_repository.rb
@@ -15,7 +15,7 @@ module Repositories
         .where(query)
         .where('versions && ?', prepared_versions(versions))
         .order('id ASC')
-        .map{ |manual_test| create_qa_submission(manual_test) }
+        .map { |manual_test| create_qa_submission(manual_test) }
     end
 
     def apply(event)

--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -98,13 +98,22 @@
 
     - panel(heading: 'QA Acceptance', klass: 'qa-submission', status: @feature_review_with_statuses.qa_status) do
       .panel-body
-        - if @feature_review_with_statuses.qa_submission
-          %p
-            %span.qa-email
-              %strong= @feature_review_with_statuses.qa_submission.email
-            at
-            %span.qa-time= @feature_review_with_statuses.qa_submission.created_at
-          = simple_format(@feature_review_with_statuses.qa_submission.comment, class: 'qa-comment')
+        - if @feature_review_with_statuses.qa_submissions.present?
+          %ul.list-group{ style: 'list-style-type: none;' }
+            - @feature_review_with_statuses.qa_submissions.each do |qa_submission|
+              %li
+                %p
+                  - icon(item_status_icon_class(qa_submission.accepted))
+                  %span.qa-email
+                    %strong= qa_submission.email
+                  at
+                  %span.qa-time= qa_submission.created_at
+                - qa_submission.versions.each do |version|
+                  = commit_link(version, @feature_review_with_statuses.app_url_for_version(version))
+                = simple_format(qa_submission.comment, class: 'qa-comment')
+
+                - unless qa_submission == @feature_review_with_statuses.qa_submissions.last
+                  %hr
         - else
           Not reviewed by QA
       .panel-footer

--- a/app/views/feature_reviews/show.html.haml
+++ b/app/views/feature_reviews/show.html.haml
@@ -99,7 +99,7 @@
     - panel(heading: 'QA Acceptance', klass: 'qa-submission', status: @feature_review_with_statuses.qa_status) do
       .panel-body
         - if @feature_review_with_statuses.qa_submissions.present?
-          %ul.list-group{ style: 'list-style-type: none;' }
+          %ul.list-group.qa-comments-list
             - @feature_review_with_statuses.qa_submissions.each do |qa_submission|
               %li
                 %p
@@ -108,8 +108,8 @@
                     %strong= qa_submission.email
                   at
                   %span.qa-time= qa_submission.created_at
-                - qa_submission.versions.each do |version|
-                  = commit_link(version, @feature_review_with_statuses.app_url_for_version(version))
+                - version_links = qa_submission.versions.map { |version| commit_link(version, @feature_review_with_statuses.app_url_for_version(version)) }
+                = raw version_links.compact.join(' | ')
                 = simple_format(qa_submission.comment, class: 'qa-comment')
 
                 - unless qa_submission == @feature_review_with_statuses.qa_submissions.last

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -231,8 +231,9 @@ Scenario: QA rejects feature
 
   And I reload the page after a while
   Then I should see the QA acceptance
-    | status  | email       | comment |
-    | success | foo@bar.com | Superb! |
+    | status  | email       | comment         |
+    | danger  | foo@bar.com | Not good enough |
+    | success | foo@bar.com | Superb!         |
 
 Scenario: QA has approved previous commit
   Given an application called "frontend"
@@ -267,6 +268,7 @@ Scenario: QA has approved previous commit
   When I reload the page after a while
   Then I should see the QA acceptance
     | status   | email       | comment            |
+    | success  | foo@bar.com | All good           |
     | danger   | foo@bar.com | Needs improvements |
 
 Scenario: Repo Owner approves feature

--- a/features/feature_review.feature
+++ b/features/feature_review.feature
@@ -234,6 +234,41 @@ Scenario: QA rejects feature
     | status  | email       | comment |
     | success | foo@bar.com | Superb! |
 
+Scenario: QA has approved previous commit
+  Given an application called "frontend"
+  And a commit "#initial" by "Bob" is created at "2017-08-24 08:00:00" for app "frontend"
+  And the branch "new-branch" is checked out
+  And the branch "new-branch" is merged with merge commit "#merge1" at "2017-08-24 09:00:00"
+  And a commit "#abc" by "Alice" is created at "2017-08-24 10:00:00" for app "frontend"
+  And a commit "#def" by "Alice" is created at "2017-08-24 11:00:00" for app "frontend"
+  And I am logged in as "foo@bar.com"
+  And developer prepares review known as "review1" with apps
+    | app_name | version |
+    | frontend | #abc    |
+  And developer prepares review known as "review2" with apps
+    | app_name | version |
+    | frontend | #def    |
+
+  When I visit the feature review known as "review1"
+  Then I should see the QA acceptance with heading "warning"
+  When I "accept" the feature with comment "All good" as a QA
+  Then I should see an alert: "Thank you for your submission. It will appear in a moment."
+  When I reload the page after a while
+  Then I should see the QA acceptance
+    | status   | email       | comment  |
+    | success  | foo@bar.com | All good |
+
+  When I visit the feature review known as "review2"
+  Then I should see the QA acceptance
+    | status   | email       | comment  |
+    | success  | foo@bar.com | All good |
+  When I "reject" the feature with comment "Needs improvements" as a QA
+  Then I should see an alert: "Thank you for your submission. It will appear in a moment."
+  When I reload the page after a while
+  Then I should see the QA acceptance
+    | status   | email       | comment            |
+    | danger   | foo@bar.com | Needs improvements |
+
 Scenario: Repo Owner approves feature
   Given an application with owner "foo@bar.com" called "frontend"
   And an application with owner "foo@bar.com" called "backend"

--- a/features/step_definitions/feature_review_steps.rb
+++ b/features/step_definitions/feature_review_steps.rb
@@ -85,12 +85,12 @@ Then 'I should see the QA acceptance with heading "$status"' do |status|
 end
 
 Then 'I should see the QA acceptance' do |table|
-  expected_qa_submission = table.hashes.first
+  expected_qa_submission = table.hashes.last
   status = expected_qa_submission.delete('status')
   panel = feature_review_page.qa_submission_panel
 
   expect(panel.status).to eq(status)
-  expect(panel.items.first).to eq(expected_qa_submission)
+  expect(panel.items.last).to eq(expected_qa_submission)
 end
 
 Then 'I should see the Repo Owner Commentary with heading "$status"' do |status|

--- a/spec/controllers/feature_reviews_controller_spec.rb
+++ b/spec/controllers/feature_reviews_controller_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe FeatureReviewsController do
     it { is_expected.to require_authentication_on(:post, :link_ticket) }
   end
 
+  before do
+    repository1 = instance_double(GitRepository, get_dependent_commits: [double(id: 'abc')])
+    repository2 = instance_double(GitRepository, get_dependent_commits: [double(id: 'def')])
+
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('frontend').and_return(repository1)
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('backend').and_return(repository2)
+  end
+
   describe 'GET #new', :logged_in do
     let(:feature_review_form) { instance_double(Forms::FeatureReviewForm) }
 

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -5,7 +5,7 @@ require 'feature_review_with_statuses'
 RSpec.describe FeatureReviewWithStatuses do
   let(:tickets) { double(:tickets) }
   let(:builds) { double(:builds) }
-  let(:qa_submission) { double(:qa_submission) }
+  let(:qa_submissions) { [] }
   let(:release_exception) { double(:release_exception) }
   let(:apps) { { 'app1' => 'xxx', 'app2' => 'yyy' } }
   let(:app_names) { apps.keys }
@@ -19,7 +19,7 @@ RSpec.describe FeatureReviewWithStatuses do
       feature_review,
       builds: builds,
       release_exception: release_exception,
-      qa_submission: qa_submission,
+      qa_submissions: qa_submissions,
       tickets: tickets,
       at: query_time,
     )
@@ -28,7 +28,7 @@ RSpec.describe FeatureReviewWithStatuses do
   it 'returns all necessary fields as initialized' do
     expect(decorator.builds).to eq(builds)
     expect(decorator.release_exception).to eq(release_exception)
-    expect(decorator.qa_submission).to eq(qa_submission)
+    expect(decorator.qa_submissions).to eq(qa_submissions)
     expect(decorator.tickets).to eq(tickets)
     expect(decorator.time).to eq(query_time)
   end
@@ -36,10 +36,10 @@ RSpec.describe FeatureReviewWithStatuses do
   context 'when initialized without parameters' do
     let(:decorator) { described_class.new(feature_review) }
 
-    it 'returns default values for #builds, #qa_submission, #tickets and #time' do
+    it 'returns default values for #builds, #qa_submissions, #tickets and #time' do
       expect(decorator.builds).to eq({})
       expect(decorator.release_exception).to eq(nil)
-      expect(decorator.qa_submission).to eq(nil)
+      expect(decorator.qa_submissions).to eq(nil)
       expect(decorator.tickets).to eq([])
       expect(decorator.time).to eq(nil)
     end
@@ -195,7 +195,7 @@ RSpec.describe FeatureReviewWithStatuses do
 
   describe '#qa_status' do
     context 'when QA submission is accepted' do
-      let(:qa_submission) { QaSubmission.new(accepted: true) }
+      let(:qa_submissions) { [QaSubmission.new(accepted: true)] }
 
       it 'returns :success' do
         expect(decorator.qa_status).to eq(:success)
@@ -203,7 +203,7 @@ RSpec.describe FeatureReviewWithStatuses do
     end
 
     context 'when QA submission is rejected' do
-      let(:qa_submission) { QaSubmission.new(accepted: false) }
+      let(:qa_submissions) { [QaSubmission.new(accepted: false)] }
 
       it 'returns :failure' do
         expect(decorator.qa_status).to eq(:failure)
@@ -211,7 +211,7 @@ RSpec.describe FeatureReviewWithStatuses do
     end
 
     context 'when QA submission is missing' do
-      let(:qa_submission) { nil }
+      let(:qa_submissions) { nil }
 
       it 'returns nil' do
         expect(decorator.qa_status).to be nil
@@ -222,7 +222,7 @@ RSpec.describe FeatureReviewWithStatuses do
   describe '#summary_status' do
     context 'when status of builds, and QA submission are success' do
       let(:builds) { { 'frontend' => Build.new(success: true) } }
-      let(:qa_submission) { QaSubmission.new(accepted: true) }
+      let(:qa_submissions) { [QaSubmission.new(accepted: true)] }
 
       it 'returns :success' do
         expect(decorator.summary_status).to eq(:success)
@@ -231,7 +231,7 @@ RSpec.describe FeatureReviewWithStatuses do
 
     context 'when any status of builds, or QA submission is failed' do
       let(:builds) { { 'frontend' => Build.new(success: true) } }
-      let(:qa_submission) { QaSubmission.new(accepted: false) }
+      let(:qa_submissions) { [QaSubmission.new(accepted: false)] }
 
       it 'returns :failure' do
         expect(decorator.summary_status).to eq(:failure)
@@ -240,7 +240,7 @@ RSpec.describe FeatureReviewWithStatuses do
 
     context 'when no status is a failure but at least one is a warning' do
       let(:builds) { { 'frontend' => Build.new } }
-      let(:qa_submission) { QaSubmission.new(accepted: true) }
+      let(:qa_submissions) { [QaSubmission.new(accepted: true)] }
 
       it 'returns nil' do
         expect(decorator.summary_status).to be(nil)

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe CommitStatus do
   before do
     stub_const('ShipmentTracker::GITHUB_REPO_STATUS_WRITE_TOKEN', 'token')
     allow(GithubClient).to receive(:new).and_return(client)
+
+    repository1     = instance_double(GitRepository, get_dependent_commits: [])
+    repository_repo = instance_double(GitRepository, get_dependent_commits: [])
+
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app1').and_return(repository1)
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('repo').and_return(repository_repo)
   end
 
   let(:client) { instance_double(GithubClient) }

--- a/spec/models/events/handlers/link_ticket_handler_spec.rb
+++ b/spec/models/events/handlers/link_ticket_handler_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe Events::Handlers::LinkTicketHandler do
         build(:jira_event, key: 'JIRA-1', comment_body: LinkTicket.build_comment(url1), created_at: time - 1.hour),
       ]
 
+      repository1 = instance_double(GitRepository, get_dependent_commits: [double(id: 'one')])
+      repository2 = instance_double(GitRepository, get_dependent_commits: [double(id: 'two')])
+
+      allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app1').and_return(repository1)
+      allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app2').and_return(repository2)
+
       final_ticket = events.reduce({}) { |ticket, event| described_class.new(ticket, event).apply }
+
       expect(final_ticket).to match(
         hash_including(
           'key' => 'JIRA-1',

--- a/spec/models/events/handlers/unlink_ticket_handler_spec.rb
+++ b/spec/models/events/handlers/unlink_ticket_handler_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe Events::Handlers::UnlinkTicketHandler do
         created_at: time - 1.hour,
       )
 
+      repository2 = instance_double(GitRepository, get_dependent_commits: [double(id: 'two')])
+      allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app2').and_return(repository2)
+
       new_ticket = described_class.new(ticket, unlink_2_event).apply
       expect(new_ticket).to include(
         'key' => 'JIRA-1',

--- a/spec/models/factories/feature_review_factory_spec.rb
+++ b/spec/models/factories/feature_review_factory_spec.rb
@@ -6,6 +6,14 @@ require 'ticket'
 RSpec.describe Factories::FeatureReviewFactory do
   subject(:factory) { described_class.new }
 
+  before do
+    repository = instance_double(GitRepository, get_dependent_commits: [])
+
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app1').and_return(repository)
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('foo').and_return(repository)
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('a').and_return(repository)
+  end
+
   describe '#create_from_text' do
     let(:url1) { full_url('apps[app1]' => 'abc', 'apps[app2]' => 'def') }
     let(:url2) { full_url('apps[app1]' => 'abc') }

--- a/spec/models/queries/decorated_feature_reviews_query_spec.rb
+++ b/spec/models/queries/decorated_feature_reviews_query_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 
 RSpec.describe Queries::DecoratedFeatureReviewsQuery do
   describe '#get_commit' do
+    before do
+      repository1 = instance_double(GitRepository, get_dependent_commits: [double(id: 'abc')])
+      allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app1').and_return(repository1)
+    end
+
     context 'when tickets exist for the given commit' do
       let(:tickets) {
         [

--- a/spec/models/queries/feature_review_query_spec.rb
+++ b/spec/models/queries/feature_review_query_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe Queries::FeatureReviewQuery do
     allow(Repositories::TicketRepository).to receive(:new).and_return(ticket_repository)
     allow(Repositories::ReleaseExceptionRepository).to receive(:new).and_return(release_exception_repository)
 
+    repository1 = instance_double(GitRepository, get_dependent_commits: [])
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app1').and_return(repository1)
+
     allow(build_repository).to receive(:builds_for)
       .with(apps: expected_apps, at: time)
       .and_return(expected_builds)

--- a/spec/models/queries/feature_review_query_spec.rb
+++ b/spec/models/queries/feature_review_query_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Queries::FeatureReviewQuery do
   let(:expected_release_exception) { double('release_exception') }
 
   let(:expected_apps) { { 'app1' => '123' } }
-  let(:versions) { { 'app1' => ['123'] } }
 
   let(:time) { Time.current }
   let(:feature_review) { new_feature_review(expected_apps) }
@@ -35,7 +34,7 @@ RSpec.describe Queries::FeatureReviewQuery do
       .with(apps: expected_apps, at: time)
       .and_return(expected_builds)
     allow(manual_test_repository).to receive(:qa_submissions_for)
-      .with(versions: versions, at: time)
+      .with(versions: expected_apps.values, at: time)
       .and_return(expected_qa_submissions)
     allow(release_exception_repository).to receive(:release_exception_for)
       .with(versions: expected_apps.values, at: time)

--- a/spec/models/queries/feature_review_query_spec.rb
+++ b/spec/models/queries/feature_review_query_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Queries::FeatureReviewQuery do
   let(:expected_release_exception) { double('release_exception') }
 
   let(:expected_apps) { { 'app1' => '123' } }
-  let(:versions) { {'app1' => ['123']} }
+  let(:versions) { { 'app1' => ['123'] } }
 
   let(:time) { Time.current }
   let(:feature_review) { new_feature_review(expected_apps) }

--- a/spec/models/queries/feature_review_query_spec.rb
+++ b/spec/models/queries/feature_review_query_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe Queries::FeatureReviewQuery do
   let(:release_exception_repository) { instance_double(Repositories::ReleaseExceptionRepository) }
 
   let(:expected_builds) { double('expected builds') }
-  let(:expected_qa_submission) { double('expected qa submission') }
+  let(:expected_qa_submissions) { double('expected qa submissions') }
   let(:expected_tickets) { double('expected tickets') }
   let(:expected_release_exception) { double('release_exception') }
 
   let(:expected_apps) { { 'app1' => '123' } }
+  let(:versions) { {'app1' => ['123']} }
 
   let(:time) { Time.current }
   let(:feature_review) { new_feature_review(expected_apps) }
@@ -33,9 +34,9 @@ RSpec.describe Queries::FeatureReviewQuery do
     allow(build_repository).to receive(:builds_for)
       .with(apps: expected_apps, at: time)
       .and_return(expected_builds)
-    allow(manual_test_repository).to receive(:qa_submission_for)
-      .with(versions: expected_apps.values, at: time)
-      .and_return(expected_qa_submission)
+    allow(manual_test_repository).to receive(:qa_submissions_for)
+      .with(versions: versions, at: time)
+      .and_return(expected_qa_submissions)
     allow(release_exception_repository).to receive(:release_exception_for)
       .with(versions: expected_apps.values, at: time)
       .and_return(expected_release_exception)
@@ -50,7 +51,7 @@ RSpec.describe Queries::FeatureReviewQuery do
         .with(
           feature_review,
           builds: expected_builds,
-          qa_submission: expected_qa_submission,
+          qa_submissions: expected_qa_submissions,
           tickets: expected_tickets,
           release_exception: expected_release_exception,
           at: time,

--- a/spec/models/repositories/manual_test_repository_spec.rb
+++ b/spec/models/repositories/manual_test_repository_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Repositories::ManualTestRepository do
         build(:manual_test_event, default.merge(accepted: false, created_at: t[0])),
         build(:manual_test_event, default.merge(apps: { 'app2' => '2' }, accepted: false, created_at: t[1])),
         build(:manual_test_event, default.merge(accepted: true, created_at: t[2])),
-        build(:manual_test_event, default.merge(apps: { 'app1' => '1' }, comment: 'Not good', accepted: false, created_at: t[3])),
+        build(:manual_test_event, default.merge(apps: { 'app1' => '1' }, accepted: false, created_at: t[3])),
       ]
 
       events.each do |event|
@@ -61,7 +61,13 @@ RSpec.describe Repositories::ManualTestRepository do
         result = repository.qa_submissions_for(versions: %w(abc def), at: 2.hours.ago)
 
         expect(result.last).to eq(
-          QaSubmission.new(email: 'foo@ex.io', accepted: true, comment: 'Good', created_at: times[1], versions: %w(abc def)),
+          QaSubmission.new(
+            email: 'foo@ex.io',
+            accepted: true,
+            comment: 'Good',
+            created_at: times[1],
+            versions: %w(abc def),
+          ),
         )
       end
     end

--- a/spec/models/repositories/manual_test_repository_spec.rb
+++ b/spec/models/repositories/manual_test_repository_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe Repositories::ManualTestRepository do
       result = repository.qa_submissions_for(versions: %w(1 2))
 
       expect(result).to include(
-        QaSubmission.new(email: 'foo@ex.io', accepted: true, comment: 'Good', created_at: t[2]),
+        QaSubmission.new(email: 'foo@ex.io', accepted: true, comment: 'Good', created_at: t[2], versions: %w(1 2)),
       )
 
       expect(result.last).to eq(
-        QaSubmission.new(email: 'foo@ex.io', accepted: false, comment: 'Not good', created_at: t[3])
+        QaSubmission.new(email: 'foo@ex.io', accepted: false, comment: 'Good', created_at: t[3], versions: %w(1)),
       )
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Repositories::ManualTestRepository do
         result = repository.qa_submissions_for(versions: %w(abc def), at: 2.hours.ago)
 
         expect(result.last).to eq(
-          QaSubmission.new(email: 'foo@ex.io', accepted: true, comment: 'Good', created_at: times[1]),
+          QaSubmission.new(email: 'foo@ex.io', accepted: true, comment: 'Good', created_at: times[1], versions: %w(abc def)),
         )
       end
     end

--- a/spec/models/repositories/released_ticket_repository_spec.rb
+++ b/spec/models/repositories/released_ticket_repository_spec.rb
@@ -151,6 +151,9 @@ RSpec.describe Repositories::ReleasedTicketRepository do
       commit = instance_double(GitCommit, id: commit_version, associated_ids: %w(abc def))
       repository_loader = instance_double(GitRepositoryLoader)
 
+      allow(repository).to receive(:get_dependent_commits).with('abc').and_return([commit])
+      allow(repository).to receive(:get_dependent_commits).with('def').and_return([commit])
+
       allow(GitRepositoryLoader).to receive(:from_rails_config).and_return(repository_loader)
       allow(repository_loader).to receive(:load).and_return(repository)
       allow(repository).to receive(:commit_for_version).and_return(commit)

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe Repositories::TicketRepository do
 
   let(:git_repo_location) { class_double(GitRepositoryLocation) }
 
+  before do
+    repository_foo = instance_double(GitRepository, get_dependent_commits: [double(id: 'foo')])
+    repository1    = instance_double(GitRepository, get_dependent_commits: [double(id: 'one')])
+    repository2    = instance_double(GitRepository, get_dependent_commits: [double(id: 'two')])
+
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app').and_return(repository_foo)
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app1').and_return(repository1)
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('app2').and_return(repository2)
+    allow_any_instance_of(GitRepositoryLoader).to receive(:load).with('frontend').and_return(repository2)
+  end
+
   describe '#table_name' do
     it 'delegates to the active record class backing the repository' do
       active_record_class = class_double(Snapshots::Ticket, table_name: 'tickets')


### PR DESCRIPTION
When a Feature Review is generated, QA Submission messages for all related commits are shown. A related commit is every commit between the last merge commit and the given commit. This applies for all applications for which the Feature Review is generated:

<img width="1265" alt="screen shot 2017-08-31 at 15 29 03" src="https://user-images.githubusercontent.com/3731686/29923227-6fd7ce7a-8e61-11e7-85bc-14434dc1a337.png">

Relates:
- [x] JIRA :gem:: https://jira.fundingcircle.com/browse/PO-3612

/cc @FundingCircle/prod-ops 🙇‍♀️ 