### PR TITLE
Update New Relic app id for staging

### DIFF
--- a/dropzone.yaml
+++ b/dropzone.yaml
@@ -17,7 +17,7 @@ vars:
     web_instances: 3
     web_memory: 1024
   staging:
-    new_relic_app_id: 225742386
+    new_relic_app_id: 262878917
   uat:
     new_relic_app_id: 216487708
   default:


### PR DESCRIPTION
💁 This identifier changed some time around 2019-04-05 and was not updated here at the time. This needs to be updated so that all the deployment related tasks will pass.