### PR TITLE
Remove use of envconsul-launch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
     image: shipment_tracker
+    entrypoint: []
     command: >
       sh -c 'bundle exec rake db:structure:load && \
              exec bundle exec unicorn --config-file config/unicorn.rb'
@@ -60,6 +61,7 @@ services:
 
   git-worker:
     image: shipment_tracker
+    entrypoint: []
     command: bundle exec rake jobs:update_git_loop
     environment:
       <<: *common_environment
@@ -78,6 +80,7 @@ services:
 
   event-worker:
     image: shipment_tracker
+    entrypoint: []
     command: bundle exec rake jobs:update_events_loop
     environment:
       <<: *common_environment
@@ -90,6 +93,7 @@ services:
 
   delayed-job:
     image: shipment_tracker
+    entrypoint: []
     command: bundle exec rake jobs:work
     environment:
       <<: *common_environment
@@ -107,6 +111,7 @@ services:
 
   prometheus-exporter:
     image: shipment_tracker
+    entrypoint: []
     command: bundle exec prometheus_exporter
     env_file: secrets.env
     tty: true

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
-exec envconsul-launch \
-  -prefix shipment_tracker/config \
-  -secret-no-prefix shipment_tracker/secrets \
+. /etc/mesos-vault-token
+
+exec envconsul \
+  -config /etc/envconsul-common.hcl \
+  -config /app/envconsul.hcl \
   "$@"

--- a/envconsul.hcl
+++ b/envconsul.hcl
@@ -1,0 +1,8 @@
+secret {
+    no_prefix = true
+    path = "shipment_tracker/secrets"
+}
+
+prefix {
+    path = "shipment_tracker/config"
+}


### PR DESCRIPTION
Required after Ruby upgrade in https://github.com/FundingCircle/shipment_tracker/pull/475 due to the removal of `envconsul-launch` from the Ruby 2.7 base image. 