### PR TITLE
Fix the bug where the repo is not found and throws a 500 instead 404

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -9,7 +9,10 @@ class ReleasesController < ApplicationController
 
   def show
     update_region_cookies
-    redirect_to release_path(app_name, region: region) unless params[:region]
+    unless params[:region]
+      redirect_to release_path(app_name, region: region)
+      return
+    end
     projection = build_projection
     @pending_releases = projection.pending_releases
     @deployed_releases = projection.deployed_releases


### PR DESCRIPTION
Currently, when `redirect_to release_path`  doesn't find the repository, it throws a 500 error - https://app.honeybadger.io/projects/44071/faults/37414480/ffac580e-4d6d-11ea-9e25-485f731e82ee
I've modified the call so it stops the method when fails.