### PR TITLE
Reduce interval for unicorn stats collection

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -10,7 +10,7 @@ pid_file = '/tmp/unicorn.pid'
 PrometheusExporter::Instrumentation::Unicorn.start(
   pid_file: pid_file,
   listener_address: "0.0.0.0:#{port_http}",
-  frequency: 1,
+  frequency: 0.01,
 )
 
 worker_processes Integer(ENV['WEB_CONCURRENCY'] || 1)


### PR DESCRIPTION
Collecting unicorn stats every second is not frequent enough to record the true situation. The current [graph](https://grafana.fc-ops.com/d/Zh46rPtZz/shipment-tracker?orgId=1&var-datasource=Prometheus&var-country=GBR&var-region=eu-west-1&var-environment=production&var-repository=funding_circle_app&refresh=15s&from=now-2d&to=now&fullscreen&panelId=56) very rarely shows an active worker.

<img width="1423" alt="image" src="https://user-images.githubusercontent.com/4941953/67940460-9ba93000-fbcb-11e9-814c-c38596a927c6.png">

