### PR TITLE
Update GitHub status only when changed

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -37,7 +37,7 @@ class CommitStatus
   end
 
   def last_status
-    github.last_status_for(repo: full_repo_name, sha: sha)
+    @last_status ||= github.last_status_for(repo: full_repo_name, sha: sha)
   end
 
   private

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -19,7 +19,9 @@ class CommitStatus
   def update
     status, description = feature_reviews_status.values_at(:status, :description)
 
-    post_status({ status: status, description: description }, target_url)
+    if !last_status || (last_status.state != status && last_status.description != description)
+      post_status({ status: status, description: description }, target_url)
+    end
   end
 
   def reset
@@ -32,6 +34,10 @@ class CommitStatus
 
   def not_found
     post_status(not_found_status, target_url)
+  end
+
+  def last_status
+    github.last_status_for(repo: full_repo_name, sha: sha)
   end
 
   private

--- a/features/step_definitions/feature_review_steps.rb
+++ b/features/step_definitions/feature_review_steps.rb
@@ -125,7 +125,7 @@ Then 'I should see that the Feature Review requires reapproval' do
 end
 
 When 'I reload the page after a while' do
-  scenario_context.stub_github_status
+  scenario_context.stub_github_commit_status_checks
   Repositories::Updater.from_rails_config.run
   page.visit(page.current_url)
 end

--- a/features/step_definitions/feature_review_steps.rb
+++ b/features/step_definitions/feature_review_steps.rb
@@ -125,6 +125,7 @@ Then 'I should see that the Feature Review requires reapproval' do
 end
 
 When 'I reload the page after a while' do
+  scenario_context.stub_github_status
   Repositories::Updater.from_rails_config.run
   page.visit(page.current_url)
 end

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -110,9 +110,12 @@ module Support
         comment_body: comment_type.build_comment(url),
         updated: time,
       )
+
       @stubbed_requests['pending'] = stub_request(:post, %r{https://api.github.com/.*})
                                      .with(body: /"state":"pending"/)
                                      .and_return(status: 201)
+      stub_github_status
+
       event = build(:jira_event, ticket_details)
       travel_to Time.zone.parse(time) do
         post_event 'jira', event.details
@@ -144,6 +147,11 @@ module Support
       @stubbed_requests[state] = stub_request(:post, %r{https://api.github.com/.*})
                                  .with(body: /"state":"#{state}"/)
                                  .and_return(status: 201)
+    end
+
+    def stub_github_status
+      stub_request(:get, %r{https://api.github.com/.*/status})
+        .to_return(status: 201, headers: { content_type: 'json' }, body: { statuses: [] }.to_json)
     end
 
     def review_url(feature_review_nickname: nil, time: nil)

--- a/features/support/scenario_context.rb
+++ b/features/support/scenario_context.rb
@@ -114,7 +114,7 @@ module Support
       @stubbed_requests['pending'] = stub_request(:post, %r{https://api.github.com/.*})
                                      .with(body: /"state":"pending"/)
                                      .and_return(status: 201)
-      stub_github_status
+      stub_github_commit_status_checks
 
       event = build(:jira_event, ticket_details)
       travel_to Time.zone.parse(time) do
@@ -149,7 +149,7 @@ module Support
                                  .and_return(status: 201)
     end
 
-    def stub_github_status
+    def stub_github_commit_status_checks
       stub_request(:get, %r{https://api.github.com/.*/status})
         .to_return(status: 201, headers: { content_type: 'json' }, body: { statuses: [] }.to_json)
     end

--- a/lib/clients/github.rb
+++ b/lib/clients/github.rb
@@ -30,6 +30,15 @@ class GithubClient
     false
   end
 
+  def last_status_for(repo:, sha:)
+    client.combined_status(repo, sha)[:statuses].reverse.find do |status|
+      status[:context] == 'shipment-tracker'
+    end
+  rescue Octokit::Error
+    Rails.logger.warn "Failed to fetch status for #{repo} at #{sha}"
+    nil
+  end
+
   private
 
   def client

--- a/lib/clients/github.rb
+++ b/lib/clients/github.rb
@@ -34,8 +34,8 @@ class GithubClient
     client.combined_status(repo, sha)[:statuses].reverse.find do |status|
       status[:context] == 'shipment-tracker'
     end
-  rescue Octokit::Error
-    Rails.logger.warn "Failed to fetch status for #{repo} at #{sha}"
+  rescue Octokit::Error => e
+    Rails.logger.warn "Failed to fetch status for #{repo} at #{sha}: #{e.class.name} #{e.message}"
     nil
   end
 

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe CommitStatus do
 
       allow(Repositories::ReleaseExceptionRepository).to receive(:new).and_return(exception_repository)
       allow(exception_repository).to receive(:release_exception_for).and_return(nil)
+
+      allow(client).to receive(:last_status_for).with(any_args)
     end
 
     context 'when a single Feature Review exists for the relevant commit' do
@@ -242,6 +244,17 @@ RSpec.describe CommitStatus do
       )
 
       CommitStatus.new(full_repo_name: 'owner/repo', sha: 'abc123').not_found
+    end
+  end
+
+  describe '#last_status' do
+    it 'requests status for the given repository and SHA' do
+      expect(client).to receive(:last_status_for).with(
+        repo: 'owner/repo',
+        sha: 'abc123',
+      )
+
+      CommitStatus.new(full_repo_name: 'owner/repo', sha: 'abc123').last_status
     end
   end
 end


### PR DESCRIPTION
In order to reduce updates sent to GitHub, only post status when the new status is different from the previous. For more information see:
https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref

@FundingCircle/prod-ops, @FundingCircle/engineering-effectiveness 🙇‍♀️ 