### PR TITLE
Accept jira_key with whitespace or lowercase on link_ticket

### DIFF
--- a/app/controllers/feature_reviews_controller.rb
+++ b/app/controllers/feature_reviews_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FeatureReviewsController < ApplicationController
+  before_action :sanitize_jira_key_param, only: %i[link_ticket unlink_ticket]
+
   def new
     @app_names = GitRepositoryLocation.app_names
     @feature_review_form = feature_review_form
@@ -55,7 +57,7 @@ class FeatureReviewsController < ApplicationController
   private
 
   def ticket_linking_options
-    { jira_key: params.fetch(:jira_key, '').strip, feature_review_path: redirect_path, root_url: root_url }
+    { jira_key: params[:jira_key], feature_review_path: redirect_path, root_url: root_url }
   end
 
   def time
@@ -87,5 +89,9 @@ class FeatureReviewsController < ApplicationController
 
   def normalize_feature_review_path(path)
     factory.create_from_url_string(path).path
+  end
+
+  def sanitize_jira_key_param
+    params[:jira_key] = params[:jira_key].upcase.strip unless params[:jira_key].nil?
   end
 end

--- a/app/controllers/feature_reviews_controller.rb
+++ b/app/controllers/feature_reviews_controller.rb
@@ -55,7 +55,7 @@ class FeatureReviewsController < ApplicationController
   private
 
   def ticket_linking_options
-    { jira_key: params['jira_key'], feature_review_path: redirect_path, root_url: root_url }
+    { jira_key: params.fetch(:jira_key, '').strip, feature_review_path: redirect_path, root_url: root_url }
   end
 
   def time

--- a/spec/controllers/feature_reviews_controller_spec.rb
+++ b/spec/controllers/feature_reviews_controller_spec.rb
@@ -193,5 +193,29 @@ RSpec.describe FeatureReviewsController do
         expect(response).to redirect_to(feature_review_path(apps_with_versions))
       end
     end
+
+    context 'ticket id has leading or trailing space' do
+      let(:ticket_id) { 'JIRA-123 ' }
+      let(:apps_with_versions) { { 'frontend' => 'abc', 'backend' => 'def' } }
+      let(:message) { 'Some message' }
+
+      subject(:link_ticket) {
+        post :link_ticket, return_to: feature_review_path(apps_with_versions), jira_key: ticket_id
+      }
+
+      before do
+        allow(LinkTicket).to receive(:run).and_return(Success(message))
+      end
+
+      it 'links the ticket' do
+        expect(LinkTicket).to receive(:run).with(
+          jira_key: 'JIRA-123',
+          feature_review_path: feature_review_path(apps_with_versions),
+          root_url: 'http://test.host/',
+        )
+
+        link_ticket
+      end
+    end
   end
 end

--- a/spec/controllers/feature_reviews_controller_spec.rb
+++ b/spec/controllers/feature_reviews_controller_spec.rb
@@ -2,6 +2,18 @@
 
 require 'rails_helper'
 
+RSpec.shared_examples 'links the ticket with correct Jira id' do |ticket_id:|
+  it 'links the ticket' do
+    expect(LinkTicket).to receive(:run).with(
+      jira_key: ticket_id,
+      feature_review_path: feature_review_path(apps_with_versions),
+      root_url: 'http://test.host/',
+    )
+
+    link_ticket
+  end
+end
+
 RSpec.describe FeatureReviewsController do
   context 'when logged out' do
     it { is_expected.to require_authentication_on(:get, :new) }
@@ -194,28 +206,22 @@ RSpec.describe FeatureReviewsController do
       end
     end
 
-    context 'ticket id has leading or trailing space' do
+    context 'ticket id has trailing space' do
       let(:ticket_id) { 'JIRA-123 ' }
-      let(:apps_with_versions) { { 'frontend' => 'abc', 'backend' => 'def' } }
-      let(:message) { 'Some message' }
 
-      subject(:link_ticket) {
-        post :link_ticket, return_to: feature_review_path(apps_with_versions), jira_key: ticket_id
-      }
+      it_behaves_like 'links the ticket with correct Jira id', ticket_id: 'JIRA-123'
+    end
 
-      before do
-        allow(LinkTicket).to receive(:run).and_return(Success(message))
-      end
+    context 'ticket id has leading space' do
+      let(:ticket_id) { ' JIRA-123' }
 
-      it 'links the ticket' do
-        expect(LinkTicket).to receive(:run).with(
-          jira_key: 'JIRA-123',
-          feature_review_path: feature_review_path(apps_with_versions),
-          root_url: 'http://test.host/',
-        )
+      it_behaves_like 'links the ticket with correct Jira id', ticket_id: 'JIRA-123'
+    end
 
-        link_ticket
-      end
+    context 'ticket id has lowercase letters' do
+      let(:ticket_id) { ' jira-123' }
+
+      it_behaves_like 'links the ticket with correct Jira id', ticket_id: 'JIRA-123'
     end
   end
 end


### PR DESCRIPTION
Add logic to strip trailing and leading spaces from 'jira_key' params

This helps when the Jira ticket is carelessly copied from another page
and makes the app more usable and flexible