### PR TITLE
Remove better_errors Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,6 @@ group :dockerignore do
 end
 
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
   gem 'foreman', require: false
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,12 +44,6 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    better_errors (2.5.1)
-      coderay (>= 1.0.0)
-      erubi (>= 1.0.0)
-      rack (>= 0.9.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -82,7 +76,6 @@ GEM
       rails (>= 3, < 5)
     daemons (1.3.1)
     database_cleaner (1.7.0)
-    debug_inspector (0.0.3)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
     delayed_job_active_record (4.1.4)
@@ -100,7 +93,6 @@ GEM
     docile (1.3.0)
     dotenv (2.6.0)
     equalizer (0.0.11)
-    erubi (1.8.0)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
     execjs (2.7.0)
@@ -409,8 +401,6 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
-  better_errors
-  binding_of_caller
   bootstrap-sass
   capybara
   cucumber-rails


### PR DESCRIPTION
While debugging a production issue with @bliof, we noticed that the error was impossible to reproduce in our local environment. @bliof discovered that `better_errors` was basically preventing us from replicate the issue that we were seeing in production.

This PR will remove this Gem in order to have an environment that replicates production as much as possible.