### PR TITLE
Auto link a ticket on PR to master only

### DIFF
--- a/app/jobs/auto_link_ticket_job.rb
+++ b/app/jobs/auto_link_ticket_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'link_ticket'
+
+class AutoLinkTicketJob < ActiveJob::Base
+  include Rails.application.routes.url_helpers
+
+  JIRA_TICKET_REGEX = /(?<ticket_key>[A-Z]{2,10}-[1-9][0-9]*)/.freeze
+
+  queue_as :default
+
+  def perform(args)
+    head_sha = args.delete(:head_sha)
+    repo_name = args.delete(:repo_name)
+    branch_name = args.delete(:branch_name)
+    title = args.delete(:title)
+
+    jira_key = extract_jira_key(branch_name) || extract_jira_key(title)
+    return unless jira_key
+
+    LinkTicket.run(
+      jira_key: jira_key,
+      feature_review_path: feature_reviews_path(apps: { repo_name => head_sha }),
+      root_url: root_url,
+    )
+  end
+
+  private
+
+  def extract_jira_key(text)
+    text[JIRA_TICKET_REGEX, 'ticket_key']
+  end
+end

--- a/app/models/payloads/github_pull_request.rb
+++ b/app/models/payloads/github_pull_request.rb
@@ -61,5 +61,9 @@ module Payloads
     def base_branch_master?
       pull_request&.dig('base', 'ref') == 'master'
     end
+
+    def title
+      pull_request['title']
+    end
   end
 end

--- a/app/use_cases/handle_pull_request_created_event.rb
+++ b/app/use_cases/handle_pull_request_created_event.rb
@@ -4,12 +4,23 @@ class HandlePullRequestCreatedEvent
   include SolidUseCase
   include PullRequestEventValidatable
 
-  steps :validate, :post_not_found_status
+  steps :validate, :post_not_found_status, :auto_link_ticket
 
   def post_not_found_status(payload)
     CommitStatusNotFoundJob.perform_later(
       full_repo_name: payload.full_repo_name,
       sha: payload.head_sha,
+    )
+
+    continue(payload)
+  end
+
+  def auto_link_ticket(payload)
+    AutoLinkTicketJob.perform_later(
+      repo_name: payload.repo_name,
+      head_sha: payload.head_sha,
+      branch_name: payload.branch_name,
+      title: payload.title,
     )
 
     continue(payload)

--- a/spec/jobs/auto_link_ticket_job_spec.rb
+++ b/spec/jobs/auto_link_ticket_job_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutoLinkTicketJob do
+  describe '#perform' do
+    let(:args) {
+      {
+        head_sha: 'abc123',
+        repo_name: 'my-repo',
+        branch_name: branch_name,
+        title: title,
+      }
+    }
+    let(:branch_name) { 'branch-name' }
+    let(:title) { 'A Cool Title' }
+
+    context 'when there is no ticket name in the branch name or title' do
+      let(:branch_name) { 'branch-name' }
+      let(:title) { 'A Cool Title' }
+
+      it 'does not attempt to link a ticket' do
+        expect(LinkTicket).not_to receive(:run)
+        described_class.perform_later(args)
+      end
+    end
+
+    context 'when there is a ticket name at the start of the branch name' do
+      let(:branch_name) { 'TEST-101-branch-name' }
+
+      it 'attempts to link the ticket' do
+        expect(LinkTicket).to receive(:run).with(hash_including(jira_key: 'TEST-101'))
+        described_class.perform_later(args)
+      end
+    end
+
+    context 'when there is a ticket name in the middle of the branch name' do
+      let(:branch_name) { 'abc-TEST-101-branch-name' }
+
+      it 'attempts to link the ticket' do
+        expect(LinkTicket).to receive(:run).with(hash_including(jira_key: 'TEST-101'))
+        described_class.perform_later(args)
+      end
+    end
+
+    context 'when there is a lower-case ticket name in the branch name' do
+      let(:branch_name) { 'test-101-branch-name' }
+
+      it 'does not attempt to link the ticket' do
+        expect(LinkTicket).not_to receive(:run)
+        described_class.perform_later(args)
+      end
+    end
+
+    context 'when there is a ticket name in the branch name and title' do
+      let(:branch_name) { 'TEST-101-branch-name' }
+      let(:title) { '[TEST-102] A Cool Title' }
+
+      it 'attempts to link the ticket from the branch name' do
+        expect(LinkTicket).to receive(:run).with(hash_including(jira_key: 'TEST-101'))
+        described_class.perform_later(args)
+      end
+    end
+
+    context 'when there is a ticket name in the title' do
+      let(:title) { '[TEST-101] A Cool Title' }
+
+      it 'attempts to link the ticket' do
+        expect(LinkTicket).to receive(:run).with(hash_including(jira_key: 'TEST-101'))
+        described_class.perform_later(args)
+      end
+    end
+
+    context 'when there is a lower-case ticket name in the title' do
+      let(:title) { '[test-101] A Cool Title' }
+
+      it 'does not attempt to link the ticket' do
+        expect(LinkTicket).not_to receive(:run)
+        described_class.perform_later(args)
+      end
+    end
+  end
+end

--- a/spec/models/payloads/github_pull_request_spec.rb
+++ b/spec/models/payloads/github_pull_request_spec.rb
@@ -252,4 +252,23 @@ RSpec.describe Payloads::GithubPullRequest do
       end
     end
   end
+
+  describe '#title' do
+    context 'with title data' do
+      it 'returns the title' do
+        data = { 'pull_request' => { 'title' => 'A Cool Title' } }
+        payload = described_class.new(data)
+
+        expect(payload.title).to eq('A Cool Title')
+      end
+    end
+
+    context 'with no title data' do
+      it 'returns nil' do
+        payload = described_class.new('pull_request' => { 'some_key' => 'some_value' })
+
+        expect(payload.title).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
#412 Caused a huge amount of load from `salesforce` and `ce-salesforce` repos which have PRs into staging that are being auto-linked. This resulted in us quite quickly hitting the 5000 request per hour GitHub API limit whenever changes are pushed to these repos.

The idea behind this change is to use GitHub webhooks for [PullRequestEvent](https://developer.github.com/v3/activity/events/types/#pullrequestevent)s and do the auto-link only when a PR is created for the `master` branch.

This time it will also look for the ticket in the PR title as well as the branch name.

Tested successfully on UAT.