### PR TITLE
Fix handling of GitHub merge events

### DIFF
--- a/app/controllers/github_notifications_controller.rb
+++ b/app/controllers/github_notifications_controller.rb
@@ -16,11 +16,14 @@ class GithubNotificationsController < ApplicationController
   private
 
   def handle_pull_request_event
-    if pull_request_payload.updated? || pull_request_payload.merged?
+    if pull_request_payload.updated?
       HandlePullRequestUpdatedEvent.run(pull_request_payload)
       head :ok
     elsif pull_request_payload.created?
       HandlePullRequestCreatedEvent.run(pull_request_payload)
+      head :ok
+    elsif pull_request_payload.merged?
+      HandlePullRequestMergedEvent.run(pull_request_payload)
       head :ok
     else
       head :accepted

--- a/app/use_cases/handle_pull_request_event_base.rb
+++ b/app/use_cases/handle_pull_request_event_base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'solid_use_case'
+
+require 'git_repository_location'
+require 'pull_request_event_validatable'
+
+class HandlePullRequestEventBase
+  include SolidUseCase
+  include PullRequestEventValidatable
+
+  def update_remote_head(payload)
+    git_repository_location = GitRepositoryLocation.find_by_full_repo_name(payload.full_repo_name)
+    return fail :repo_not_found unless git_repository_location
+
+    git_repository_location.update(remote_head: payload.after_sha)
+    continue(payload)
+  end
+end

--- a/app/use_cases/handle_pull_request_merged_event.rb
+++ b/app/use_cases/handle_pull_request_merged_event.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'handle_pull_request_event_base'
+
+class HandlePullRequestMergedEvent < HandlePullRequestEventBase
+  steps :validate, :update_remote_head
+end

--- a/app/use_cases/handle_pull_request_updated_event.rb
+++ b/app/use_cases/handle_pull_request_updated_event.rb
@@ -1,21 +1,10 @@
 # frozen_string_literal: true
 
-require 'git_repository_location'
 require 'relink_ticket_job'
+require 'handle_pull_request_event_base'
 
-class HandlePullRequestUpdatedEvent
-  include SolidUseCase
-  include PullRequestEventValidatable
-
+class HandlePullRequestUpdatedEvent < HandlePullRequestEventBase
   steps :validate, :update_remote_head, :reset_commit_status, :relink_tickets
-
-  def update_remote_head(payload)
-    git_repository_location = GitRepositoryLocation.find_by_full_repo_name(payload.full_repo_name)
-    return fail :repo_not_found unless git_repository_location
-
-    git_repository_location.update(remote_head: payload.after_sha)
-    continue(payload)
-  end
 
   def reset_commit_status(payload)
     CommitStatusResetJob.perform_later(

--- a/spec/controllers/github_notifications_controller_spec.rb
+++ b/spec/controllers/github_notifications_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GithubNotificationsController do
       end
 
       context 'when event is a pull request opened' do
-        it 'runs the HandlePullRequestCreatedEvent use case' do
+        it 'runs the correct use case and responds with a 200 OK' do
           expect(HandlePullRequestCreatedEvent).to receive(:run).with(anything)
 
           post :create, github_notification: { 'action' => 'opened' }
@@ -32,7 +32,7 @@ RSpec.describe GithubNotificationsController do
       end
 
       context 'when event is a pull request updated' do
-        it 'runs the HandlePullRequestUpdatedEvent use case' do
+        it 'runs the correct use case and responds with a 200 OK' do
           expect(HandlePullRequestUpdatedEvent).to receive(:run).with(anything)
 
           post :create, github_notification: { 'action' => 'synchronize' }
@@ -42,8 +42,8 @@ RSpec.describe GithubNotificationsController do
       end
 
       context 'when event is a pull request merged' do
-        it 'runs the HandlePullRequestUpdatedEvent use case' do
-          expect(HandlePullRequestUpdatedEvent).to receive(:run).with(anything)
+        it 'runs the correct use case and responds with a 200 OK' do
+          expect(HandlePullRequestMergedEvent).to receive(:run).with(anything)
 
           post :create, github_notification: { 'action' => 'closed', 'pull_request' => { 'merged' => true } }
 

--- a/spec/use_cases/handle_pull_request_merged_event_spec.rb
+++ b/spec/use_cases/handle_pull_request_merged_event_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'handle_pull_request_merged_event'
+require 'payloads/github_pull_request'
+
+RSpec.describe HandlePullRequestMergedEvent do
+  let(:payload_data) {
+    {
+      'pull_request' => {
+        'head' => { 'sha' => 'def1234', 'ref' => branch_name },
+        'base' => { 'ref' => base_branch, 'repo' => { 'full_name' => repository } },
+      },
+      'before' => 'abc1234',
+      'after' => 'def1234',
+    }
+  }
+  let(:payload) { Payloads::GithubPullRequest.new(payload_data) }
+  let(:branch_name) { 'branch-name' }
+  let(:base_branch) { 'master' }
+  let(:repository) { 'owner/repo_1' }
+
+  before do
+    allow_any_instance_of(CommitStatus).to receive(:reset)
+    allow(GitRepositoryLocation).to receive(:repo_tracked?).and_return(true)
+  end
+
+  describe 'validation' do
+    context 'when repo is not audited' do
+      before do
+        allow(GitRepositoryLocation).to receive(:repo_tracked?).and_return(false)
+      end
+
+      it 'fails' do
+        result = described_class.run(payload)
+        expect(result).to fail_with(:repo_not_under_audit)
+      end
+    end
+
+    context 'when base branch is not "master"' do
+      let(:base_branch) { 'other-base-branch' }
+
+      it 'fails' do
+        result = described_class.run(payload)
+        expect(result).to fail_with(:base_not_master)
+      end
+    end
+  end
+
+  describe 'updating remote head' do
+    context 'when repo not found' do
+      before do
+        allow(GitRepositoryLocation).to receive(:find_by_full_repo_name).and_return(nil)
+      end
+
+      it 'fails' do
+        result = described_class.run(payload)
+        expect(result).to fail_with(:repo_not_found)
+      end
+    end
+
+    context 'repo exists' do
+      let(:git_repository_location) { instance_double(GitRepositoryLocation) }
+      let(:git_repository_loader) { instance_double(GitRepositoryLoader) }
+      let(:git_repository) { instance_double(GitRepository) }
+
+      before do
+        allow_any_instance_of(CommitStatus).to receive(:not_found)
+
+        allow(GitRepositoryLocation).to receive(:find_by_full_repo_name).and_return(git_repository_location)
+
+        allow(GitRepositoryLoader).to receive(:from_rails_config) { git_repository_loader }
+        allow(git_repository_loader).to receive(:load) { git_repository }
+        allow(git_repository).to receive(:commit_on_master?) { false }
+      end
+
+      it 'updates the corresponding repository location' do
+        expect(git_repository_location).to receive(:update).with(remote_head: 'def1234')
+        described_class.run(payload)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We do not need to update the commit status for the merge commit. Currently we are showing a ❌ for the master branch as we post a "not found" status after a merge event.

e.g.

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/4941953/66202270-3c740080-e69d-11e9-9d83-4ad7efb0007b.png">
