### PR TITLE
PagerDuty integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
               quay.io/fundingcircle/docker-scripts:latest docker/ci-docker-publish
   pagerduty_plan:
     docker:
-      - image: quay.io/fundingcircle/circleci-terraform:latest
+      - image: quay.io/fundingcircle/circleci-terraform:5.3-0.11.14
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
@@ -185,7 +185,7 @@ jobs:
 
   pagerduty_apply:
     docker:
-      - image: quay.io/fundingcircle/circleci-terraform:latest
+      - image: quay.io/fundingcircle/circleci-terraform:5.3-0.11.14
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
           PLUGIN_ACTIONS: plan
           PLUGIN_ROOT_DIR: terraform/
           TF_VAR_service_name: shipment_tracker
-          TF_VAR_escalation_policy_name: Global DevOps Escalation Policy
+          TF_VAR_escalation_policy_name: Observability
 
     steps:
       - checkout
@@ -192,7 +192,7 @@ jobs:
         environment:
           PLUGIN_ROOT_DIR: terraform/
           TF_VAR_service_name: shipment_tracker
-          TF_VAR_escalation_policy_name: Global DevOps Escalation Policy
+          TF_VAR_escalation_policy_name: Observability
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,13 +220,13 @@ workflows:
             - features
       - publish-docker-image:
           context: org-global
-      - pagerduty_plan:
-          context: org-pagerduty
-          filters:
-            branches:
-              ignore: master
+      # - pagerduty_plan:
+      #     context: org-pagerduty
+      #     filters:
+      #       branches:
+      #         ignore: master
       - pagerduty_apply:
           context: org-pagerduty
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,10 @@ workflows:
               ignore: master
       - pagerduty_apply:
           context: org-pagerduty
+          requires:
+            - specs
+            - features
+            - publish-docker-image
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,13 +220,13 @@ workflows:
             - features
       - publish-docker-image:
           context: org-global
-      # - pagerduty_plan:
-      #     context: org-pagerduty
-      #     filters:
-      #       branches:
-      #         ignore: master
+      - pagerduty_plan:
+          context: org-pagerduty
+          filters:
+            branches:
+              ignore: master
       - pagerduty_apply:
           context: org-pagerduty
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ defaults: &defaults
       environment:
         POSTGRES_DB: shipment_tracker_test
         POSTGRES_USER: st_test
-        POSTGRES_PASSWORD: ""
+        POSTGRES_PASSWORD: ''
 
 install_system_packages: &install_system_packages
   run:
@@ -165,6 +165,40 @@ jobs:
               --env DOCKER_PASS="$DOCKER_PASSWORD" \
               --volume /var/run/docker.sock:/var/run/docker.sock \
               quay.io/fundingcircle/docker-scripts:latest docker/ci-docker-publish
+  pagerduty_plan:
+    docker:
+      - image: quay.io/fundingcircle/circleci-terraform:latest
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
+        environment:
+          PLUGIN_ACTIONS: plan
+          PLUGIN_ROOT_DIR: terraform/
+          TF_VAR_service_name: shipment_tracker
+          TF_VAR_escalation_policy_name: Global DevOps Escalation Policy
+
+    steps:
+      - checkout
+      - run:
+          name: Terraform Plan
+          command: /bin/circleci-terraform
+
+  pagerduty_apply:
+    docker:
+      - image: quay.io/fundingcircle/circleci-terraform:latest
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
+        environment:
+          PLUGIN_ROOT_DIR: terraform/
+          TF_VAR_service_name: shipment_tracker
+          TF_VAR_escalation_policy_name: Global DevOps Escalation Policy
+
+    steps:
+      - checkout
+      - run:
+          name: Terraform Apply
+          command: /bin/circleci-terraform
 
 workflows:
   version: 2
@@ -186,3 +220,13 @@ workflows:
             - features
       - publish-docker-image:
           context: org-global
+      - pagerduty_plan:
+          context: org-pagerduty
+          filters:
+            branches:
+              ignore: master
+      - pagerduty_apply:
+          context: org-pagerduty
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
               quay.io/fundingcircle/docker-scripts:latest docker/ci-docker-publish
   pagerduty_plan:
     docker:
-      - image: quay.io/fundingcircle/circleci-terraform:5.3-0.11.14
+      - image: quay.io/fundingcircle/circleci-terraform:6.2-0.12.16
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
@@ -185,7 +185,7 @@ jobs:
 
   pagerduty_apply:
     docker:
-      - image: quay.io/fundingcircle/circleci-terraform:5.3-0.11.14
+      - image: quay.io/fundingcircle/circleci-terraform:6.2-0.12.16
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ log/*.log
 tmp
 docker-compose.yml
 config/database.yml
+terraform/

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "= 0.11.14"
+  required_version = "= 0.12.16"
 
   backend "s3" {
     bucket         = "fc-tfstate"

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = "= 0.11.14"
+
+  backend "s3" {
+    bucket         = "fc-tfstate"
+    region         = "eu-west-1"
+    key            = "global/pagerduty/shipment_tracker.tfstate"
+    dynamodb_table = "tfstate-lock"
+    role_arn       = "arn:aws:iam::721867752048:role/terraform"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,3 @@
 output "pagerduty_service_integrations" {
-  value = "${module.pagerduty.pagerduty_service_integrations}"
+  value = module.pagerduty.pagerduty_service_integrations
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "pagerduty_honeybadger_integration_key" {
+  value = "${module.pagerduty.pagerduty_honeybadger_integration_key}"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,3 @@
-output "pagerduty_honeybadger_integration_key" {
-  value = "${module.pagerduty.pagerduty_honeybadger_integration_key}"
+output "pagerduty_service_integrations" {
+  value = "${module.pagerduty.pagerduty_service_integrations}"
 }

--- a/terraform/pagerduty.tf
+++ b/terraform/pagerduty.tf
@@ -1,5 +1,5 @@
 module "pagerduty" {
-  source = "github.com/fundingcircle/terraform-module-pagerduty?ref=v0.0.5"
+  source = "github.com/fundingcircle/terraform-module-pagerduty?ref=v0.0.6"
 
   pagerduty_token        = "${var.pagerduty_token}"
   service_name           = "${var.service_name}"

--- a/terraform/pagerduty.tf
+++ b/terraform/pagerduty.tf
@@ -1,0 +1,9 @@
+module "pagerduty" {
+  source = "github.com/fundingcircle/terraform-module-pagerduty?ref=v0.0.5"
+
+  pagerduty_token        = "${var.pagerduty_token}"
+  service_name           = "${var.service_name}"
+  escalation_policy_name = "${var.escalation_policy_name}"
+
+  enable_honeybadger_integration = true
+}

--- a/terraform/pagerduty.tf
+++ b/terraform/pagerduty.tf
@@ -1,9 +1,9 @@
 module "pagerduty" {
-  source = "github.com/fundingcircle/terraform-module-pagerduty?ref=v0.0.6"
+  source = "github.com/fundingcircle/terraform-module-pagerduty?ref=v0.0.7"
 
-  pagerduty_token        = "${var.pagerduty_token}"
-  service_name           = "${var.service_name}"
-  escalation_policy_name = "${var.escalation_policy_name}"
+  pagerduty_token        = var.pagerduty_token
+  service_name           = var.service_name
+  escalation_policy_name = var.escalation_policy_name
 
   enable_honeybadger_integration = true
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,3 @@
+variable "pagerduty_token" {}
+variable "escalation_policy_name" {}
+variable "service_name" {}


### PR DESCRIPTION
This integration is now using the `v0.0.7` version of the Terraform Module, which outputs the PagerDuty integrations URL instead of the token itself.
```
Outputs:

pagerduty_service_integrations = https://funding-circle-usa.pagerduty.com/service-directory/PS1URJ6/integrations
```