### PR TITLE
Case insensitive build statuses in the api

### DIFF
--- a/app/models/events/circle_ci_event.rb
+++ b/app/models/events/circle_ci_event.rb
@@ -17,7 +17,7 @@ module Events
     end
 
     def success
-      details.dig('payload', 'outcome') == 'success'
+      details.dig('payload', 'outcome')&.downcase == 'success'
     end
 
     def app_name

--- a/app/models/events/circle_ci_manual_webhook_event.rb
+++ b/app/models/events/circle_ci_manual_webhook_event.rb
@@ -8,7 +8,7 @@ module Events
     def success
       all_steps_but_last = details.fetch('steps', [])[0..-2]
       actions = all_steps_but_last.flat_map { |s| s.fetch('actions', []) }
-      actions.present? && actions.all? { |a| a['status'] == 'success' }
+      actions.present? && actions.all? { |a| a['status']&.downcase == 'success' }
     end
 
     def version

--- a/app/models/events/jenkins_event.rb
+++ b/app/models/events/jenkins_event.rb
@@ -17,7 +17,7 @@ module Events
     end
 
     def success
-      details.dig('build', 'status') == 'SUCCESS'
+      details.dig('build', 'status')&.downcase == 'success'
     end
 
     def app_name

--- a/app/models/events/manual_test_event.rb
+++ b/app/models/events/manual_test_event.rb
@@ -21,7 +21,7 @@ module Events
     end
 
     def accepted?
-      details.fetch('status', nil) == 'success'
+      details.fetch('status', nil)&.downcase == 'success'
     end
   end
 end

--- a/spec/models/events/circle_ci_event_spec.rb
+++ b/spec/models/events/circle_ci_event_spec.rb
@@ -36,4 +36,38 @@ RSpec.describe Events::CircleCiEvent do
       { some: 'nonsense' }
     }
   end
+
+  describe 'case insensitive payload.outcome' do
+    it_behaves_like 'a test build subclass' do
+      subject { described_class.new(details: payload) }
+
+      let(:expected_source) { 'CircleCi' }
+
+      let(:version) { '123' }
+      let(:payload) { success_payload }
+      let(:success_payload) {
+        {
+          'payload' => {
+            'build_url' => 'http://example.com',
+            'outcome' => 'sUccEss',
+            'vcs_revision' => version,
+          },
+        }
+      }
+      let(:failure_payload) {
+        {
+          'payload' => {
+            'app_name' => 'example',
+            'build_type' => 'integration',
+            'build_url' => 'http://example.com',
+            'outcome' => 'FaiLeD',
+            'vcs_revision' => version,
+          },
+        }
+      }
+      let(:invalid_payload) {
+        { some: 'nonsense' }
+      }
+    end
+  end
 end

--- a/spec/models/events/circle_ci_manual_webhook_event_spec.rb
+++ b/spec/models/events/circle_ci_manual_webhook_event_spec.rb
@@ -40,4 +40,42 @@ RSpec.describe Events::CircleCiManualWebhookEvent do
       { some: 'nonsense' }
     }
   end
+
+  describe 'case insensitive steps.actions.status and status' do
+    it_behaves_like 'a test build subclass' do
+      subject { described_class.new(details: payload) }
+
+      let(:expected_source) { 'CircleCi' }
+
+      let(:version) { '123' }
+      let(:payload) { success_payload }
+      let(:success_payload) {
+        {
+          'steps' => [
+            { 'actions' => [{ 'status' => 'sUcceSs' }] },
+            { 'actions' => [{ 'status' => 'succEss' }] },
+            { 'actions' => [{ 'status' => 'runnIng' }] },
+          ],
+          'outcome' => nil,
+          'status' => 'runNing',
+          'vcs_revision' => version,
+        }
+      }
+      let(:failure_payload) {
+        {
+          'steps' => [
+            { 'actions' => [{ 'status' => 'sucCess' }] },
+            { 'actions' => [{ 'status' => 'faILed' }] },
+            { 'actions' => [{ 'status' => 'ruNning' }] },
+          ],
+          'outcome' => nil,
+          'status' => 'runninG',
+          'vcs_revision' => version,
+        }
+      }
+      let(:invalid_payload) {
+        { some: 'nonsense' }
+      }
+    end
+  end
 end

--- a/spec/models/events/jenkins_event_spec.rb
+++ b/spec/models/events/jenkins_event_spec.rb
@@ -41,4 +41,43 @@ RSpec.describe Events::JenkinsEvent do
       { some: 'nonsense' }
     }
   end
+
+  describe 'case insensitive build.status' do
+    it_behaves_like 'a test build subclass' do
+      subject { described_class.new(details: payload) }
+      let(:expected_source) { 'Jenkins' }
+
+      let(:version) { '123' }
+      let(:payload) { success_payload }
+      let(:success_payload) {
+        {
+          'build' => {
+            'app_name' => 'example',
+            'build_type' => 'integration',
+            'full_url' => 'http://example.com',
+            'scm' => {
+              'commit' => version,
+            },
+            'status' => 'sUccEss',
+          },
+        }
+      }
+      let(:failure_payload) {
+        {
+          'build' => {
+            'app_name' => 'example',
+            'build_type' => 'integration',
+            'full_url' => 'http://example.com',
+            'scm' => {
+              'commit' => version,
+            },
+            'status' => 'FaiLuRe',
+          },
+        }
+      }
+      let(:invalid_payload) {
+        { some: 'nonsense' }
+      }
+    end
+  end
 end

--- a/spec/models/events/manual_test_event_spec.rb
+++ b/spec/models/events/manual_test_event_spec.rb
@@ -3,7 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Events::ManualTestEvent do
-  subject(:event) { described_class.new(details: details) }
+  def event_for(details)
+    described_class.new(details: details)
+  end
+
+  subject(:event) { event_for(details) }
 
   let(:apps) { [{ 'name' => 'frontend', 'version' => 'abc' }] }
   let(:email) { 'alice@example.com' }
@@ -51,16 +55,20 @@ RSpec.describe Events::ManualTestEvent do
   end
 
   describe '#accepted?' do
-    it 'returns the status' do
-      expect(event.accepted?).to be true
+    it 'is true for "success"' do
+      expect(event_for(details.merge(status: 'success')).accepted?).to be true
     end
 
-    context 'when there is no status' do
-      let(:details) { default_details.except('status') }
+    it 'is true for SUccess' do
+      expect(event_for(details.merge(status: 'SUccess')).accepted?).to be true
+    end
 
-      it 'returns nil' do
-        expect(event.accepted?).to be false
-      end
+    it 'is false for "failure"' do
+      expect(event_for(details.merge(status: 'failure')).accepted?).to be false
+    end
+
+    it 'is false if there is no status' do
+      expect(event_for(details.except('status')).accepted?).to be false
     end
   end
 


### PR DESCRIPTION
Accept all variations `success` as success status - `SUCCESS`, `succeSs`, `success` ...

Currently the jenkins test builds use `SUCCESS` but the other use `success`. This change will make the api a bit more forgiving. 

https://github.com/FundingCircle/shipment_tracker/wiki/Events-API