### PR TITLE
Stop git fetch in RelinkTicketJob

### DIFF
--- a/app/jobs/relink_ticket_job.rb
+++ b/app/jobs/relink_ticket_job.rb
@@ -66,7 +66,7 @@ class RelinkTicketJob < ActiveJob::Base
   end
 
   def commit_on_master?(full_repo_name, sha)
-    git_repo = GitRepositoryLoader.from_rails_config.load(full_repo_name.split('/')[1], update_repo: true)
+    git_repo = GitRepositoryLoader.from_rails_config.load(full_repo_name.split('/')[1])
 
     git_repo.commit_on_master?(sha)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,7 +58,7 @@ module ShipmentTracker
     config.git_repository_cache_dir = ENV.fetch('GIT_REPOSITORY_CACHE_DIR', Dir.tmpdir)
     config.data_maintenance_mode = ENV['DATA_MAINTENANCE'] == 'true'
     config.allow_git_fetch_on_request = ENV['ALLOW_GIT_FETCH_ON_REQUEST'] == 'true'
-    config.git_worker_interval_seconds = ENV.fetch('GIT_WORKER_INTERVAL_SECONDS', 5).to_i
+    config.git_worker_interval_seconds = ENV.fetch('GIT_WORKER_INTERVAL_SECONDS', 5).to_f
     config.git_worker_max_threads = ENV.fetch('GIT_WORKER_MAX_THREADS', 16).to_i
     config.disable_github_status_update = ENV['DISABLE_GITHUB_STATUS_UPDATE'] == 'true'
     config.disable_jira_comments = ENV['DISABLE_JIRA_COMMENTS'] == 'true'


### PR DESCRIPTION
These errors happen because the local git repositories are being updated from two processes, the scheduled git worker and the delayed job workers. The original design was to update the local git repositories from the git worker only, every few seconds. Then a change was made to the RelinkTicketJob delayed job which required looking up a commit in the local repo. In response to errors related to missing commits this was changed to also update the git repo before the lookup. This introduces a locking issue from the concurrent fetches that can result in the repo being deleted and re-cloned. We should either:

1. Stop updating from the RelinkTicketJob and instead play with reducing `GIT_WORKER_INTERVAL_SECONDS` from the current value of 5. Reducing it to 1 second or less might be enough for the local git repo to be updated by the time it is looked up in RelinkTicketJob.
1. Remove the git worker. Currently it is effectively redundant other than for the initial full clone when the directory is empty.

I think we should try 1 first, as it relies more on the git protocol than webhooks from GitHub. If that still results in problems with missing commits, we can do 2.