### PR TITLE
Heroku-16 stack compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,9 @@ defaults: &defaults
 install_system_packages: &install_system_packages
   run:
     name: Install system packages
-    command: sudo apt-get install -y cmake postgresql-client
+    command: |
+      sudo apt-get update -qq
+      sudo apt-get install -qqy cmake postgresql-client
 
 restore_gems: &restore_gems
   restore_cache:

--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,3 @@
 cmake
+libarchive13
 libssh2-1-dev

--- a/app.json
+++ b/app.json
@@ -1,0 +1,180 @@
+{
+  "name": "shipment_tracker",
+  "description": "",
+  "scripts": {},
+  "env": {
+	"ALLOW_GIT_FETCH_ON_REQUEST": {
+	  "required": true
+	},
+	"AUTH0_CLIENT_ID": {
+	  "required": true
+	},
+	"AUTH0_CLIENT_SECRET": {
+	  "required": true
+	},
+	"AUTH0_CONNECTION": {
+	  "required": true
+	},
+	"AUTH0_DOMAIN": {
+	  "required": true
+	},
+	"DATA_MAINTENANCE": {
+	  "required": true
+	},
+	"DEPLOY_ALERT_EMAIL": {
+	  "required": true
+	},
+	"DEPLOY_ALERT_SLACK_CHANNEL": {
+	  "required": true
+	},
+	"DEPLOY_REGIONS": {
+	  "required": true
+	},
+	"DEVELOPMENT_STATUSES": {
+	  "required": true
+	},
+	"GITHUB_REPO_READ_TOKEN": {
+	  "required": true
+	},
+	"GITHUB_REPO_STATUS_WRITE_TOKEN": {
+	  "required": true
+	},
+	"HEROKU_POSTGRESQL_PURPLE_URL": {
+	  "required": true
+	},
+	"HONEYBADGER_API_KEY": {
+	  "required": true
+	},
+	"HONEYBADGER_ENV": {
+	  "required": true
+	},
+	"HOST_NAME": {
+	  "required": true
+	},
+	"ISAE_AUDITABLE": {
+	  "required": true
+	},
+	"JIRA_FQDN": {
+	  "required": true
+	},
+	"JIRA_PASSWD": {
+	  "required": true
+	},
+	"JIRA_PATH": {
+	  "required": true
+	},
+	"JIRA_USER": {
+	  "required": true
+	},
+	"LANG": {
+	  "required": true
+	},
+	"MAILGUN": {
+	  "required": true
+	},
+	"MAILGUN_API_KEY": {
+	  "required": true
+	},
+	"MAILGUN_DOMAIN": {
+	  "required": true
+	},
+	"MAILGUN_PUBLIC_KEY": {
+	  "required": true
+	},
+	"MAILGUN_SMTP_LOGIN": {
+	  "required": true
+	},
+	"MAILGUN_SMTP_PASSWORD": {
+	  "required": true
+	},
+	"MAILGUN_SMTP_PORT": {
+	  "required": true
+	},
+	"MAILGUN_SMTP_SERVER": {
+	  "required": true
+	},
+	"NEW_RELIC_APP_NAME": {
+	  "required": true
+	},
+	"NEW_RELIC_LICENSE_KEY": {
+	  "required": true
+	},
+	"NEW_RELIC_LOG": {
+	  "required": true
+	},
+	"NEWRELIC_AGENT_ENABLED": {
+	  "required": true
+	},
+	"PROTECT_STDOUT": {
+	  "required": true
+	},
+	"PROTOCOL": {
+	  "required": true
+	},
+	"PROXIMO_URL": {
+	  "required": true
+	},
+	"RACK_ENV": {
+	  "required": true
+	},
+	"RAILS_ENV": {
+	  "required": true
+	},
+	"RAILS_SERVE_STATIC_FILES": {
+	  "required": true
+	},
+	"SECRET_KEY_BASE": {
+	  "required": true
+	},
+	"SLACK_WEBHOOK": {
+	  "required": true
+	},
+	"SSH_PRIVATE_KEY": {
+	  "required": true
+	},
+	"SSH_PUBLIC_KEY": {
+	  "required": true
+	},
+	"SSH_USER": {
+	  "required": true
+	}
+  },
+  "formation": {
+	"mailcatcher": {
+	  "quantity": 1,
+	  "size": "Standard-1X"
+	},
+	"worker": {
+	  "quantity": 1,
+	  "size": "Standard-1X"
+	},
+	"git_worker": {
+	  "quantity": 1,
+	  "size": "Standard-1X"
+	},
+	"background": {
+	  "quantity": 1,
+	  "size": "Standard-1X"
+	},
+	"web": {
+	  "quantity": 1,
+	  "size": "Standard-1X"
+	}
+  },
+  "addons": [
+	"heroku-postgresql",
+	"newrelic",
+	"logentries",
+	"mailgun",
+	"proximo"
+  ],
+  "buildpacks": [
+	{
+	  "url": "https://github.com/heroku/heroku-buildpack-apt"
+	},
+	{
+	  "url": "heroku/ruby"
+	}
+  ],
+  "stack": "heroku-16"
+}


### PR DESCRIPTION
💁 Heroku have updated their default stack from Cedar-14 to [Heroku-16, based on Ubuntu 16.04](https://devcenter.heroku.com/articles/heroku-16-stack). These changes facilitate that update in the stack being used. I've also added a configuration file for [Heroku's review apps pipeline](https://devcenter.heroku.com/articles/github-integration-review-apps).