### PR TITLE
[PO-3871] Clone repository if git folder is not present

### DIFF
--- a/app/views/feature_reviews/new.html.haml
+++ b/app/views/feature_reviews/new.html.haml
@@ -21,6 +21,10 @@
           - @feature_review_form.errors[app_name].each do |error|
             %span.help-inline= error
 
-  .row
-    .col-md-6
-      = f.submit("Submit", class: "btn btn-primary pull-right")
+  - if @app_names.present?
+    .row
+      .col-md-6
+        = f.submit("Submit", class: "btn btn-primary pull-right")
+  - else
+    There are no applications. You can add some in
+    = link_to 'Repositories', git_repository_locations_path

--- a/spec/models/git_repository_loader_spec.rb
+++ b/spec/models/git_repository_loader_spec.rb
@@ -223,13 +223,8 @@ RSpec.describe GitRepositoryLoader do
           allow(Rugged::Repository).to receive(:new) { fail Rugged::RepositoryError }
         end
 
-        it 'raised a BadLocation error' do
-          expect {
-            git_repository_loader.load('repo', update_repo: false)
-          }.to raise_error(
-            GitRepositoryLoader::BadLocation,
-            "Invalid directory location for repository: #{git_repository_location.name}",
-          )
+        it 'updates rugged repository' do
+          expect(git_repository_loader.load('repo', update_repo: true)).to be_instance_of(GitRepository)
         end
       end
     end


### PR DESCRIPTION
If the `.git` folder in the project directory is not present, the rugged repository will fail to get created. This will cause an error when a feature review for that repository is generated. To fix this the project will be cloned again when this error occurs and the rugged repository will be successfully created.

Relates:
- [x] JIRA :gem:: https://jira.fundingcircle.com/browse/PO-3871

/cc @FundingCircle/prod-ops 🙇‍♀️ 