### PR TITLE
Update ticket's authored_by with assignee email if needed 

### DIFF
--- a/app/models/events/handlers/ticket_handler.rb
+++ b/app/models/events/handlers/ticket_handler.rb
@@ -34,6 +34,8 @@ module Events
           event.user_email
         elsif last_ticket.present?
           last_ticket['authored_by']
+        elsif event.approval?
+          event.assignee_email
         end
       end
 

--- a/app/models/events/jira_event.rb
+++ b/app/models/events/jira_event.rb
@@ -27,6 +27,10 @@ module Events
       details.dig('issue', 'fields', 'status', 'name')
     end
 
+    def assignee_email
+      details.dig('issue', 'fields', 'assignee', 'emailAddress')
+    end
+
     def comment
       details.dig('comment', 'body') || ''
     end

--- a/spec/factories/jira_event.rb
+++ b/spec/factories/jira_event.rb
@@ -11,6 +11,7 @@ FactoryGirl.define do
       description ''
       display_name 'joe'
       user_email 'joe.bloggs@example.com'
+      assignee_email 'joe.assignee@example.com'
       status 'To Do'
       updated '2015-05-07T15:24:34.957+0100'
       comment_body nil
@@ -32,6 +33,9 @@ FactoryGirl.define do
               'description' => description,
               'status' => { 'name' => status },
               'updated' => updated,
+              'assignee' => {
+                'emailAddress' => assignee_email,
+              },
             },
           },
         }

--- a/spec/models/events/jira_event_spec.rb
+++ b/spec/models/events/jira_event_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Events::JiraEvent do
   end
 
   describe '#assignee_email' do
-    it 'return the email of the assignee' do
+    it 'returns the email of the assignee' do
       expect(build(:jira_event, :development_completed).assignee_email).to eq 'joe.assignee@example.com'
     end
   end

--- a/spec/models/events/jira_event_spec.rb
+++ b/spec/models/events/jira_event_spec.rb
@@ -95,4 +95,10 @@ RSpec.describe Events::JiraEvent do
       expect(build(:jira_event, :created).user_email).to eq 'joe.bloggs@example.com'
     end
   end
+
+  describe '#assignee_email' do
+    it 'return the email of the assignee' do
+      expect(build(:jira_event, :development_completed).assignee_email).to eq 'joe.assignee@example.com'
+    end
+  end
 end


### PR DESCRIPTION
When handling a Jira approval event and creating a ticket, if the previous ticket with that Jira key doesn't have authored_by, set it to the event's assignee email 💭 

This will fix the following bug: when a ticket is moved in a _development_ status, then linked in Shipment Tracker and then approved ➡️ authored_by is `nil` which might lead to _false positives_.

/cc @FundingCircle/engineering-effectiveness, @FundingCircle/prod-ops for review 🙇‍♀️ 