### PR TITLE
Disable GitHub and Jira updates via environment variables

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,8 @@ module ShipmentTracker
     config.allow_git_fetch_on_request = ENV['ALLOW_GIT_FETCH_ON_REQUEST'] == 'true'
     config.git_worker_interval_seconds = ENV.fetch('GIT_WORKER_INTERVAL_SECONDS', 5).to_i
     config.git_worker_max_threads = ENV.fetch('GIT_WORKER_MAX_THREADS', 16).to_i
+    config.disable_github_status_update = ENV['DISABLE_GITHUB_STATUS_UPDATE'] == 'true'
+    config.disable_jira_comments = ENV['DISABLE_JIRA_COMMENTS'] == 'true'
 
     config.default_deploy_region = ENV.fetch('DEFAULT_DEPLOY_REGION', 'gb')
 

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Delayed::Worker.sleep_delay = 2
+Delayed::Worker.max_attempts = 10
+Delayed::Worker.max_run_time = 5.minutes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:9.4-alpine
+    image: postgres:9.6-alpine
     command: postgres -c log_statement=all
     environment:
       POSTGRES_DB: shipment_tracker

--- a/dropzone.yaml
+++ b/dropzone.yaml
@@ -29,6 +29,7 @@ vars:
 
 deploy_tasks:
   shipment_tracker:
+    enabled: true
     deploy_token: KxT3S6cFjtQ5aVsB3GSVrzQW
   marathon:
     apps:

--- a/dropzone.yaml
+++ b/dropzone.yaml
@@ -12,6 +12,9 @@ vars:
   production:
     new_relic_app_id: 7057912
     git_worker_memory: 4096
+    delayed_job_instances: 3
+    delayed_job_memory: 1024
+    web_instances: 3
     web_memory: 1024
   staging:
     new_relic_app_id: 225742386
@@ -19,6 +22,9 @@ vars:
     new_relic_app_id: 216487708
   default:
     git_worker_memory: 1024
+    delayed_job_instances: 2
+    delayed_job_memory: 512
+    web_instances: 2
     web_memory: 512
 
 deploy_tasks:
@@ -27,9 +33,9 @@ deploy_tasks:
   marathon:
     apps:
       - id: delayed-job
-        instances: 3
+        instances: {{ delayed_job_instances }}
         cpus: 0.25
-        mem: 512
+        mem: {{ delayed_job_memory }}
         args: ["bundle", "exec", "rake", "jobs:work"]
         constraints:
           - *az_constraint
@@ -62,7 +68,7 @@ deploy_tasks:
             - *git_volume
 
       - id: web
-        instances: 3
+        instances: {{ web_instances }}
         cpus: 0.25
         mem: {{ web_memory }}
         args: ["bundle", "exec", "unicorn", "--config-file", "config/unicorn.rb"]

--- a/lib/clients/github.rb
+++ b/lib/clients/github.rb
@@ -14,14 +14,17 @@ class GithubClient
   end
 
   def create_status(repo:, sha:, state:, description:, target_url: nil)
-    client.create_status(
-      repo, sha, state,
-      context: 'shipment-tracker',
-      description: description,
-      target_url: target_url
-    )
-  rescue Octokit::NotFound
-    Rails.logger.warn "Failed to set #{state} commit status for #{repo} at #{sha}"
+    return if Rails.configuration.disable_github_status_update
+    begin
+      client.create_status(
+        repo, sha, state,
+        context: 'shipment-tracker',
+        description: description,
+        target_url: target_url
+      )
+    rescue Octokit::NotFound
+      Rails.logger.warn "Failed to set #{state} commit status for #{repo} at #{sha}"
+    end
   end
 
   def repo_accessible?(uri)

--- a/lib/clients/jira.rb
+++ b/lib/clients/jira.rb
@@ -6,12 +6,15 @@ class JiraClient
   class InvalidKeyError < RuntimeError; end
 
   def self.post_comment(issue_id, comment_msg)
-    issue = get_issue(issue_id)
-    comment = issue.comments.build
-    comment.save('body': comment_msg)
-  rescue JIRA::HTTPError => error
-    raise InvalidKeyError if error.code == '404'
-    raise error
+    return if Rails.configuration.disable_jira_comments
+    begin
+      issue = get_issue(issue_id)
+      comment = issue.comments.build
+      comment.save('body': comment_msg)
+    rescue JIRA::HTTPError => error
+      raise InvalidKeyError if error.code == '404'
+      raise error
+    end
   end
 
   def self.get_issue(id)

--- a/spec/lib/clients/github_spec.rb
+++ b/spec/lib/clients/github_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe GithubClient do
         github.create_status(repo: 'owner/repo', sha: 'abc123', state: 'success', description: 'foo')
       }.to_not raise_error
     end
+
+    context 'when disabled' do
+      before do
+        allow(Rails.configuration).to receive(:disable_github_status_update).and_return(true)
+      end
+
+      it 'does not update the status' do
+        expect_any_instance_of(Octokit::Client).not_to receive(:create_status)
+        github.create_status(repo: 'owner/repo', sha: 'abc123', state: 'success', description: 'foo')
+      end
+    end
   end
 
   describe '#repo_accessible?' do

--- a/spec/lib/clients/jira_spec.rb
+++ b/spec/lib/clients/jira_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe JiraClient do
       JiraClient.post_comment('ISSUE-ID', 'comment text')
     end
 
+    context 'when disabled' do
+      before do
+        allow(Rails.configuration).to receive(:disable_jira_comments).and_return(true)
+      end
+
+      it 'does not post a comment' do
+        expect(comment_mock).not_to receive(:save)
+        JiraClient.post_comment('ISSUE-ID', 'comment text')
+      end
+    end
+
     context 'when posting fails' do
       context 'because of HTTP 404' do
         let(:error) { JIRA::HTTPError.new(response) }


### PR DESCRIPTION
- Enables testing with an org level GitHub webhook in a non-production environment without updates being propagated to GitHub or Jira.
`DISABLE_GITHUB_STATUS_UPDATE=true`
`DISABLE_JIRA_COMMENTS=true`
 
- Reduces the number of web and delayed job instances to 2 outside production, as the availability zone constraint make it harder to get a resource offer from Mesos.
 
- Configures the delayed job workers with more sensible values than the defaults (for this workload).