### PR TITLE
Update the repo in the relink_ticket_job

### DIFF
--- a/app/jobs/relink_ticket_job.rb
+++ b/app/jobs/relink_ticket_job.rb
@@ -58,7 +58,7 @@ class RelinkTicketJob < ActiveJob::Base
   end
 
   def commit_on_master?(full_repo_name, sha)
-    git_repo = GitRepositoryLoader.from_rails_config.load(full_repo_name.split('/')[1])
+    git_repo = GitRepositoryLoader.from_rails_config.load(full_repo_name.split('/')[1], update_repo: true)
 
     git_repo.commit_on_master?(sha)
   end


### PR DESCRIPTION
A lot of times the repo is no updated when running this job and commit
new commit sha is not found. This causes and exception and the task
fails..