### PR TITLE
Fix the migrations

### DIFF
--- a/db/migrate/20170407150443_set_the_global_event_pointer.rb
+++ b/db/migrate/20170407150443_set_the_global_event_pointer.rb
@@ -13,7 +13,7 @@ class SetTheGlobalEventPointer < ActiveRecord::Migration
   def up
     record = Snapshots::EventCount.create!(
       snapshot_name: 'global_event_pointer',
-      event_id: Events::BaseEvent.last.id,
+      event_id: Events::BaseEvent.last.try(:id) || 0,
     )
 
     say "Global Event Pointer (last applied event id): #{record.event_id}"


### PR DESCRIPTION
Fix the 20170407150443_set_the_global_event_pointer transaction - now it will pass if there are no events in the database