### PR TITLE
Remove Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CircleCI](https://circleci.com/gh/FundingCircle/shipment_tracker/tree/master.svg?style=shield)](https://circleci.com/gh/FundingCircle/shipment_tracker/tree/master)
 [![Code Climate](https://codeclimate.com/github/FundingCircle/shipment_tracker/badges/gpa.svg)](https://codeclimate.com/github/FundingCircle/shipment_tracker)
 [![Test Coverage](https://codeclimate.com/github/FundingCircle/shipment_tracker/badges/coverage.svg)](https://codeclimate.com/github/FundingCircle/shipment_tracker/coverage)
-[![Dependency Status](https://gemnasium.com/badges/github.com/FundingCircle/shipment_tracker.svg)](https://gemnasium.com/github.com/FundingCircle/shipment_tracker)
 
 [![](http://i.imgur.com/VkjlJmj.jpg)](https://www.flickr.com/photos/britishlibrary/11237769263/)
 


### PR DESCRIPTION
💁 Gemnasium has been unavailable since May 2018. We should remove the badge.

https://about.gitlab.com/press/releases/2018-01-30-gemnasium-acquisition.html