### PR TITLE
Allow disabling github status updates for certain applications

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -38,6 +38,8 @@ class CommitStatus
   end
 
   def last_status
+    return unless allow_requests?
+
     @last_status ||= github.last_status_for(repo: full_repo_name, sha: sha)
   end
 
@@ -48,12 +50,23 @@ class CommitStatus
   end
 
   def post_status(notification, target_url = nil)
+    return unless allow_requests?
+
     github.create_status(
       repo: full_repo_name,
       sha: sha,
       state: notification[:status],
       description: notification[:description],
       target_url: target_url,
+    )
+  end
+
+  def allow_requests?
+    app = full_repo_name.split('/').last
+
+    !(
+      ShipmentTracker::DISABLE_GITHUB_STATUS_UPDATES_FOR_APPS.include?(app) ||
+      ShipmentTracker::DISABLE_GITHUB_STATUS_UPDATES_FOR_APPS.include?(full_repo_name)
     )
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module ShipmentTracker
   GITHUB_REPO_STATUS_WRITE_TOKEN ||= ENV.fetch('GITHUB_REPO_STATUS_WRITE_TOKEN', nil)
   DEFAULT_DEPLOY_LOCALE ||= ENV.fetch('DEFAULT_DEPLOY_LOCALE', 'gb') # For older events without locale
   NUMBER_OF_TICKETS_TO_DISPLAY ||= ENV.fetch('NUMBER_OF_TICKETS_TO_DISPLAY', 100)
+  DISABLE_GITHUB_STATUS_UPDATES_FOR_APPS ||=
+    ENV.fetch('DISABLE_GITHUB_STATUS_UPDATES_FOR_APPS', '').split(',').map(&:strip)
   # TODO: Move our constants here. Keep Rails config for actual Rails configuration.
 
   class Application < Rails::Application

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -312,4 +312,18 @@ RSpec.describe CommitStatus do
       CommitStatus.new(full_repo_name: 'owner/repo', sha: 'abc123').last_status
     end
   end
+
+  describe 'disabling commit status updates with DISABLE_GITHUB_STATUS_UPDATES_FOR_APPS' do
+    it "won't do a call to github if the app is in DISABLE_GITHUB_STATUS_UPDATES_FOR_APPS" do
+      stub_const('ShipmentTracker::DISABLE_GITHUB_STATUS_UPDATES_FOR_APPS', ['my-repo', 'test-org/cool-app'])
+
+      expect(client).not_to receive(:create_status)
+      CommitStatus.new(full_repo_name: 'owner/my-repo', sha: 'abc123').not_found
+      CommitStatus.new(full_repo_name: 'test-org/cool-app', sha: 'abc123').not_found
+
+      expect(client).not_to receive(:last_status_for)
+      CommitStatus.new(full_repo_name: 'owner/my-repo', sha: 'abc123').last_status
+      CommitStatus.new(full_repo_name: 'test-org/cool-app', sha: 'abc123').last_status
+    end
+  end
 end


### PR DESCRIPTION
This feature is needed as we have a lot of repositories and some
workflows cause a lot of calls to github and we get rate limited.

Work like this:

```
DISABLE_GITHUB_STATUS_UPDATES_FOR_APPS='shipment-tracker, FundingCircle/loga'
```

allowed values: `org/repo` or just the `repo` name