### PR TITLE
Retry commit status updates when GitHub API rate limit is reset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,12 @@ jobs:
           command: echo "$DOCKER_PASSWORD" | docker login --username="$DOCKER_USERNAME" --password-stdin $DOCKER_REGISTRY
       - run:
           name: Build Docker image
-          command: docker build . --tag $CIRCLE_PROJECT_REPONAME --pull
+          command: |
+            docker build . \
+              --tag $CIRCLE_PROJECT_REPONAME \
+              --pull \
+              --build-arg NAME=$CIRCLE_PROJECT_REPONAME \
+              --build-arg REVISION=$CIRCLE_SHA1
       - run:
           name: Push to Docker registry
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,3 +57,9 @@ COPY --chown=shipment_tracker:shipment_tracker dropzone.yaml /usr/local/deploy/d
 COPY --chown=shipment_tracker:shipment_tracker . .
 
 ENTRYPOINT ["/sbin/tini", "--", "docker-entrypoint.sh"]
+
+ARG REVISION=unknown
+ENV REVISION=$REVISION
+ARG NAME=shipment_tracker
+LABEL name=$NAME version=$REVISION
+RUN echo "$REVISION" > REVISION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,10 +83,10 @@ GEM
     daemons (1.2.4)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
-    delayed_job (4.1.5)
-      activesupport (>= 3.0, < 5.3)
-    delayed_job_active_record (4.1.3)
-      activerecord (>= 3.0, < 5.3)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
       delayed_job (>= 3.0, < 5)
     delayed_job_web (1.4.3)
       activerecord (> 3.0.0)
@@ -197,7 +197,7 @@ GEM
     mime-types (2.99.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.12.0)
     multi_json (1.11.2)
     multi_test (0.1.2)
     multi_xml (0.5.5)
@@ -464,4 +464,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/jobs/commit_status_error_job.rb
+++ b/app/jobs/commit_status_error_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'commit_status'
+
+class CommitStatusErrorJob < CommitStatusRetryableJob
+  queue_as :default
+
+  def perform(opts)
+    CommitStatus.new(full_repo_name: opts[:full_repo_name], sha: opts[:sha]).error
+  end
+end

--- a/app/jobs/commit_status_not_found_job.rb
+++ b/app/jobs/commit_status_not_found_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'commit_status'
+
+class CommitStatusNotFoundJob < CommitStatusRetryableJob
+  queue_as :default
+
+  def perform(opts)
+    CommitStatus.new(full_repo_name: opts[:full_repo_name], sha: opts[:sha]).not_found
+  end
+end

--- a/app/jobs/commit_status_reset_job.rb
+++ b/app/jobs/commit_status_reset_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'commit_status'
+
+class CommitStatusResetJob < CommitStatusRetryableJob
+  queue_as :default
+
+  def perform(opts)
+    CommitStatus.new(full_repo_name: opts[:full_repo_name], sha: opts[:sha]).reset
+  end
+end

--- a/app/jobs/commit_status_retryable_job.rb
+++ b/app/jobs/commit_status_retryable_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CommitStatusRetryableJob < ActiveJob::Base
+  rescue_from(GithubClient::RateLimitError) do |error|
+    Rails.logger.warn 'GitHub API rate limit reached. '\
+      "Will retry when limit is reset at #{error.rate_limit.resets_at.strftime('%k:%M %Z')}"
+    retry_job wait: error.rate_limit.resets_in
+  end
+end

--- a/app/jobs/commit_status_update_job.rb
+++ b/app/jobs/commit_status_update_job.rb
@@ -2,16 +2,10 @@
 
 require 'commit_status'
 
-class CommitStatusUpdateJob < ActiveJob::Base
+class CommitStatusUpdateJob < CommitStatusRetryableJob
   queue_as :default
 
-  rescue_from(GithubClient::RateLimitError) do |error|
-    Rails.logger.warn 'GitHub API rate limit reached. '\
-      "Will retry when limit is reset at #{error.rate_limit.resets_at.strftime('%k:%M %Z')}"
-    retry_job wait: error.rate_limit.resets_in
-  end
-
-  def perform(opts, method: :update)
-    CommitStatus.new(full_repo_name: opts[:full_repo_name], sha: opts[:sha]).send(method)
+  def perform(opts)
+    CommitStatus.new(full_repo_name: opts[:full_repo_name], sha: opts[:sha]).update
   end
 end

--- a/app/jobs/commit_status_update_job.rb
+++ b/app/jobs/commit_status_update_job.rb
@@ -3,7 +3,7 @@
 class CommitStatusUpdateJob < ActiveJob::Base
   queue_as :default
 
-  def perform(opts)
-    CommitStatus.new(full_repo_name: opts[:full_repo_name], sha: opts[:sha]).update
+  def perform(opts, method: :update)
+    CommitStatus.new(full_repo_name: opts[:full_repo_name], sha: opts[:sha]).send(method)
   end
 end

--- a/app/jobs/commit_status_update_job.rb
+++ b/app/jobs/commit_status_update_job.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
+require 'commit_status'
+
 class CommitStatusUpdateJob < ActiveJob::Base
   queue_as :default
+
+  rescue_from(GithubClient::RateLimitError) do |error|
+    Rails.logger.warn 'GitHub API rate limit reached. '\
+      "Will retry when limit is reset at #{error.rate_limit.resets_at.strftime('%k:%M %Z')}"
+    retry_job wait: error.rate_limit.resets_in
+  end
 
   def perform(opts, method: :update)
     CommitStatus.new(full_repo_name: opts[:full_repo_name], sha: opts[:sha]).send(method)

--- a/app/jobs/relink_ticket_job.rb
+++ b/app/jobs/relink_ticket_job.rb
@@ -52,18 +52,16 @@ class RelinkTicketJob < ActiveJob::Base
   end
 
   def post_not_found_status(full_repo_name, sha)
-    CommitStatusUpdateJob.perform_later(
+    CommitStatusNotFoundJob.perform_later(
       full_repo_name: full_repo_name,
       sha: sha,
-      method: 'not_found',
     )
   end
 
   def post_error_status(full_repo_name, sha)
-    CommitStatusUpdateJob.perform_later(
+    CommitStatusErrorJob.perform_later(
       full_repo_name: full_repo_name,
       sha: sha,
-      method: 'error',
     )
   end
 

--- a/app/jobs/relink_ticket_job.rb
+++ b/app/jobs/relink_ticket_job.rb
@@ -52,11 +52,19 @@ class RelinkTicketJob < ActiveJob::Base
   end
 
   def post_not_found_status(full_repo_name, sha)
-    CommitStatus.new(full_repo_name: full_repo_name, sha: sha).not_found
+    CommitStatusUpdateJob.perform_later(
+      full_repo_name: full_repo_name,
+      sha: sha,
+      method: 'not_found',
+    )
   end
 
   def post_error_status(full_repo_name, sha)
-    CommitStatus.new(full_repo_name: full_repo_name, sha: sha).error
+    CommitStatusUpdateJob.perform_later(
+      full_repo_name: full_repo_name,
+      sha: sha,
+      method: 'error',
+    )
   end
 
   def commit_on_master?(full_repo_name, sha)

--- a/app/use_cases/handle_push_event.rb
+++ b/app/use_cases/handle_push_event.rb
@@ -27,10 +27,9 @@ class HandlePushEvent
   def reset_commit_status(payload)
     return fail :protected_branch if payload.push_to_master?
 
-    CommitStatusUpdateJob.perform_later(
+    CommitStatusResetJob.perform_later(
       full_repo_name: payload.full_repo_name,
       sha: payload.after_sha,
-      method: 'reset',
     )
 
     continue(payload)

--- a/app/use_cases/handle_push_event.rb
+++ b/app/use_cases/handle_push_event.rb
@@ -27,7 +27,12 @@ class HandlePushEvent
   def reset_commit_status(payload)
     return fail :protected_branch if payload.push_to_master?
 
-    CommitStatus.new(full_repo_name: payload.full_repo_name, sha: payload.after_sha).reset
+    CommitStatusUpdateJob.perform_later(
+      full_repo_name: payload.full_repo_name,
+      sha: payload.after_sha,
+      method: 'reset',
+    )
+
     continue(payload)
   end
 

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -30,4 +30,4 @@ module Sinatra
   register DelayedJobAuth
 end
 
-DelayedJobWeb.register Sinatra::DelayedJobAuth
+DelayedJobWeb.register Sinatra::DelayedJobAuth unless Rails.env.development?

--- a/lib/clients/github.rb
+++ b/lib/clients/github.rb
@@ -3,11 +3,6 @@
 require 'git_clone_url'
 require 'octokit'
 
-Octokit.middleware = Faraday::RackBuilder.new { |builder|
-  builder.response :logger
-  builder.adapter Faraday.default_adapter
-}
-
 class GithubClient
   class RateLimitError < RuntimeError
     attr_accessor :rate_limit

--- a/lib/clients/github.rb
+++ b/lib/clients/github.rb
@@ -50,7 +50,7 @@ class GithubClient
 
   def last_status_for(repo:, sha:)
     response = client.combined_status(repo, sha)
-  rescue Octokit::ClientError => e
+  rescue Octokit::Error => e
     Rails.logger.warn "Failed to fetch status for #{repo} at #{sha}: #{e.class.name} #{e.message}"
 
     if e.class == Octokit::TooManyRequests

--- a/spec/jobs/commit_status_error_job_spec.rb
+++ b/spec/jobs/commit_status_error_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CommitStatusErrorJob do
+  describe '#perform' do
+    it 'passes its parameters to CommitStatus#error' do
+      pr_status = instance_double(CommitStatus)
+      params = { full_repo_name: 'owner/repo', sha: 'abc123' }
+
+      allow(CommitStatus).to receive(:new).with(params).and_return(pr_status)
+      expect(pr_status).to receive(:error)
+
+      described_class.perform_now(params)
+    end
+  end
+end

--- a/spec/jobs/commit_status_not_found_job_spec.rb
+++ b/spec/jobs/commit_status_not_found_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CommitStatusNotFoundJob do
+  describe '#perform' do
+    it 'passes its parameters to CommitStatus#not_found' do
+      pr_status = instance_double(CommitStatus)
+      params = { full_repo_name: 'owner/repo', sha: 'abc123' }
+
+      allow(CommitStatus).to receive(:new).with(params).and_return(pr_status)
+      expect(pr_status).to receive(:not_found)
+
+      described_class.perform_now(params)
+    end
+  end
+end

--- a/spec/jobs/commit_status_reset_job_spec.rb
+++ b/spec/jobs/commit_status_reset_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CommitStatusResetJob do
+  describe '#perform' do
+    it 'passes its parameters to CommitStatus#reset' do
+      pr_status = instance_double(CommitStatus)
+      params = { full_repo_name: 'owner/repo', sha: 'abc123' }
+
+      allow(CommitStatus).to receive(:new).with(params).and_return(pr_status)
+      expect(pr_status).to receive(:reset)
+
+      described_class.perform_now(params)
+    end
+  end
+end


### PR DESCRIPTION
When Shipment Tracker makes more than 5000 GitHub API requests per hour, PR status updates will begin to fail and the delayed job queue builds up with retries which will never succeed. Currently there are [10](https://github.com/FundingCircle/shipment_tracker/blob/5ea1759ce8ef8d8647fc434b93b6bf33a71e3855/config/initializers/delayed_job.rb#L4) retries per status update which causes a huge backlog of jobs, until the limit is reset. This creates a lot of log spam. After the retries are exhausted the PR needs to be manually updated to trigger a new status update.

This change retries the job when the GitHub API rate limit is reset, therefore allowing the original job to complete at the earliest opportunity.

#### TODO
- [x] Do a real world test.
- [x] Fix specs and add new examples.
