### PR TITLE
Switch to official Slack Ruby client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'prometheus_exporter', require: false
 gem 'pry-rails'
 gem 'rugged'
 gem 'sass-rails'
-gem 'slack-notifier'
+gem 'slack-ruby-client'
 gem 'solid_use_case'
 gem 'uglifier'
 gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.15.0)
     flag-icon-sass (1.1.3)
       sass (~> 3.2)
@@ -122,6 +124,7 @@ GEM
       multi_json (~> 1.3)
     git_clone_url (2.0.0)
       uri-ssh_git (>= 2.0)
+    gli (2.20.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     guard (2.16.2)
@@ -378,7 +381,12 @@ GEM
     skinny (0.2.2)
       eventmachine (~> 1.0)
       thin
-    slack-notifier (2.3.2)
+    slack-ruby-client (0.17.0)
+      faraday (>= 1.0)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
     solid_use_case (2.2.0)
       deterministic (~> 0.6.0)
     spring (2.1.1)
@@ -479,7 +487,7 @@ DEPENDENCIES
   sass-rails
   shoulda-matchers
   simplecov (< 0.18)
-  slack-notifier
+  slack-ruby-client
   solid_use_case
   spring
   spring-commands-rspec

--- a/lib/clients/slack.rb
+++ b/lib/clients/slack.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'slack-notifier'
+require 'slack-ruby-client'
 
 class SlackClient
   def self.send_deploy_alert(msg, releases_link, app_name, deployer)
@@ -9,19 +9,22 @@ class SlackClient
     client.send_with_attachments(attachments)
   end
 
-  def initialize(webhook, channel)
-    @notifier = Slack::Notifier.new(webhook) do
-      defaults channel: prepend_hash(channel)
+  def initialize(token, channel)
+    @channel = channel
+    Slack.configure do |config|
+      config.token = token
     end
+    @notifier = Slack::Web::Client.new
+    @notifier.auth_test
   end
 
   def send_with_attachments(attachments)
-    notifier.ping(attachments: attachments, link_names: 1)
+    notifier.chat_postMessage(channel: channel, attachments: attachments, as_user: true)
   end
 
   private
 
-  attr_reader :notifier
+  attr_reader :notifier, :channel
 
   def self.format_alert_msg(msg, releases_link, app_name, deployer)
     [
@@ -39,8 +42,4 @@ class SlackClient
     ]
   end
   private_class_method :format_alert_msg
-
-  def prepend_hash(channel)
-    channel.start_with?('#') ? channel : "##{channel}"
-  end
 end

--- a/spec/lib/clients/slack_spec.rb
+++ b/spec/lib/clients/slack_spec.rb
@@ -5,7 +5,7 @@ require 'clients/slack'
 
 RSpec.describe SlackClient do
   before do
-    allow_any_instance_of(Slack::Notifier).to receive(:ping)
+    allow_any_instance_of(Slack::Web::Client).to receive(:chat_postMessage)
   end
 
   describe '.send_deploy_alert' do
@@ -35,24 +35,19 @@ RSpec.describe SlackClient do
   end
 
   describe '#send_with_attachments' do
-    subject(:client) { SlackClient.new(webhook, channel) }
+    subject(:client) { SlackClient.new(token, channel) }
     let(:notifier) { double(:notifier).as_null_object }
     let(:attachments) { double }
-    let(:webhook) { double }
+    let(:token) { double }
     let(:channel) { 'double' }
 
     before do
-      allow(Slack::Notifier).to receive(:new).and_return(notifier)
-    end
-    it 'pings the notifier with the given attachments' do
-      client.send_with_attachments(attachments)
-      expect(notifier).to have_received(:ping).with(attachments: attachments, link_names: 1)
+      allow(Slack::Web::Client).to receive(:new).and_return(notifier)
     end
 
-    xit 'posts to the correct channel' do
+    it 'posts the message with the given attachments' do
       client.send_with_attachments(attachments)
-      expect(Slack::Notifier).to have_received(:new).with(webhook)
-      expect(notifier).to have_received(:channel=).with('#double')
+      expect(notifier).to have_received(:chat_postMessage).with(channel: channel, attachments: attachments, as_user: true)
     end
   end
 end


### PR DESCRIPTION
Deployment alerts are currently broken after the recent upgrades. Instead of using the legacy webhooks use the official Ruby client with OAuth2.

Requires https://github.com/FundingCircle/cvseeds/pull/7623
