### PR TITLE
Update moved tickets in Feature Reviews

### DIFF
--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -32,11 +32,11 @@ module Events
     end
 
     def changelog_old_key
-      key_item.fetch('fromString')
+      key_item['fromString']
     end
 
     def changelog_new_key
-      key_item.fetch('toString')
+      key_item['toString']
     end
 
     def approval?
@@ -86,7 +86,7 @@ module Events
     end
 
     def key_item
-      @key_item ||= changelog_items.find { |item| item['field'] == 'Key' }
+      @key_item ||= changelog_items.find { |item| item['field'] == 'Key' } || {}
     end
 
     def changelog_items

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -31,6 +31,14 @@ module Events
       details.dig('comment', 'body') || ''
     end
 
+    def changelog_old_key
+      key_item.fetch('fromString')
+    end
+
+    def changelog_new_key
+      key_item.fetch('toString')
+    end
+
     def approval?
       status_item &&
         !approved_status?(status_item['fromString']) &&
@@ -41,6 +49,12 @@ module Events
       status_item &&
         approved_status?(status_item['fromString']) &&
         !approved_status?(status_item['toString'])
+    end
+
+    def transfer?
+      return false unless key_item.present?
+
+      changelog_old_key != changelog_new_key
     end
 
     def apply(ticket)
@@ -69,6 +83,10 @@ module Events
 
     def status_item
       @status_item ||= changelog_items.find { |item| item['field'] == 'status' }
+    end
+
+    def key_item
+      @key_item ||= changelog_items.find { |item| item['field'] == 'Key' }
     end
 
     def changelog_items

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -55,7 +55,7 @@ module Repositories
     end
 
     def previous_ticket_data(event)
-      key = event.transfer? ? event.changelog_new_key : event.key
+      key = event.transfer? ? event.changelog_old_key : event.key
       attrs = store.where(key: key).last&.attributes || {}
       attrs.except!('id')
     end

--- a/app/models/repositories/ticket_repository.rb
+++ b/app/models/repositories/ticket_repository.rb
@@ -34,12 +34,13 @@ module Repositories
       return unless event.is_a?(Events::JiraEvent) && event.issue?
 
       feature_reviews = feature_review_factory.create_from_text(event.comment)
-      last_ticket = previous_ticket_data(event.key)
+      last_ticket = previous_ticket_data(event)
 
       return if last_ticket.empty? && feature_reviews.empty?
 
-      new_ticket = event.apply(last_ticket)
+      update_keys(event)
 
+      new_ticket = event.apply(last_ticket)
       store.create!(new_ticket)
 
       update_github_status_for([new_ticket, last_ticket]) if update_github_status?(event, feature_reviews)
@@ -49,14 +50,19 @@ module Repositories
 
     attr_reader :git_repository_location, :feature_review_factory
 
-    def previous_ticket_data(key)
+    def update_keys(event)
+      store.where(key: event.changelog_old_key).update_all(key: event.changelog_new_key) if event.transfer?
+    end
+
+    def previous_ticket_data(event)
+      key = event.transfer? ? event.changelog_new_key : event.key
       attrs = store.where(key: key).last&.attributes || {}
       attrs.except!('id')
     end
 
     def update_github_status?(event, feature_reviews)
       return false if Rails.configuration.data_maintenance_mode
-      event.approval? || event.unapproval? || feature_reviews.present?
+      event.approval? || event.unapproval? || event.transfer? || feature_reviews.present?
     end
 
     def update_github_status_for(ticket_hashes)

--- a/spec/factories/jira_event.rb
+++ b/spec/factories/jira_event.rb
@@ -159,6 +159,21 @@ FactoryGirl.define do
       )
       in_progress
     end
+
+    trait :moved do
+      changelog_details(
+        'changelog' => {
+          'items' => [
+            {
+              'field' => 'Key',
+              'fromString' => 'ONEJIRA-1',
+              'toString' => 'TWOJIRA-2',
+            },
+          ],
+        },
+      )
+      todo
+    end
   end
 
   factory :jira_event_user_created, class: Events::JiraEvent do

--- a/spec/models/events/jira_event_spec.rb
+++ b/spec/models/events/jira_event_spec.rb
@@ -53,4 +53,30 @@ RSpec.describe Events::JiraEvent do
       end
     end
   end
+
+  describe '#transfer?' do
+    it 'returns true' do
+      expect(build(:jira_event, :moved).transfer?).to be true
+    end
+  end
+
+  describe 'changelog_old_key' do
+    it 'returns old key of a moved ticket' do
+      expect(build(:jira_event, :moved).changelog_old_key).to eq 'ONEJIRA-1'
+    end
+
+    it 'return of ticket that is not moved' do
+      expect(build(:jira_event, :started).changelog_old_key).to be nil
+    end
+  end
+
+  describe 'changelog_new_key' do
+    it 'returns old key of a moved ticket' do
+      expect(build(:jira_event, :moved).changelog_new_key).to eq 'TWOJIRA-2'
+    end
+
+    it 'return of ticket that is not moved' do
+      expect(build(:jira_event, :started).changelog_new_key).to be nil
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?
It implements automatic update of the key of a ticket that has been moved in Jira. 

### Any background context you want to provide?
At the moment when a ticket is moved, the old ticket key remains in the feature reviews and cannot be linked because it cannot be found. This causes problem with the approval of feature reviews.


/cc @FundingCircle/prod-ops and @FundingCircle/engineering-effectiveness for review 🙇‍♀️ 
