### PR TITLE
Fix spacing in ownership stanza

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @FundingCircle/engineering-effectiveness
+*       @FundingCircle/engineering-effectiveness


### PR DESCRIPTION
💁 It appears that GitHub are fairly strict when parsing the spacing between file glob and team name. This change should start automatically assigning reviews to @FundingCircle/engineering-effectiveness, as intended in #231.