### PR TITLE
Add deployment alerts for devs that approve their own code

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,3 +25,8 @@ Metrics/ParameterLists:
   Max: 6
   Exclude:
     - 'app/decorators/feature_review_with_statuses.rb'
+
+Metrics/AbcSize:
+  Exclude:
+    - 'app/decorators/feature_review_with_statuses.rb'
+    - 'app/models/events/jira_event.rb'

--- a/app/controllers/git_repository_locations_controller.rb
+++ b/app/controllers/git_repository_locations_controller.rb
@@ -31,7 +31,8 @@ class GitRepositoryLocationsController < ApplicationController
   def update
     load_edit_env
 
-    edit_params = params.require(:forms_edit_git_repository_location_form).permit(:repo_owners, :repo_approvers)
+    edit_params = params.require(:forms_edit_git_repository_location_form)
+                        .permit(:repo_owners, :repo_approvers, audit_options: [])
     @form = form_for(@git_repository_location, edit_params)
 
     if @form.call

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -78,7 +78,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def authorised?
-    @authorised ||= approved_by_owner? || (tickets.present? && tickets.all? { |t| t.authorised?(versions) })
+    @authorised ||= approved_by_owner? || (tickets.present? && tickets.all? { |t| t.authorised?(versions, isae_auditable?) })
   end
 
   def authorisation_status
@@ -127,5 +127,9 @@ class FeatureReviewWithStatuses < SimpleDelegator
 
   def git_repository_for(app_name)
     GitRepositoryLoader.from_rails_config.load(app_name)
+  end
+
+  def isae_auditable?
+    (@feature_review.app_names - Rails.application.config.isae_auditable).empty?
   end
 end

--- a/app/decorators/feature_review_with_statuses.rb
+++ b/app/decorators/feature_review_with_statuses.rb
@@ -78,7 +78,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
   end
 
   def authorised?
-    @authorised ||= approved_by_owner? || (tickets.present? && tickets.all? { |t| t.authorised?(versions, isae_auditable?) })
+    @authorised ||= approved_by_owner? || (tickets.present? && tickets.all? { |t| t.authorised?(versions, isae_3402_auditable?) })
   end
 
   def authorisation_status
@@ -129,7 +129,7 @@ class FeatureReviewWithStatuses < SimpleDelegator
     GitRepositoryLoader.from_rails_config.load(app_name)
   end
 
-  def isae_auditable?
-    (@feature_review.app_names - Rails.application.config.isae_auditable).empty?
+  def isae_3402_auditable?
+    GitRepositoryLocation.where(name: @feature_review.app_names).all?(&:isae_3402_auditable?)
   end
 end

--- a/app/models/events/git_repository_location_event.rb
+++ b/app/models/events/git_repository_location_event.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'events/base_event'
+
+module Events
+  class GitRepositoryLocationEvent < Events::BaseEvent
+    def app_name
+      details.fetch('app_name')
+    end
+
+    def audit_options
+      details.fetch('audit_options', [])
+    end
+  end
+end

--- a/app/models/events/handlers/ticket_handler.rb
+++ b/app/models/events/handlers/ticket_handler.rb
@@ -13,7 +13,7 @@ module Events
           'summary' => event.summary,
           'status' => event.status,
           'event_created_at' => event.created_at,
-          'developed_by' => merge_developed_by(ticket, event),
+          'authored_by' => merge_authored_by(ticket, event),
           'approved_at' => merge_approved_at(ticket, event),
           'approved_by' => merge_approved_by(ticket, event),
         )
@@ -29,11 +29,11 @@ module Events
 
       private
 
-      def merge_developed_by(last_ticket, event)
+      def merge_authored_by(last_ticket, event)
         if event.development?
           event.user_email
         elsif last_ticket.present?
-          last_ticket['developed_by']
+          last_ticket['authored_by']
         end
       end
 

--- a/app/models/events/handlers/ticket_handler.rb
+++ b/app/models/events/handlers/ticket_handler.rb
@@ -13,7 +13,9 @@ module Events
           'summary' => event.summary,
           'status' => event.status,
           'event_created_at' => event.created_at,
+          'developed_by' => merge_developed_by(ticket, event),
           'approved_at' => merge_approved_at(ticket, event),
+          'approved_by' => merge_approved_by(ticket, event),
         )
       end
 
@@ -27,11 +29,27 @@ module Events
 
       private
 
+      def merge_developed_by(last_ticket, event)
+        if event.development?
+          event.user_email
+        elsif last_ticket.present?
+          last_ticket['developed_by']
+        end
+      end
+
       def merge_approved_at(last_ticket, event)
         if event.approval?
           event.created_at
         elsif last_ticket.present? && Ticket.new(status: event.status).approved?
           last_ticket['approved_at']
+        end
+      end
+
+      def merge_approved_by(last_ticket, event)
+        if event.approval? && event.details['user']
+          event.user_email
+        elsif last_ticket.present? && Ticket.new(status: event.status).approved?
+          last_ticket['approved_by']
         end
       end
     end

--- a/app/models/events/handlers/ticket_handler.rb
+++ b/app/models/events/handlers/ticket_handler.rb
@@ -46,7 +46,7 @@ module Events
       end
 
       def merge_approved_by(last_ticket, event)
-        if event.approval? && event.details['user']
+        if event.approval?
           event.user_email
         elsif last_ticket.present? && Ticket.new(status: event.status).approved?
           last_ticket['approved_by']

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -55,15 +55,14 @@ module Events
         !approved_status?(status_item['toString'])
     end
 
+    def development?
+      status_item && development_status?(status_item['toString'])
+    end
+
     def transfer?
       return false unless key_item.present?
 
       changelog_old_key != changelog_new_key
-    end
-
-    def development?
-      status_item &&
-        development_status?(status_item['toString'])
     end
 
     def apply(ticket)

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -39,6 +39,10 @@ module Events
       key_item['toString']
     end
 
+    def user_email
+      details.dig('user', 'emailAddress') || ''
+    end
+
     def approval?
       status_item &&
         !approved_status?(status_item['fromString']) &&
@@ -55,6 +59,11 @@ module Events
       return false unless key_item.present?
 
       changelog_old_key != changelog_new_key
+    end
+
+    def development?
+      status_item &&
+        development_status?(status_item['toString'])
     end
 
     def apply(ticket)
@@ -95,6 +104,10 @@ module Events
 
     def approved_status?(status)
       Rails.application.config.approved_statuses.include?(status)
+    end
+
+    def development_status?(status)
+      Rails.application.config.development_statuses.include?(status)
     end
   end
 end

--- a/app/models/forms/edit_git_repository_location_form.rb
+++ b/app/models/forms/edit_git_repository_location_form.rb
@@ -9,34 +9,29 @@ module Forms
       @repo = repo
       @params = params
       @current_user = current_user
+      @audit_options = params[:audit_options]
 
       super(params)
 
       @repo_owners ||= ''
       @repo_approvers ||= ''
+      @audit_options ||= []
     end
 
-    attr_accessor :repo_owners, :repo_approvers
+    attr_accessor :repo_owners, :repo_approvers, :audit_options
     attr_reader :repo, :params, :current_user
 
     validates :repo_owners, with: :validate_repo_owners, allow_blank: true
     validates :repo_approvers, with: :validate_repo_approvers, allow_blank: true
+    validates :audit_options, with: :validate_audit_options, allow_blank: true
 
     alias git_repository_location repo
 
     def call
       return false unless valid?
 
-      event = Events::RepoOwnershipEvent.create!(
-        details: {
-          app_name: repo.name,
-          repo_owners: owners_address_list.format(keep_brackets: true),
-          repo_approvers: approvers_address_list.format(keep_brackets: true),
-          email: current_user.email,
-        },
-      )
-
-      repo_ownership_repository.apply(event)
+      apply_repo_ownership_event
+      apply_git_repo_location_event
     end
 
     def repo_owners_data
@@ -65,12 +60,20 @@ module Forms
       @repo_ownership_repository ||= Repositories::RepoOwnershipRepository.new
     end
 
+    def git_repo_location_repository
+      @git_repo_location_repository ||= Repositories::GitRepoLocationRepository.new
+    end
+
     def owners_address_list
       @owners_address_list ||= parse_emails(repo_owners)
     end
 
     def approvers_address_list
       @approvers_address_list ||= parse_emails(repo_approvers)
+    end
+
+    def audit_options_list_valid?
+      @audit_options.all? { |option| GitRepositoryLocation::AUDIT_OPTIONS.keys.include?(option) }
     end
 
     def parse_emails(raw_emails)
@@ -88,7 +91,36 @@ module Forms
     def validate_repo_approvers
       return if approvers_address_list.valid?
 
-      errors.add(:repo_owners, 'is invalid')
+      errors.add(:repo_approvers, 'is invalid')
+    end
+
+    def validate_audit_options
+      return if audit_options_list_valid?
+
+      errors.add(:audit_options, 'is invalid')
+    end
+
+    def apply_repo_ownership_event
+      event = Events::RepoOwnershipEvent.create!(
+        details: {
+          app_name: repo.name,
+          repo_owners: owners_address_list.format(keep_brackets: true),
+          email: current_user.email,
+        },
+      )
+
+      repo_ownership_repository.apply(event)
+    end
+
+    def apply_git_repo_location_event
+      event = Events::GitRepositoryLocationEvent.create!(
+        details: {
+          app_name: repo.name,
+          audit_options: audit_options,
+        },
+      )
+
+      git_repo_location_repository.apply(event)
     end
   end
 end

--- a/app/models/forms/edit_git_repository_location_form.rb
+++ b/app/models/forms/edit_git_repository_location_form.rb
@@ -105,6 +105,7 @@ module Forms
         details: {
           app_name: repo.name,
           repo_owners: owners_address_list.format(keep_brackets: true),
+          repo_approvers: approvers_address_list.format(keep_brackets: true),
           email: current_user.email,
         },
       )

--- a/app/models/git_repository_location.rb
+++ b/app/models/git_repository_location.rb
@@ -10,6 +10,8 @@ class GitRepositoryLocation < ActiveRecord::Base
   validates :uri, presence: true
   validates :name, uniqueness: true
 
+  AUDIT_OPTIONS = { 'isae_3402' => 'ISAE 3402' }
+
   def self.app_names
     all.order(name: :asc).pluck(:name)
   end

--- a/app/models/git_repository_location.rb
+++ b/app/models/git_repository_location.rb
@@ -59,6 +59,10 @@ class GitRepositoryLocation < ActiveRecord::Base
     repo_ownership_repository.approvers_of(self)
   end
 
+  def isae_3402_auditable?
+    audit_options.include?('isae_3402')
+  end
+
   private
 
   def repo_ownership_repository

--- a/app/models/git_repository_location.rb
+++ b/app/models/git_repository_location.rb
@@ -10,7 +10,7 @@ class GitRepositoryLocation < ActiveRecord::Base
   validates :uri, presence: true
   validates :name, uniqueness: true
 
-  AUDIT_OPTIONS = { 'isae_3402' => 'ISAE 3402' }
+  AUDIT_OPTIONS = { 'isae_3402' => 'ISAE 3402' }.freeze
 
   def self.app_names
     all.order(name: :asc).pluck(:name)

--- a/app/models/repositories/git_repo_location_repository.rb
+++ b/app/models/repositories/git_repo_location_repository.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Repositories
+  class GitRepoLocationRepository < Base
+    def initialize(store = Snapshots::GitRepositoryLocation)
+      @store = store
+    end
+
+    # Events::GitRepositoryLocationEvent
+    def apply(event)
+      return unless event.is_a?(Events::GitRepositoryLocationEvent)
+
+      repo = GitRepositoryLocation.find_by(name: event.app_name)
+      repo.audit_options = event.audit_options
+      repo.save!
+    end
+  end
+end

--- a/app/models/snapshots/git_repository_location.rb
+++ b/app/models/snapshots/git_repository_location.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'active_record'
+
+module Snapshots
+  class GitRepositoryLocation < ActiveRecord::Base
+    class << self
+      def for(app_name)
+        find_or_initialize_by(name: app_name)
+      end
+    end
+  end
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -10,7 +10,7 @@ class Ticket
     attribute :description, String, default: ''
     attribute :status, String, default: 'To Do'
     attribute :paths, Array, default: []
-    attribute :developed_by, String
+    attribute :authored_by, String
     attribute :approved_at, DateTime
     attribute :approved_by, String
     attribute :version_timestamps, Hash[String => DateTime]
@@ -34,6 +34,6 @@ class Ticket
   end
 
   def authorised_by_developer?
-    developed_by.present? && approved_by.present? && developed_by == approved_by
+    authored_by.present? && approved_by.present? && authored_by == approved_by
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -26,8 +26,8 @@ class Ticket
     Rails.application.config.approved_statuses.include?(status)
   end
 
-  def authorised?(versions_under_review, isae_auditable = false)
-    return false if approved_at.nil? || (isae_auditable && authorised_by_developer?)
+  def authorised?(versions_under_review, isae_3402_auditable = false)
+    return false if approved_at.nil? || (isae_3402_auditable && authorised_by_developer?)
     linked_at = versions_under_review.map { |v| version_timestamps[v] }.compact.min
     return false if linked_at.nil?
     approved_at >= linked_at

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -10,7 +10,9 @@ class Ticket
     attribute :description, String, default: ''
     attribute :status, String, default: 'To Do'
     attribute :paths, Array, default: []
+    attribute :developed_by, String
     attribute :approved_at, DateTime
+    attribute :approved_by, String
     attribute :version_timestamps, Hash[String => DateTime]
     attribute :versions, Array, default: []
   end
@@ -25,9 +27,13 @@ class Ticket
   end
 
   def authorised?(versions_under_review)
-    return false if approved_at.nil?
+    return false if approved_at.nil? || authorised_by_developer
     linked_at = versions_under_review.map { |v| version_timestamps[v] }.compact.min
     return false if linked_at.nil?
     approved_at >= linked_at
+  end
+
+  def authorised_by_developer
+    developed_by.present? && approved_by.present? && developed_by == approved_by
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -26,14 +26,14 @@ class Ticket
     Rails.application.config.approved_statuses.include?(status)
   end
 
-  def authorised?(versions_under_review)
-    return false if approved_at.nil? || authorised_by_developer
+  def authorised?(versions_under_review, isae_auditable = false)
+    return false if approved_at.nil? || (isae_auditable && authorised_by_developer?)
     linked_at = versions_under_review.map { |v| version_timestamps[v] }.compact.min
     return false if linked_at.nil?
     approved_at >= linked_at
   end
 
-  def authorised_by_developer
+  def authorised_by_developer?
     developed_by.present? && approved_by.present? && developed_by == approved_by
   end
 end

--- a/app/views/git_repository_locations/edit.html.haml
+++ b/app/views/git_repository_locations/edit.html.haml
@@ -16,4 +16,12 @@
     = f.text_area(:repo_approvers, placeholder: "John Doe <repo-owner@example.com>\nsecond-repo-owner@example.com, third-repo-owner@example.com", value: @form.repo_approvers_data, class: 'form-control', rows: 5)
 
   .form-group
+    = f.label(:audit_options, class: 'control-label')
+    - GitRepositoryLocation::AUDIT_OPTIONS.each do |option, option_name|
+      .checkbox
+        %label
+          = check_box_tag option, option, @form.git_repository_location.audit_options.include?(option), name: 'forms_edit_git_repository_location_form[audit_options][]'
+          = option_name
+
+  .form-group
     = f.submit('Update Git Repository', class: 'btn btn-primary')

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,8 @@ module ShipmentTracker
                                   .split(/\s*,\s*/)
     config.development_statuses = ENV.fetch('DEVELOPMENT_STATUSES', 'In Progress, In Review')
                                      .split(/\s*,\s*/)
+    config.isae_auditable = ENV.fetch('ISAE_AUDITABLE', '')
+                               .split(/\s*,\s*/)
     config.git_repository_cache_dir = Dir.tmpdir
     config.data_maintenance_mode = ENV['DATA_MAINTENANCE'] == 'true'
     config.allow_git_fetch_on_request = ENV['ALLOW_GIT_FETCH_ON_REQUEST'] == 'true'

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,8 +51,6 @@ module ShipmentTracker
                                   .split(/\s*,\s*/)
     config.development_statuses = ENV.fetch('DEVELOPMENT_STATUSES', 'In Progress, In Review')
                                      .split(/\s*,\s*/)
-    config.isae_auditable = ENV.fetch('ISAE_AUDITABLE', '')
-                               .split(/\s*,\s*/)
     config.git_repository_cache_dir = Dir.tmpdir
     config.data_maintenance_mode = ENV['DATA_MAINTENANCE'] == 'true'
     config.allow_git_fetch_on_request = ENV['ALLOW_GIT_FETCH_ON_REQUEST'] == 'true'

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,8 @@ module ShipmentTracker
     config.ssh_user = ENV['SSH_USER']
     config.approved_statuses = ENV.fetch('APPROVED_STATUSES', 'Ready for Deployment, Deployed, Done')
                                   .split(/\s*,\s*/)
+    config.development_statuses = ENV.fetch('DEVELOPMENT_STATUSES', 'In Progress, In review')
+                                  .split(/\s*,\s*/)
     config.git_repository_cache_dir = Dir.tmpdir
     config.data_maintenance_mode = ENV['DATA_MAINTENANCE'] == 'true'
     config.allow_git_fetch_on_request = ENV['ALLOW_GIT_FETCH_ON_REQUEST'] == 'true'

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,8 +49,8 @@ module ShipmentTracker
     config.ssh_user = ENV['SSH_USER']
     config.approved_statuses = ENV.fetch('APPROVED_STATUSES', 'Ready for Deployment, Deployed, Done')
                                   .split(/\s*,\s*/)
-    config.development_statuses = ENV.fetch('DEVELOPMENT_STATUSES', 'In Progress, In review')
-                                  .split(/\s*,\s*/)
+    config.development_statuses = ENV.fetch('DEVELOPMENT_STATUSES', 'In Progress, In Review')
+                                     .split(/\s*,\s*/)
     config.git_repository_cache_dir = Dir.tmpdir
     config.data_maintenance_mode = ENV['DATA_MAINTENANCE'] == 'true'
     config.allow_git_fetch_on_request = ENV['ALLOW_GIT_FETCH_ON_REQUEST'] == 'true'

--- a/db/migrate/20180115135632_add_approved_by_and_authored_by_to_tickets.rb
+++ b/db/migrate/20180115135632_add_approved_by_and_authored_by_to_tickets.rb
@@ -1,0 +1,6 @@
+class AddApprovedByAndAuthoredByToTickets < ActiveRecord::Migration
+  def change
+    add_column :tickets, :approved_by, :string
+    add_column :tickets, :authored_by, :string
+  end
+end

--- a/db/migrate/20180115135632_add_approved_by_and_developed_by_to_tickets.rb
+++ b/db/migrate/20180115135632_add_approved_by_and_developed_by_to_tickets.rb
@@ -1,0 +1,6 @@
+class AddApprovedByAndDevelopedByToTickets < ActiveRecord::Migration
+  def change
+    add_column :tickets, :approved_by, :string
+    add_column :tickets, :developed_by, :string
+  end
+end

--- a/db/migrate/20180115135632_add_approved_by_and_developed_by_to_tickets.rb
+++ b/db/migrate/20180115135632_add_approved_by_and_developed_by_to_tickets.rb
@@ -1,6 +1,0 @@
-class AddApprovedByAndDevelopedByToTickets < ActiveRecord::Migration
-  def change
-    add_column :tickets, :approved_by, :string
-    add_column :tickets, :developed_by, :string
-  end
-end

--- a/db/migrate/20180123100359_add_audit_options_to_git_repository_location.rb
+++ b/db/migrate/20180123100359_add_audit_options_to_git_repository_location.rb
@@ -1,0 +1,5 @@
+class AddAuditOptionsToGitRepositoryLocation < ActiveRecord::Migration
+  def change
+    add_column :git_repository_locations, :audit_options, :text, array: true, default: []
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -495,7 +495,7 @@ CREATE TABLE tickets (
     approved_at timestamp without time zone,
     version_timestamps hstore DEFAULT ''::hstore NOT NULL,
     approved_by character varying,
-    developed_by character varying
+    authored_by character varying
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -277,7 +277,8 @@ CREATE TABLE git_repository_locations (
     name character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    remote_head character varying
+    remote_head character varying,
+    audit_options text[] DEFAULT '{}'::text[]
 );
 
 
@@ -1072,4 +1073,6 @@ INSERT INTO schema_migrations (version) VALUES ('20171205132454');
 INSERT INTO schema_migrations (version) VALUES ('20171219093236');
 
 INSERT INTO schema_migrations (version) VALUES ('20180115135632');
+
+INSERT INTO schema_migrations (version) VALUES ('20180123100359');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.4.14
+-- Dumped from database version 9.4.15
 -- Dumped by pg_dump version 9.6.3
 
 SET statement_timeout = 0;
@@ -277,8 +277,7 @@ CREATE TABLE git_repository_locations (
     name character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    remote_head character varying,
-    required_checks text[] DEFAULT '{}'::text[]
+    remote_head character varying
 );
 
 
@@ -494,7 +493,8 @@ CREATE TABLE tickets (
     versions text[] DEFAULT '{}'::text[],
     approved_at timestamp without time zone,
     version_timestamps hstore DEFAULT ''::hstore NOT NULL,
-    approved_by_email character varying
+    approved_by character varying,
+    developed_by character varying
 );
 
 
@@ -1067,11 +1067,9 @@ INSERT INTO schema_migrations (version) VALUES ('20170407150443');
 
 INSERT INTO schema_migrations (version) VALUES ('20170808075905');
 
-INSERT INTO schema_migrations (version) VALUES ('20170901114312');
-
 INSERT INTO schema_migrations (version) VALUES ('20171205132454');
 
-INSERT INTO schema_migrations (version) VALUES ('20171208143840');
-
 INSERT INTO schema_migrations (version) VALUES ('20171219093236');
+
+INSERT INTO schema_migrations (version) VALUES ('20180115135632');
 

--- a/features/repository_locations.feature
+++ b/features/repository_locations.feature
@@ -65,3 +65,12 @@ Scenario: Edit approvers of a repository
   Then I should see the repository locations:
     | Name      | URI                | Repo Owners | Repo Approvers                                              |
     | new-app   | uri_for("new-app") |             | repo-approver@example.com, second-repo-approver@example.com |
+
+@disable_repo_verification
+Scenario: Select ISAE 3402 audit option for a repository
+  Given "new-app" repository
+  And I am on the edit repository location form for "new-app"
+  When I select audit options "isae_3402"
+  When I click "Update Git Repository"
+  And I am on the edit repository location form for "new-app"
+  Then the previously set "isae_3402" audit options should be selected

--- a/features/step_definitions/repository_locations_steps.rb
+++ b/features/step_definitions/repository_locations_steps.rb
@@ -51,6 +51,16 @@ When 'I enter approver emails "$repo_approvers"' do |repo_approvers|
   edit_git_repository_location_page.fill_in_repo_approvers(repo_approvers: repo_approvers)
 end
 
+When 'I select audit options "$audit_options"' do |audit_options|
+  edit_git_repository_location_page.select_audit_options(audit_options: audit_options)
+end
+
 When 'I click "$button"' do |button|
   edit_git_repository_location_page.click(button)
+end
+
+Then 'the previously set "$audit_options" audit options should be selected' do |audit_options|
+  audit_options.split(',').each do |audit_option|
+    expect(find("##{audit_option}")).to be_checked
+  end
 end

--- a/features/support/pages/repository_location_page.rb
+++ b/features/support/pages/repository_location_page.rb
@@ -43,6 +43,12 @@ module Pages
       page.fill_in 'Repo Approvers', with: repo_approvers
     end
 
+    def select_audit_options(audit_options:)
+      audit_options.split(',').each do |audit_option|
+        page.find("##{audit_option}").set(true)
+      end
+    end
+
     def click(button)
       page.click_link_or_button(button)
     end

--- a/spec/decorators/feature_review_with_statuses_spec.rb
+++ b/spec/decorators/feature_review_with_statuses_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FeatureReviewWithStatuses do
   let(:app_names) { apps.keys }
   let(:versions) { apps.values }
 
-  let(:feature_review) { instance_double(FeatureReview, app_versions: apps, versions: versions) }
+  let(:feature_review) { instance_double(FeatureReview, app_versions: apps, versions: versions, app_names: app_names) }
   let(:query_time) { Time.parse('2014-08-10 14:40:48 UTC') }
 
   subject(:decorator) {
@@ -476,6 +476,7 @@ RSpec.describe FeatureReviewWithStatuses do
         query_hash: { 'apps' => apps },
         app_versions: apps,
         versions: apps.values,
+        app_names: app_names,
       )
     }
 

--- a/spec/factories/git_repository_event.rb
+++ b/spec/factories/git_repository_event.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'events/git_repository_location_event'
+
+FactoryGirl.define do
+  factory :git_repository_location_event, class: Events::GitRepositoryLocationEvent do
+    transient do
+      app_name 'test-app'
+      audit_options []
+    end
+
+    details {
+      {
+        'app_name' => app_name,
+        'audit_options' => audit_options,
+      }
+    }
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/factories/git_repository_location_snapshot.rb
+++ b/spec/factories/git_repository_location_snapshot.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :git_repository_location_snapshot, class: Snapshots::GitRepositoryLocation do
+    name 'test-app'
+    audit_options []
+  end
+end

--- a/spec/models/events/git_repository_location_event_spec.rb
+++ b/spec/models/events/git_repository_location_event_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Events::GitRepositoryLocationEvent do
+  describe 'init' do
+    it 'is initialized as expected' do
+      event = described_class.new(
+        details: {
+          'app_name' => 'Some_App',
+          'audit_options' => [],
+        },
+      )
+
+      expect(event.app_name).to eq('Some_App')
+      expect(event.audit_options).to eq([])
+    end
+  end
+end

--- a/spec/models/events/jira_event_spec.rb
+++ b/spec/models/events/jira_event_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe Events::JiraEvent do
     end
   end
 
+  describe '#development?' do
+    it 'returns true' do
+      expect(build(:jira_event, :started).development?).to be true
+    end
+  end
+
   describe 'changelog_old_key' do
     it 'returns old key of a moved ticket' do
       expect(build(:jira_event, :moved).changelog_old_key).to eq 'ONEJIRA-1'
@@ -77,6 +83,12 @@ RSpec.describe Events::JiraEvent do
 
     it 'return of ticket that is not moved' do
       expect(build(:jira_event, :started).changelog_new_key).to be nil
+    end
+  end
+
+  describe '#user_email' do
+    it 'returns the email of the user' do
+      expect(build(:jira_event, :created).user_email).to eq 'joe.bloggs@example.com'
     end
   end
 end

--- a/spec/models/events/jira_event_spec.rb
+++ b/spec/models/events/jira_event_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe Events::JiraEvent do
     it 'returns true' do
       expect(build(:jira_event, :started).development?).to be true
     end
+
+    it 'returns false' do
+      expect(build(:jira_event, :approved).development?).to be false
+    end
   end
 
   describe 'changelog_old_key' do

--- a/spec/models/forms/edit_git_repository_location_form_spec.rb
+++ b/spec/models/forms/edit_git_repository_location_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Forms::EditGitRepositoryLocationForm do
         expect(form_for(repo_owners: nil)).to be_valid
       end
 
-      describe 'a signle repo owner' do
+      describe 'a single repo owner' do
         it 'expects an email or a name with email' do
           expect(form_for(repo_owners: 'test@example.com')).to be_valid
           expect(form_for(repo_owners: 'Test Example<test@example.com>')).to be_valid
@@ -42,9 +42,32 @@ RSpec.describe Forms::EditGitRepositoryLocationForm do
         end
       end
     end
+
+    describe 'for audit options' do
+      it 'could be blank' do
+        expect(form_for(audit_options: [])).to be_valid
+        expect(form_for(audit_options: nil)).to be_valid
+      end
+
+      it 'could contain only certain checks' do
+        expect(form_for(audit_options: %w(isae_3402))).to be_valid
+        expect(form_for(audit_options: %w(invalid_check))).not_to be_valid
+      end
+    end
   end
 
   describe '#call' do
+    let(:form) {
+      form_for(
+        {
+          repo_owners: "test@example.com, test3@example.com \n\n\nTest Example <test2@example.com>  \n\n\n",
+          audit_options: %w(isae_3402),
+        },
+        repo: FactoryGirl.create(:git_repository_location, name: 'my-app'),
+        current_user: double('User', email: 'test@test.com'),
+      )
+    }
+
     it 'will generate a repo ownership event' do
       repo = FactoryGirl.create(:git_repository_location, name: 'my-app')
       current_user = double('User', email: 'test@test.com')
@@ -64,6 +87,19 @@ RSpec.describe Forms::EditGitRepositoryLocationForm do
             repo_owners: 'test@example.com, test3@example.com, Test Example <test2@example.com>',
             repo_approvers: 'test4@example.com, test5@example.com, Test Example <test6@example.com>',
             email: 'test@test.com',
+          },
+        ),
+      )
+
+      form.call
+    end
+
+    it 'will generate a git repository location event' do
+      expect(Events::GitRepositoryLocationEvent).to(
+        receive(:create!).with(
+          details: {
+            app_name: 'my-app',
+            audit_options: %w(isae_3402),
           },
         ),
       )

--- a/spec/models/repositories/git_repo_location_repository_spec.rb
+++ b/spec/models/repositories/git_repo_location_repository_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Repositories::GitRepoLocationRepository do
+  subject(:repository) { described_class.new }
+
+  describe '#apply' do
+    let!(:git_repo) { create(:git_repository_location, name: 'test', audit_options: []) }
+
+    it 'will store a snapshot of the repo' do
+      event = build(
+        :git_repository_location_event,
+        app_name: 'test',
+        audit_options: %w(isae_3402),
+      )
+
+      repository.apply(event)
+
+      expect(Snapshots::GitRepositoryLocation.last).to have_attributes(
+        name: 'test',
+        audit_options: %w(isae_3402),
+      )
+    end
+
+    it 'will update already existing git repository location' do
+      git_repo2 = create(:git_repository_location, name: 'test2', audit_options: %w(isae_3402))
+
+      event = build(
+        :git_repository_location_event,
+        app_name: 'test',
+        audit_options: [],
+      )
+
+      repository.apply(event)
+
+      expect(GitRepositoryLocation.count).to eq(2)
+
+      expect(git_repo.reload).to have_attributes(name: 'test', audit_options: [])
+      expect(git_repo2.reload).to have_attributes(name: 'test2', audit_options: %w(isae_3402))
+    end
+
+    it 'will update the already existing snapshot' do
+      event = build(
+        :git_repository_location_event,
+        app_name: 'test',
+        audit_options: %w(isae_3402),
+      )
+
+      event2 = build(
+        :git_repository_location_event,
+        app_name: 'test',
+        audit_options: [],
+      )
+
+      repository.apply(event)
+
+      snapshot = Snapshots::GitRepositoryLocation.last
+
+      expect { repository.apply(event2) }.to change { snapshot.reload.audit_options }
+    end
+  end
+end

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Repositories::TicketRepository do
 
   describe '#apply' do
     let(:time) { Time.current.change(usec: 0) }
-    let(:times) { [time - 3.hours, time - 2.hours, time - 1.hour, time - 1.minute] }
+    let(:times) { [time - 4.hours, time - 3.hours, time - 2.hours, time - 1.hour, time - 1.minute] }
     let(:url) { LinkTicket.build_comment(feature_review_url(app: 'foo')) }
     let(:path) { feature_review_path(app: 'foo') }
     let(:ticket_defaults) { { paths: [path], versions: %w(foo), version_timestamps: { 'foo' => nil } } }
@@ -322,14 +322,11 @@ RSpec.describe Repositories::TicketRepository do
         ticket_1 = jira_1.merge(ticket_defaults)
 
         [
-          build(:jira_event, :created, jira_1.merge(
-                                         comment_body: LinkTicket.build_comment(url), created_at: times[0])
-               ),
-          build(:jira_event, :approved, jira_1.merge(created_at: times[1])),
-          build(:jira_event, :created, jira_2.merge(created_at: times[2])),
-          build(:jira_event, :created, jira_2.merge(
-                                         comment_body: LinkTicket.build_comment(url), created_at: times[3])
-               ),
+          build(:jira_event, :created, jira_1.merge(comment_body: LinkTicket.build_comment(url), created_at: times[0])),
+          build(:jira_event, :started, jira_1.merge(created_at: times[1], user_email: 'some.user@example.com')),
+          build(:jira_event, :approved, jira_1.merge(created_at: times[2], user_email: 'another.user@example.com')),
+          build(:jira_event, :created, jira_2.merge(created_at: times[3])),
+          build(:jira_event, :created, jira_2.merge(comment_body: LinkTicket.build_comment(url), created_at: times[4])),
         ].each do |event|
           repository.apply(event)
         end
@@ -338,9 +335,11 @@ RSpec.describe Repositories::TicketRepository do
           Ticket.new(
             ticket_1.merge(
               status: 'Ready for Deployment',
-              approved_at: times[1],
-              event_created_at: times[1],
+              approved_at: times[2],
+              event_created_at: times[2],
               version_timestamps: { 'foo' => times[0] },
+              developed_by: 'some.user@example.com',
+              approved_by: 'another.user@example.com',
             ),
           ),
         ])

--- a/spec/models/repositories/ticket_repository_spec.rb
+++ b/spec/models/repositories/ticket_repository_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Repositories::TicketRepository do
               approved_at: times[2],
               event_created_at: times[2],
               version_timestamps: { 'foo' => times[0] },
-              developed_by: 'some.user@example.com',
+              authored_by: 'some.user@example.com',
               approved_by: 'another.user@example.com',
             ),
           ),

--- a/spec/models/snapshots/git_repository_location_spec.rb
+++ b/spec/models/snapshots/git_repository_location_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Snapshots::GitRepositoryLocation do
+  describe '.for' do
+    it 'returns the snapshot for specific repository name' do
+      snapshot = create(:git_repository_location_snapshot, name: 'test-repo')
+
+      expect(described_class.for('test-repo')).to eq(snapshot)
+    end
+
+    context 'when there is no snapshot' do
+      it 'it returns a non-persisted one with the correct name' do
+        repo = double('Repo', name: 'test-repo')
+
+        snapshot = described_class.for(repo.name)
+
+        expect(snapshot.name).to eq('test-repo')
+        expect(snapshot).to_not be_persisted
+      end
+    end
+  end
+end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Ticket do
       let(:ticket_attributes) {
         { approved_at: current_time,
           version_timestamps: { versions.first => 1.hour.ago },
-          developed_by: email,
+          authored_by: email,
           approved_by: email,
         }
       }

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Ticket do
   end
 
   describe '#authorised?' do
-    subject { ticket.authorised?(versions, isae_auditable) }
+    subject { ticket.authorised?(versions, isae_3402_auditable) }
 
     let(:versions) { %w(abc def) }
-    let(:isae_auditable) { false }
+    let(:isae_3402_auditable) { false }
     let(:current_time) { Time.current }
 
     context 'when the ticket was approved after it was linked' do
@@ -76,13 +76,13 @@ RSpec.describe Ticket do
         }
       }
 
-      context 'and the repos are in the ISAE critical list' do
-        let(:isae_auditable) { true }
+      context 'and the repos are in the ISAE 3402 critical list' do
+        let(:isae_3402_auditable) { true }
 
         it { is_expected.to be false }
       end
 
-      context 'and the repos are not ISAE critical' do
+      context 'and the repos are not ISAE 3402 critical' do
         it { is_expected.to be true }
       end
     end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe Ticket do
       }
       it { is_expected.to be false }
     end
+
+    context 'when the ticket was approved by the same user who worked on it' do
+      let(:email) { 'some.user@example.com' }
+      let(:ticket_attributes) { { approved_at: current_time, developed_by: email, approved_by: email } }
+      it { is_expected.to be false }
+    end
   end
 
   describe '#authorisation_status' do


### PR DESCRIPTION
### What does this PR do?
It adds an additional check for authorisation of tickets  - the user who has approved the 🎫  in Jira should be different from the user who worked on it 💻 

### Any specific implementation changes that would benefit highlighting?
* The ✉️  of the user that has moved the ticket in a **development** state should be different from the ✉️  of the user moving it in an **approved** state.
* Environment variable `DEVELOPMENT_STATUSES` should be set.

/cc @FundingCircle/prod-ops and @FundingCircle/engineering-effectiveness for review 🙇‍♀️ 
