### PR TITLE
Prevent unnecessary repo re-clone caused by concurrent fetches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,10 @@ jobs:
       - run:
           name: Run specs
           command: |
-            bundle exec rake spec
+            bundle exec rake spec SPEC_OPTS="--format progress --format RspecJunitFormatter --out test-results/rspec/results.xml"
             ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.specs.json coverage/.resultset.json
+      - store_test_results:
+          path: test-results
       - store_artifacts:
           path: coverage
           destination: specs-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ cache_gems: &cache_gems
       - vendor/bundle
 
 jobs:
-  build:
+  setup:
     <<: *defaults
     steps:
       - *install_system_packages
@@ -164,18 +164,18 @@ jobs:
 
 workflows:
   version: 2
-  commit:
+  test-then-publish-docker-image:
     jobs:
-      - build
+      - setup
       - specs:
           requires:
-            - build
+            - setup
       - features:
           requires:
-            - build
+            - setup
       - rubocop:
           requires:
-            - build
+            - setup
       - upload-coverage:
           requires:
             - specs

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,8 @@ Style/BlockDelimiters:
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
+  Exclude:
+    - 'spec/**/*'
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 
 group :development, :test do
   gem 'rspec-rails'
+  gem 'rspec_junit_formatter'
   gem 'rubocop'
   gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,8 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.54.0)
       parallel (~> 1.10)
       parser (>= 2.5)
@@ -424,6 +426,7 @@ DEPENDENCIES
   rails (~> 4.2.11)
   rails_12factor
   rspec-rails
+  rspec_junit_formatter
   rubocop
   rugged (~> 0.27.0)
   sass-rails
@@ -440,8 +443,5 @@ DEPENDENCIES
   virtus
   webmock
 
-RUBY VERSION
-   ruby 2.3.6p384
-
 BUNDLED WITH
-   1.16.4
+   1.17.2


### PR DESCRIPTION
The git repositories are updated by both the `git-worker` process and the `RelinkTicketJob` delayed-job.

`libgit2` creates a lock file when it updates a reference in a git fetch operation, e.g. `/tmp/6-funding_circle_app/.git/refs/remotes/origin/di-ri-928.lock`. If this fetch operation is in progress when a `libgit2` fetch from the other process tries to update the same reference, it causes an exception
```
Rugged::OSError: failed to create locked file '/tmp/6-funding_circle_app/.git/refs/remotes/origin/di-ri-928.lock': File exists 
```
We currently re-clone the repository when there is any `Rugged::OSError`, but this particular one is recoverable without doing a clone, which can take a long time for a large repository.

This will instead retry a git fetch up to 10 times if a concurrent git fetch has a lock on the same reference. It sleeps for 1 second before each retry.

Fixes e.g. https://app.honeybadger.io/projects/44071/faults/38110914/dc7c0778-1fea-11e9-8926-2faa98b2053c#notice-trace

See https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/5497
