### PR TITLE
git_repository: support main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'pg'
 gem 'raindrops'
 gem 'prometheus_exporter', require: false
 gem 'pry-rails'
-gem 'rugged', '~> 0.28.1'
+gem 'rugged', '~> 1.0.0'
 gem 'sass-rails'
 gem 'slack-notifier'
 gem 'solid_use_case'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.12.0)
       sexp_processor (~> 4.9)
-    rugged (0.28.3.1)
+    rugged (1.0.0)
     safe_yaml (1.0.4)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
@@ -438,7 +438,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop
-  rugged (~> 0.28.1)
+  rugged (~> 1.0.0)
   sass-rails
   shoulda-matchers
   simplecov

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -184,7 +184,8 @@ class GitRepository
   end
 
   def main_branch
-    rugged_repository.branches['origin/master'] || rugged_repository.branches['master']
+    rugged_repository.branches['origin/master'] || rugged_repository.branches['master'] || \
+      rugged_repository.branches['origin/main'] || rugged_repository.branches['main']
   end
 
   def lookup(sha)


### PR DESCRIPTION
Github decided to rename master to main - this PR reflects those changes